### PR TITLE
Support yaml format for Swagger/OpenAPI specifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Prerequisites: Install [Python 3.8.2](https://www.python.org/downloads/) and
 
 RESTler runs in 4 main modes (in order):
 
-1. **Compile:** from a Swagger JSON specification (and optionally examples), generate a RESTler grammar. See [Compiling](./docs/user-guide/Compiling.md).
+1. **Compile:** from a Swagger JSON or YAML specification (and optionally examples), generate a RESTler grammar. See [Compiling](./docs/user-guide/Compiling.md).
 2. **Test:** execute quickly all of the endpoints+methods in a compiled RESTler grammar for debugging the test setup and compute what parts of the Swagger spec are covered. This mode is also called a *smoketest*.
 See [Testing](./docs/user-guide/Testing.md). To use custom test engine settings, see [Test Engine Settings](./docs/user-guide/SettingsFile.md).
 3. **Fuzz-lean:** execute once every endpoint+method in a compiled RESTler grammar with a default set of checkers to see if bugs can be found quickly. See [Fuzzing](./docs/user-guide/Fuzzing.md).

--- a/docs/user-guide/Annotations.md
+++ b/docs/user-guide/Annotations.md
@@ -17,7 +17,8 @@ When provided in a separate file (e.g. annotations.json), the file contents shou
 }
 ```
 
-To provide local annotations inline in the Swagger/OpenAPI spec, include the above block globally as follows:
+To provide local annotations inline in the Swagger/OpenAPI spec,
+include the above block globally as follows (Note: only JSON is currently supported):
 
 ```json
 {
@@ -29,7 +30,6 @@ To provide local annotations inline in the Swagger/OpenAPI spec, include the abo
   ]
 }
 ```
-
 
 
 ## Local annotations

--- a/docs/user-guide/Compiling.md
+++ b/docs/user-guide/Compiling.md
@@ -1,6 +1,6 @@
 # Compiling the API Specification
 
-RESTler analyzer the Swagger/OpenAPI spec and generates a fuzzing grammar, which contains information about parameters and responses for individual requests and the dependencies between requests.  
+RESTler analyzes the Swagger/OpenAPI spec and generates a fuzzing grammar, which contains information about parameters and responses for individual requests and the dependencies between requests.
 
 - To quickly generate the RESTler grammar and templates for other artifacts required for fuzzing, run:
 
@@ -18,11 +18,11 @@ RESTler analyzer the Swagger/OpenAPI spec and generates a fuzzing grammar, which
 
 * RESTler will generate new files `grammar.py`, `grammar.json`, `dict.json`, and logs from the compiler in this sub-directory.  A brief diagnostic will be given in the console.
 
-The following describes all available inputs and configuration options for the compiler.  
+The following describes all available inputs and configuration options for the compiler.
 
 ### Required inputs
 
-1. A Swagger/OpenAPI specification in JSON format.  
+1. A Swagger/OpenAPI specification in JSON or YAML format.
 
    Several specifications may be included, and the grammar will be a union of all specifications.
 
@@ -38,7 +38,7 @@ The dictionary format is described in detail in [Fuzzing Dictionary](FuzzingDict
 
 ### Optional inputs
 
-1. Examples.  
+1. Examples.
 
    Examples may be specified to improve coverage.  They are specified either inline (e.g. already included in the specification), or in a separate file.  In the latter case, a json file specifying which endpoints and method the examples correspond to must be provided.
 
@@ -60,5 +60,5 @@ Outputs:
 
 * RESTler will generate new files `grammar.py`, `grammar.json`, `dict.json`, and logs from the compiler in this sub-directory.  A brief diagnostic will be given in the console.
 
-If producer-consumer dependencies are unresolved in the Swagger specification, the user can either ignore those or can annotate the Swagger JSON specification to help RESTler resolve those.  See [Annotations](Annotations.md).
+If producer-consumer dependencies are unresolved in the Swagger specification, the user can either ignore those or can annotate the Swagger JSON or YAML specification to help RESTler resolve those.  See [Annotations](Annotations.md).
 

--- a/src/ResultsAnalyzer/packages.lock.json
+++ b/src/ResultsAnalyzer/packages.lock.json
@@ -73,26 +73,8 @@
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "P+MBhIM0YX+JqROuf7i306ZLJEjQYA9uUyRDE+OqwUI5sh41e2ZbPQV3LfAPh+29cmceE1pUffXsGfR4eMY3KA==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Dynamic.Runtime": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
+        "resolved": "4.4.1",
+        "contentHash": "A5hI3gk6WpcBI0QGZY6/d5CCaYUxJgi7iENn1uYEng+Olo8RfI5ReGVkjXjeu3VR3srLvVYREATXa2M0X7FYJA=="
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
@@ -196,6 +178,16 @@
           "Newtonsoft.Json": "9.0.1"
         }
       },
+      "NJsonSchema.Yaml": {
+        "type": "Transitive",
+        "resolved": "10.0.27",
+        "contentHash": "bzNBxtC/0zppU+nsO0h7INLFSpQn5HuDK/cO3+GF9ZpCrOH4sShmn8c1enAouEehv5q/mfemIjE3oAkhg6QcLQ==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.4.1",
+          "NJsonSchema": "10.0.27",
+          "YamlDotNet.Signed": "5.1.0"
+        }
+      },
       "NSwag.Core": {
         "type": "Transitive",
         "resolved": "13.1.3",
@@ -203,6 +195,16 @@
         "dependencies": {
           "NJsonSchema": "10.0.27",
           "Newtonsoft.Json": "9.0.1"
+        }
+      },
+      "NSwag.Core.Yaml": {
+        "type": "Transitive",
+        "resolved": "13.1.3",
+        "contentHash": "fms5leiF7FNdU8irwhp4WFwRwh1VXdEVn4f8UI4YhsjgwYgQjtAob27HGyFTWOk4sOw1FZkfAST2RYbSG99gGw==",
+        "dependencies": {
+          "NJsonSchema.Yaml": "10.0.27",
+          "NSwag.Core": "13.1.3",
+          "YamlDotNet.Signed": "5.1.0"
         }
       },
       "Pluralize.NET.Core": {
@@ -423,27 +425,6 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Dynamic.Runtime": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
         }
       },
       "System.Globalization": {
@@ -1136,6 +1117,11 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
+      "YamlDotNet.Signed": {
+        "type": "Transitive",
+        "resolved": "5.1.0",
+        "contentHash": "3iZF8/sDp/AxnA3YZ3gR+8irfd2FiBsqdR9fywzcpeBdaqUDRncqejAv3+jIwwCoHJz3No6JT7u+NzTeVE+5VA=="
+      },
       "restler.compiler": {
         "type": "Project",
         "dependencies": {
@@ -1145,6 +1131,7 @@
           "Microsoft.FSharpLu.Json": "0.11.6",
           "NJsonSchema": "10.0.27",
           "NSwag.Core": "13.1.3",
+          "NSwag.Core.Yaml": "13.1.3",
           "Newtonsoft.Json": "11.0.2",
           "Pluralize.NET.Core": "1.0.0"
         }

--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -91,26 +91,30 @@ module Examples =
         [<Fact>]
         let ``example in grammar without dependencies`` () =
 
-            let config = { Restler.Config.SampleConfig with
-                             IncludeOptionalParameters = true
-                             GrammarOutputDirectoryPath = Some ctx.testRootDirPath
-                             ResolveBodyDependencies = false
-                             UseBodyExamples = true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo1.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo_dictionary.json"))
-                         }
-            Restler.Workflow.generateRestlerGrammar None config
-            let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
-            let grammar = File.ReadAllText(grammarFilePath)
+            // Make sure the same test works on yaml and json
+            let extensions = [".json" ; ".yaml"]
+            for extension in extensions do
+                let config = { Restler.Config.SampleConfig with
+                                 IncludeOptionalParameters = true
+                                 GrammarOutputDirectoryPath = Some ctx.testRootDirPath
+                                 ResolveBodyDependencies = false
+                                 UseBodyExamples = true
+                                 SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory,
+                                                                           sprintf @"swagger\example_demo1%s" extension))]
+                                 CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo_dictionary.json"))
+                             }
+                Restler.Workflow.generateRestlerGrammar None config
+                let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
+                let grammar = File.ReadAllText(grammarFilePath)
 
-            // The grammar should contain the fruit codes from the example
-            Assert.True(grammar.Contains("999"))
+                // The grammar should contain the fruit codes from the example
+                Assert.True(grammar.Contains("999"))
 
-            // The grammar should contain the store codes from the example
-            Assert.True(grammar.Contains("23456"))
+                // The grammar should contain the store codes from the example
+                Assert.True(grammar.Contains("23456"))
 
-            // The grammar should contain the bag type from the example
-            Assert.True(grammar.Contains("paperfestive"))
+                // The grammar should contain the bag type from the example
+                Assert.True(grammar.Contains("paperfestive"))
 
         [<Fact>]
         let ``example in grammar with dependencies`` () =

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -91,6 +91,9 @@
     <Content Include="swagger\example_demo1.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\example_demo1.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\array_example.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/packages.lock.json
+++ b/src/compiler/Restler.Compiler.Test/packages.lock.json
@@ -116,26 +116,8 @@
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "P+MBhIM0YX+JqROuf7i306ZLJEjQYA9uUyRDE+OqwUI5sh41e2ZbPQV3LfAPh+29cmceE1pUffXsGfR4eMY3KA==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Dynamic.Runtime": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
+        "resolved": "4.4.1",
+        "contentHash": "A5hI3gk6WpcBI0QGZY6/d5CCaYUxJgi7iENn1uYEng+Olo8RfI5ReGVkjXjeu3VR3srLvVYREATXa2M0X7FYJA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Transitive",
@@ -281,6 +263,26 @@
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "NJsonSchema.Yaml": {
+        "type": "Transitive",
+        "resolved": "10.0.27",
+        "contentHash": "bzNBxtC/0zppU+nsO0h7INLFSpQn5HuDK/cO3+GF9ZpCrOH4sShmn8c1enAouEehv5q/mfemIjE3oAkhg6QcLQ==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.4.1",
+          "NJsonSchema": "10.0.27",
+          "YamlDotNet.Signed": "5.1.0"
+        }
+      },
+      "NSwag.Core.Yaml": {
+        "type": "Transitive",
+        "resolved": "13.1.3",
+        "contentHash": "fms5leiF7FNdU8irwhp4WFwRwh1VXdEVn4f8UI4YhsjgwYgQjtAob27HGyFTWOk4sOw1FZkfAST2RYbSG99gGw==",
+        "dependencies": {
+          "NJsonSchema.Yaml": "10.0.27",
+          "NSwag.Core": "13.1.3",
+          "YamlDotNet.Signed": "5.1.0"
         }
       },
       "Pluralize.NET.Core": {
@@ -651,27 +653,6 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Dynamic.Runtime": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
         }
       },
       "System.Globalization": {
@@ -1582,6 +1563,11 @@
           "xunit.extensibility.core": "[2.4.1]"
         }
       },
+      "YamlDotNet.Signed": {
+        "type": "Transitive",
+        "resolved": "5.1.0",
+        "contentHash": "3iZF8/sDp/AxnA3YZ3gR+8irfd2FiBsqdR9fywzcpeBdaqUDRncqejAv3+jIwwCoHJz3No6JT7u+NzTeVE+5VA=="
+      },
       "restler.compiler": {
         "type": "Project",
         "dependencies": {
@@ -1591,6 +1577,7 @@
           "Microsoft.FSharpLu.Json": "0.11.6",
           "NJsonSchema": "10.0.27",
           "NSwag.Core": "13.1.3",
+          "NSwag.Core.Yaml": "13.1.3",
           "Newtonsoft.Json": "11.0.2",
           "Pluralize.NET.Core": "1.0.0"
         }

--- a/src/compiler/Restler.Compiler.Test/swagger/example_demo1.yaml
+++ b/src/compiler/Restler.Compiler.Test/swagger/example_demo1.yaml
@@ -1,0 +1,152 @@
+basePath: /api
+consumes:
+  - application/json
+definitions:
+  Store:
+    properties:
+      id:
+        description: The unique identifier of a store
+        type: integer
+      name:
+        description: The name of the store
+        type: integer
+  Order:
+    properties:
+      id:
+        description: The unique identifier of an order
+        type: integer
+      eta:
+        description: The date the order will be ready
+        type: string
+        format: date-time
+      status:
+        description: The order status
+        type: string
+  GroceryList:
+    properties:
+      storeId:
+        description: The unique identifier of the store
+        type: integer
+      rush:
+        description: Is it a rush order
+        type: boolean
+      bagType:
+        description: The type of bags to use
+        type: string
+      items:
+        description: The type of bags to use
+        type: array
+        items:
+          $ref: '#/definitions/GroceryListItem'
+      useDoubleBags:
+        description: Whether to use double bags
+        type: boolean
+      bannedBrands:
+        description: do not use these brands
+        type: array
+        items:
+          type: string
+  GroceryListItem:
+    properties:
+      name:
+        description: The name of the item
+        type: string
+      code:
+        description: The code of the item
+        type: integer
+      groceryItemTags:
+        description: The tags of the item
+        type: object
+      storeId:
+        description: The unique identifier of the store
+        type: integer
+      expirationMaxDate:
+        description: The maximum date that this item should expire
+        type: string
+        format: date-time
+  KeyType:
+    type: string
+    enum:
+      - NotSpecified
+      - Primary
+      - Secondary
+    x-ms-enum:
+      name: KeyType
+      modelAsString: false
+  GetCallbackUrlParameters:
+    type: object
+    properties:
+      notAfter:
+        type: string
+        format: date-time
+        description: The expiry time.
+      keyType:
+        $ref: '#/definitions/KeyType'
+        description: The key type.
+    description: The callback url parameters.
+host: 'localhost:8888'
+info:
+  description: A simple swagger spec that uses examples
+  title: My Grocery API
+  version: '1.0'
+paths:
+  /stores/:
+    get:
+      operationId: get_stores
+      responses:
+        '200':
+          description: Success retrieving store information.
+          schema:
+            $ref: '#/definitions/Store'
+    post:
+      operationId: post_stores
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Store'
+  '/stores/{storeId}/order':
+    post:
+      operationId: make_an_order
+      parameters:
+        - in: path
+          name: storeId
+          required: true
+          type: integer
+        - name: orderDetails
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/GroceryList'
+      x-ms-examples:
+        Make an order:
+          $ref: ./examples/make_order.json
+        Make a bigger order:
+          $ref: ./examples/make_big_order.json
+      responses:
+        '200':
+          description: Success retrieving an order
+          schema:
+            $ref: '#/definitions/Order'
+        '404':
+          description: Store not found.
+  '/stores/{storeId}/order/{orderId}':
+    get:
+      operationId: get_order
+      parameters:
+        - in: path
+          name: orderId
+          required: true
+          type: integer
+        - in: path
+          name: storeId
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Order'
+        '404':
+          description: Order not found.
+swagger: '2.0'

--- a/src/compiler/Restler.Compiler/Restler.Compiler.fsproj
+++ b/src/compiler/Restler.Compiler/Restler.Compiler.fsproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NJsonSchema" Version="10.0.27" />
     <PackageReference Include="NSwag.Core" Version="13.1.3" />
+    <PackageReference Include="NSwag.Core.Yaml" Version="13.1.3" />
     <PackageReference Include="Pluralize.NET.Core" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/src/compiler/Restler.Compiler/packages.lock.json
+++ b/src/compiler/Restler.Compiler/packages.lock.json
@@ -72,6 +72,17 @@
           "Newtonsoft.Json": "9.0.1"
         }
       },
+      "NSwag.Core.Yaml": {
+        "type": "Direct",
+        "requested": "[13.1.3, )",
+        "resolved": "13.1.3",
+        "contentHash": "fms5leiF7FNdU8irwhp4WFwRwh1VXdEVn4f8UI4YhsjgwYgQjtAob27HGyFTWOk4sOw1FZkfAST2RYbSG99gGw==",
+        "dependencies": {
+          "NJsonSchema.Yaml": "10.0.27",
+          "NSwag.Core": "13.1.3",
+          "YamlDotNet.Signed": "5.1.0"
+        }
+      },
       "Pluralize.NET.Core": {
         "type": "Direct",
         "requested": "[1.0.0, )",
@@ -97,26 +108,8 @@
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "P+MBhIM0YX+JqROuf7i306ZLJEjQYA9uUyRDE+OqwUI5sh41e2ZbPQV3LfAPh+29cmceE1pUffXsGfR4eMY3KA==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Dynamic.Runtime": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
+        "resolved": "4.4.1",
+        "contentHash": "A5hI3gk6WpcBI0QGZY6/d5CCaYUxJgi7iENn1uYEng+Olo8RfI5ReGVkjXjeu3VR3srLvVYREATXa2M0X7FYJA=="
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
@@ -204,6 +197,16 @@
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "NJsonSchema.Yaml": {
+        "type": "Transitive",
+        "resolved": "10.0.27",
+        "contentHash": "bzNBxtC/0zppU+nsO0h7INLFSpQn5HuDK/cO3+GF9ZpCrOH4sShmn8c1enAouEehv5q/mfemIjE3oAkhg6QcLQ==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.4.1",
+          "NJsonSchema": "10.0.27",
+          "YamlDotNet.Signed": "5.1.0"
         }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
@@ -419,27 +422,6 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Dynamic.Runtime": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
         }
       },
       "System.Globalization": {
@@ -1131,6 +1113,11 @@
           "System.Threading": "4.3.0",
           "System.Xml.ReaderWriter": "4.3.0"
         }
+      },
+      "YamlDotNet.Signed": {
+        "type": "Transitive",
+        "resolved": "5.1.0",
+        "contentHash": "3iZF8/sDp/AxnA3YZ3gR+8irfd2FiBsqdR9fywzcpeBdaqUDRncqejAv3+jIwwCoHJz3No6JT7u+NzTeVE+5VA=="
       }
     }
   }

--- a/src/compiler/Restler.CompilerExe/packages.lock.json
+++ b/src/compiler/Restler.CompilerExe/packages.lock.json
@@ -66,26 +66,8 @@
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "P+MBhIM0YX+JqROuf7i306ZLJEjQYA9uUyRDE+OqwUI5sh41e2ZbPQV3LfAPh+29cmceE1pUffXsGfR4eMY3KA==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Dynamic.Runtime": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
+        "resolved": "4.4.1",
+        "contentHash": "A5hI3gk6WpcBI0QGZY6/d5CCaYUxJgi7iENn1uYEng+Olo8RfI5ReGVkjXjeu3VR3srLvVYREATXa2M0X7FYJA=="
       },
       "Microsoft.FSharpLu": {
         "type": "Transitive",
@@ -195,6 +177,26 @@
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "NJsonSchema.Yaml": {
+        "type": "Transitive",
+        "resolved": "10.0.27",
+        "contentHash": "bzNBxtC/0zppU+nsO0h7INLFSpQn5HuDK/cO3+GF9ZpCrOH4sShmn8c1enAouEehv5q/mfemIjE3oAkhg6QcLQ==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.4.1",
+          "NJsonSchema": "10.0.27",
+          "YamlDotNet.Signed": "5.1.0"
+        }
+      },
+      "NSwag.Core.Yaml": {
+        "type": "Transitive",
+        "resolved": "13.1.3",
+        "contentHash": "fms5leiF7FNdU8irwhp4WFwRwh1VXdEVn4f8UI4YhsjgwYgQjtAob27HGyFTWOk4sOw1FZkfAST2RYbSG99gGw==",
+        "dependencies": {
+          "NJsonSchema.Yaml": "10.0.27",
+          "NSwag.Core": "13.1.3",
+          "YamlDotNet.Signed": "5.1.0"
         }
       },
       "Pluralize.NET.Core": {
@@ -415,27 +417,6 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Dynamic.Runtime": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
         }
       },
       "System.Globalization": {
@@ -1128,6 +1109,11 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
+      "YamlDotNet.Signed": {
+        "type": "Transitive",
+        "resolved": "5.1.0",
+        "contentHash": "3iZF8/sDp/AxnA3YZ3gR+8irfd2FiBsqdR9fywzcpeBdaqUDRncqejAv3+jIwwCoHJz3No6JT7u+NzTeVE+5VA=="
+      },
       "restler.compiler": {
         "type": "Project",
         "dependencies": {
@@ -1137,6 +1123,7 @@
           "Microsoft.FSharpLu.Json": "0.11.6",
           "NJsonSchema": "10.0.27",
           "NSwag.Core": "13.1.3",
+          "NSwag.Core.Yaml": "13.1.3",
           "Newtonsoft.Json": "11.0.2",
           "Pluralize.NET.Core": "1.0.0"
         }

--- a/src/driver/packages.lock.json
+++ b/src/driver/packages.lock.json
@@ -79,26 +79,8 @@
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "P+MBhIM0YX+JqROuf7i306ZLJEjQYA9uUyRDE+OqwUI5sh41e2ZbPQV3LfAPh+29cmceE1pUffXsGfR4eMY3KA==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Dynamic.Runtime": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
+        "resolved": "4.4.1",
+        "contentHash": "A5hI3gk6WpcBI0QGZY6/d5CCaYUxJgi7iENn1uYEng+Olo8RfI5ReGVkjXjeu3VR3srLvVYREATXa2M0X7FYJA=="
       },
       "Microsoft.Diagnostics.Tracing.TraceEvent": {
         "type": "Transitive",
@@ -277,6 +259,16 @@
           "Newtonsoft.Json": "9.0.1"
         }
       },
+      "NJsonSchema.Yaml": {
+        "type": "Transitive",
+        "resolved": "10.0.27",
+        "contentHash": "bzNBxtC/0zppU+nsO0h7INLFSpQn5HuDK/cO3+GF9ZpCrOH4sShmn8c1enAouEehv5q/mfemIjE3oAkhg6QcLQ==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.4.1",
+          "NJsonSchema": "10.0.27",
+          "YamlDotNet.Signed": "5.1.0"
+        }
+      },
       "NSwag.Core": {
         "type": "Transitive",
         "resolved": "13.1.3",
@@ -284,6 +276,16 @@
         "dependencies": {
           "NJsonSchema": "10.0.27",
           "Newtonsoft.Json": "9.0.1"
+        }
+      },
+      "NSwag.Core.Yaml": {
+        "type": "Transitive",
+        "resolved": "13.1.3",
+        "contentHash": "fms5leiF7FNdU8irwhp4WFwRwh1VXdEVn4f8UI4YhsjgwYgQjtAob27HGyFTWOk4sOw1FZkfAST2RYbSG99gGw==",
+        "dependencies": {
+          "NJsonSchema.Yaml": "10.0.27",
+          "NSwag.Core": "13.1.3",
+          "YamlDotNet.Signed": "5.1.0"
         }
       },
       "Pluralize.NET.Core": {
@@ -629,27 +631,6 @@
         "dependencies": {
           "Microsoft.NETCore.Platforms": "2.0.0",
           "Microsoft.Win32.SystemEvents": "4.5.0"
-        }
-      },
-      "System.Dynamic.Runtime": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
         }
       },
       "System.Globalization": {
@@ -1492,6 +1473,11 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
+      "YamlDotNet.Signed": {
+        "type": "Transitive",
+        "resolved": "5.1.0",
+        "contentHash": "3iZF8/sDp/AxnA3YZ3gR+8irfd2FiBsqdR9fywzcpeBdaqUDRncqejAv3+jIwwCoHJz3No6JT7u+NzTeVE+5VA=="
+      },
       "restler.compiler": {
         "type": "Project",
         "dependencies": {
@@ -1501,6 +1487,7 @@
           "Microsoft.FSharpLu.Json": "0.11.6",
           "NJsonSchema": "10.0.27",
           "NSwag.Core": "13.1.3",
+          "NSwag.Core.Yaml": "13.1.3",
           "Newtonsoft.Json": "11.0.2",
           "Pluralize.NET.Core": "1.0.0"
         }


### PR DESCRIPTION
## Summary of the Pull Request

Previously, RESTler only supported json specifications.  This change adds the ability to 
also compile yaml Swagger/OpenAPI specifications.  

## PR Checklist
* [x ] Applies to work item: #24 
* [ x] CLA signed. 
* [x ] Tests added/passed.  
* [ x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach. Issue number where discussion took place: #xxx

## Info on Pull Request

- use the NSWag implementation (same as for json specs)
- extended one of the example tests to cover both yaml and json
version of the spec.  editor.swagger.io was used to generate the yaml
version.

## Validation Steps Performed

Added unit test.  Also ad-hoc tested that the generated compile directory is identical, except for the file extension (i.e. grammar, dictionary, etc. are identical).