### PR TITLE
Replaced api-version with injected_query_string in invalid dynamic object checker

### DIFF
--- a/restler/checkers/invalid_dynamic_object_rule.py
+++ b/restler/checkers/invalid_dynamic_object_rule.py
@@ -128,7 +128,7 @@ class InvalidDynamicObjectChecker(CheckerBase):
         for i in range(1, len(data), 2):
             consumer_types.append(dependencies.get_variable(data[i]))
 
-        default_invalids = [f'{VALID_REPLACE_STR}?injected_query_string',\
+        default_invalids = [f'{VALID_REPLACE_STR}?injected_query_string=123',\
                             f'{VALID_REPLACE_STR}/?/',\
                             f'{VALID_REPLACE_STR}??',\
                             f'{VALID_REPLACE_STR}/{VALID_REPLACE_STR}',\


### PR DESCRIPTION
## Summary of the Pull Request
Replaced api-version with injected_query_string in invalid dynamic object checker

## PR Checklist
* [x] Applies to work item: Closes #23
* [x] CLA signed.
* [ ] Tests added/passed.  
* [ ] Requires documentation to be updated (already completed)
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach.

## Info on Pull Request

* Replaced api-version with injected_query_string in invalid dynamic object checker

## Validation Steps Performed

cd restler-fuzzer/restler
python -m pytest ./unit_tests

ran quick-start script
