### PR TITLE
Fix two bugs in dependencies.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -111,7 +111,7 @@ module Examples =
                 Assert.True(grammar.Contains("999"))
 
                 // The grammar should contain the store codes from the example
-                Assert.True(grammar.Contains("23456"))
+                Assert.True(grammar.Contains("78910"))
 
                 // The grammar should contain the bag type from the example
                 Assert.True(grammar.Contains("paperfestive"))
@@ -135,7 +135,8 @@ module Examples =
             // The grammar should contain the fruit codes from the example (which do not have a dependency)
             Assert.True(grammar.Contains("999"))
 
-            // The grammar should not contain the store codes from the example, those should be dynamic objects
+            // The grammar should not contain the store code from the top level
+            // in the example body - this should be a dynamic object
             Assert.False(grammar.Contains("23456"))
 
             // The grammar should not contain the bag type from the example, dictionary value should be used

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_annotation_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_annotation_grammar.py
@@ -113,9 +113,8 @@ request = requests.Request([
     primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
     primitives.restler_static_string(""",
     "storeId":"""),
-    primitives.restler_static_string('"'),
-    primitives.restler_static_string(_stores_post_id.reader()),
-    primitives.restler_static_string("""",
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
     "storeProperties":
         {
             "tags":"""),
@@ -153,9 +152,8 @@ request = requests.Request([
     primitives.restler_fuzzable_int("1"),
     primitives.restler_static_string(""",
             "storeId":"""),
-    primitives.restler_static_string('"'),
-    primitives.restler_static_string(_stores_post_id.reader()),
-    primitives.restler_static_string("""",
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
             "expirationMaxDate":"""),
     primitives.restler_static_string('"'),
     primitives.restler_fuzzable_string("fuzzstring"),

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_in_dictionary_payload_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_in_dictionary_payload_grammar.py
@@ -48,7 +48,7 @@ request = requests.Request([
     primitives.restler_static_string("Accept: application/json\r\n"),
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_static_string("\r\n"),
-
+    
     {
         'post_send':
         {
@@ -87,9 +87,8 @@ request = requests.Request([
     primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
     primitives.restler_static_string(""",
     "storeId":"""),
-    primitives.restler_static_string('"'),
-    primitives.restler_static_string(_stores_post_id.reader()),
-    primitives.restler_static_string("""",
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
     "storeProperties":
         {
             "tags":"""),
@@ -127,9 +126,8 @@ request = requests.Request([
     primitives.restler_fuzzable_int("1"),
     primitives.restler_static_string(""",
             "storeId":"""),
-    primitives.restler_static_string('"'),
-    primitives.restler_static_string(_stores_post_id.reader()),
-    primitives.restler_static_string("""",
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
             "expirationMaxDate":"""),
     primitives.restler_static_string('"'),
     primitives.restler_fuzzable_string("fuzzstring"),

--- a/src/compiler/Restler.Compiler.Test/swagger/examples/make_order.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/examples/make_order.json
@@ -2,7 +2,7 @@
   "parameters": {
     "storeId": "23456",
     "orderDetails": {
-      "storeId": "23456",
+      "storeId": "78910",
       "rush": "True",
       "bagType": "paperfestive",
       "items": [


### PR DESCRIPTION
1) Closes #36.  A body parameter was being treated as a path parameter.  For the following API:

POST /stores/{storeId}/order
{
  "storeId": ...
}

A dependency was inferred for the store ID in the body (the same one in the path), because the path parameter dependency inference was applied to it and the name happened to match

This in some cases is correct, but needs to be modeled explicitly.  For now,
remove this.

2) Minor fix: distinct operator was missing on names.