### PR TITLE
Add telemetry for unhandled exceptions in the driver.

### DIFF
--- a/src/compiler/Restler.Compiler/Telemetry.fs
+++ b/src/compiler/Restler.Compiler/Telemetry.fs
@@ -48,6 +48,14 @@ type TelemetryClient(machineId: System.Guid, instrumentationKey: string) =
                 "status", sprintf "%A" status
             ]))
 
+    member __.RestlerDriverFailed(version, task, executionId) =
+        client.TrackEvent("restler failed",
+            dict ([
+                "machineId", sprintf "%A" machineId
+                "version", version
+                "task", task
+                "executionId", sprintf "%A" executionId]))
+
     interface System.IDisposable with
         member __.Dispose() =
             client.Flush()

--- a/src/driver/Types.fs
+++ b/src/driver/Types.fs
@@ -185,5 +185,5 @@ module Logging =
         Trace.warning "%s" message
 
     let logError (message:string) =
-        printfn "%s" message
+        printfn "\nERROR: %s\n" message
         Trace.error "%s" message


### PR DESCRIPTION
The current telemetry only reports task results.  This change adds telemetry for unhandled exceptions during the RESTler driver execution.  