### PR TITLE
Set all checkers to default off in engine

### DIFF
--- a/restler/checkers/__init__.py
+++ b/restler/checkers/__init__.py
@@ -4,10 +4,10 @@
 # The ordering of these checkers is expected to remain consistent.
 # If a new checker is added or a new ordering is deemed necessary,
 # the unit tests and baseline logs will need to be updated as well.
-from checkers.leakage_rule import *
-from checkers.resource_hierarchy_rule import *
-from checkers.use_after_free_rule import *
-from checkers.namespace_rule import *
-from checkers.invalid_dynamic_object_rule import *
-from checkers.payload_body import *
-from checkers.examples import *
+from checkers.leakage_rule_checker import *
+from checkers.resource_hierarchy_checker import *
+from checkers.use_after_free_checker import *
+from checkers.namespace_rule_checker import *
+from checkers.invalid_dynamic_object_checker import *
+from checkers.payload_body_checker import *
+from checkers.examples_checker import *

--- a/restler/checkers/checker_base.py
+++ b/restler/checkers/checker_base.py
@@ -19,14 +19,14 @@ from utils.logger import raw_network_logging as RAW_LOGGING
 class CheckerBase:
     __metaclass__ = ABCMeta
 
-    def __init__(self, req_collection, fuzzing_requests, enabled):
+    def __init__(self, req_collection, fuzzing_requests, enabled=False):
         """ Abstract class constructor
 
         @param req_collection: The shared request collection
         @type  req_collection: RequestCollection
         @param fuzzing_requests: The collection of requests to fuzz
         @type  fuzzing_requests: FuzzingRequestCollection
-        @param enabled: Set to True to enable this checker
+        @param enabled: Set to True to enable this checker by default when fuzzing
         @type  enabled: Bool
 
         """

--- a/restler/checkers/examples_checker.py
+++ b/restler/checkers/examples_checker.py
@@ -15,7 +15,7 @@ class ExamplesChecker(CheckerBase):
     """ Checker for payload body fuzzing. """
 
     def __init__(self, req_collection, fuzzing_requests):
-        CheckerBase.__init__(self, req_collection, fuzzing_requests, False)
+        CheckerBase.__init__(self, req_collection, fuzzing_requests)
 
         # alias the log
         self._log = self._checker_log.checker_print

--- a/restler/checkers/invalid_dynamic_object_checker.py
+++ b/restler/checkers/invalid_dynamic_object_checker.py
@@ -21,7 +21,7 @@ class InvalidDynamicObjectChecker(CheckerBase):
     generation_executed_requests = dict()
 
     def __init__(self, req_collection, fuzzing_requests):
-        CheckerBase.__init__(self, req_collection, fuzzing_requests, True)
+        CheckerBase.__init__(self, req_collection, fuzzing_requests)
 
     def apply(self, rendered_sequence, lock):
         """ Applies check for invalid dynamic object rule violations.

--- a/restler/checkers/leakage_rule_checker.py
+++ b/restler/checkers/leakage_rule_checker.py
@@ -16,7 +16,7 @@ import engine.core.sequences as sequences
 class LeakageRuleChecker(CheckerBase):
     """ Checker for resource leakage violations. """
     def __init__(self, req_collection, fuzzing_requests):
-        CheckerBase.__init__(self, req_collection, fuzzing_requests, True)
+        CheckerBase.__init__(self, req_collection, fuzzing_requests)
 
     def apply(self, rendered_sequence, lock):
         """ Applies check for leakage rule violations.

--- a/restler/checkers/namespace_rule_checker.py
+++ b/restler/checkers/namespace_rule_checker.py
@@ -18,7 +18,7 @@ STATIC_OAUTH_TOKEN = 'static_oauth_token'
 class NameSpaceRuleChecker(CheckerBase):
     """ Checker for Namespace rule violations. """
     def __init__(self, req_collection, fuzzing_requests):
-        CheckerBase.__init__(self, req_collection, fuzzing_requests, False)
+        CheckerBase.__init__(self, req_collection, fuzzing_requests)
 
     def apply(self, rendered_sequence, lock):
         """ Applies check for namespace rule violations.

--- a/restler/checkers/payload_body_checker.py
+++ b/restler/checkers/payload_body_checker.py
@@ -36,7 +36,7 @@ class PayloadBodyChecker(CheckerBase):
     """ Checker for payload body fuzzing. """
 
     def __init__(self, req_collection, fuzzing_requests):
-        CheckerBase.__init__(self, req_collection, fuzzing_requests, True)
+        CheckerBase.__init__(self, req_collection, fuzzing_requests)
 
         # alias the log
         self._log = self._checker_log.checker_print

--- a/restler/checkers/resource_hierarchy_checker.py
+++ b/restler/checkers/resource_hierarchy_checker.py
@@ -14,7 +14,7 @@ import engine.core.sequences as sequences
 class ResourceHierarchyChecker(CheckerBase):
     """ Checker for ResourceHierarchy rule violations. """
     def __init__(self, req_collection, fuzzing_requests):
-        CheckerBase.__init__(self, req_collection, fuzzing_requests, True)
+        CheckerBase.__init__(self, req_collection, fuzzing_requests)
 
     def apply(self, rendered_sequence, lock):
         """ Applies check for resource hierarchy rule violations.

--- a/restler/checkers/use_after_free_checker.py
+++ b/restler/checkers/use_after_free_checker.py
@@ -19,7 +19,7 @@ from utils.logger import raw_network_logging as RAW_LOGGING
 class UseAfterFreeChecker(CheckerBase):
     """ Checker for use after free violations. """
     def __init__(self, req_collection, fuzzing_requests):
-        CheckerBase.__init__(self, req_collection, fuzzing_requests, True)
+        CheckerBase.__init__(self, req_collection, fuzzing_requests)
 
     def apply(self, rendered_sequence, lock):
         """ Applies check for resource leakage rule violations.

--- a/restler/unit_tests/test_basic_functionality_end_to_end.py
+++ b/restler/unit_tests/test_basic_functionality_end_to_end.py
@@ -228,7 +228,8 @@ class FunctionalityTests(unittest.TestCase):
         args = Common_Settings + [
             '--fuzzing_mode', 'bfs-cheap',
             '--restler_grammar',f'{os.path.join(Test_File_Directory, "test_grammar.py")}',
-            '--time_budget', f'{Fuzz_Time}'
+            '--time_budget', f'{Fuzz_Time}', '--enable_checkers', '*',
+            '--disable_checkers', 'namespacerule', 'examples'
         ]
 
         result = subprocess.run(args, capture_output=True)

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -65,7 +65,8 @@ let usage() =
         --disable_checkers <list of checkers>
             <list of checkers> - A comma-separated list of checker names without spaces.
             Supported checkers: leakagerule, resourcehierarchy, useafterfree,
-                                namespacerule, invaliddynamicobject, payloadbody.
+                                namespacerule, invaliddynamicobject, payloadbody,
+                                examples.
             Note: some checkers are enabled by default in fuzz-lean and fuzz mode.
         --no_results_analyzer
             If specified, do not run results analyzer on the network logs.


### PR DESCRIPTION
Set all checkers to default off in engine and renamed checker files to match class names.

Closes #41 