### PR TITLE
Added custom_bug_codes and custom_non_bug_codes

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -30,6 +30,14 @@ Checkers' Friendly Names:
 ### custom_bug_codes: list(str)
 List of status codes that will be flagged as bugs.
 
+Note:
+
+Use wildcard '\*' to allow any value after the star to exist.
+Ex: '2*' will match 200, 201, 210, etc.
+
+Use wildcard '?' to allow any value in that specific location.
+Ex: '2?1' will match 201 or 211, but not 202.
+
 ### custom_checkers: list(str) (default None)
 List of paths to custom checker files that will be loaded during runtime.
 
@@ -37,6 +45,14 @@ List of paths to custom checker files that will be loaded during runtime.
 A list of "non-bug" status codes.
 When this setting is defined,
 any status code received from the service-in-test that was _not_ included in this list will be flagged as a bug.
+
+Note:
+
+Use wildcard '\*' to allow any value on or after the star to exist.
+Ex: '2*' will match 200, 201, 210, etc.
+
+Use wildcard '?' to allow any value in that specific location.
+Ex: '2?1' will match 201 or 211, but not 202.
 
 ### dyn_objects_cache_size: int (default 10)
 Max number of objects of one type before deletion by the garbage collector

--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -27,8 +27,16 @@ Checkers' Friendly Names:
 * PayloadBody
 * Examples
 
-### custom_checkers: str (default None)
-Path to a custom checker file that will be loaded during runtime.
+### custom_bug_codes: list(str)
+List of status codes that will be flagged as bugs.
+
+### custom_checkers: list(str) (default None)
+List of paths to custom checker files that will be loaded during runtime.
+
+### custom_non_bug_codes: list(str)
+A list of "non-bug" status codes.
+When this setting is defined,
+any status code received from the service-in-test that was _not_ included in this list will be flagged as a bug.
 
 ### dyn_objects_cache_size: int (default 10)
 Max number of objects of one type before deletion by the garbage collector

--- a/restler/engine/transport_layer/response.py
+++ b/restler/engine/transport_layer/response.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 import string
+import re
+from restler_settings import Settings
 
 DELIM = "\r\n\r\n"
 VALID_CODES = {'200', '201', '202', '204', '304'}
@@ -115,7 +117,19 @@ class HttpResponse(object):
 
         """
         if self._status_code:
-            return self._status_code.startswith('5')
+            if Settings().custom_non_bug_codes:
+                # If the non-bug-code list is nonempty,
+                # return False only if the status code exists in the list.
+                for code in Settings().custom_non_bug_codes:
+                    if re.match(code, self._status_code):
+                        return False
+                else:
+                    return True
+            if self._status_code.startswith('5'):
+                return True
+            for code in Settings().custom_bug_codes:
+                if re.match(code, self._status_code):
+                    return True
         return False
 
     def has_valid_code(self):

--- a/restler/engine/transport_layer/response.py
+++ b/restler/engine/transport_layer/response.py
@@ -118,8 +118,8 @@ class HttpResponse(object):
         """
         if self._status_code:
             if Settings().custom_non_bug_codes:
-                # If the non-bug-code list is nonempty,
-                # return False only if the status code exists in the list.
+                # All codes except the ones in the custom_non_bug_codes list should be flagged as bugs.
+                # Hence, return False only if the status code exists in the list.
                 for code in Settings().custom_non_bug_codes:
                     if re.match(code, self._status_code):
                         return False

--- a/restler/unit_tests/restler_user_settings.json
+++ b/restler/unit_tests/restler_user_settings.json
@@ -51,8 +51,16 @@
             "start_with_examples" : true,
             "size_dep_budget" : false,
             "use_feedback" : true,
-            "recipe_file" : "C:\\restler\\restlerpayloadbody\\recipe_custom.json",
-            "grammar_file" : "C:\\restler\\restlerpayloadbody\\compile\\grammar.json"
+            "recipe_file" : "C:\\restler\\restlerpayloadbody\\recipe_custom.json"
         }
-    }
+    },
+    "custom_bug_codes": [
+        "400",
+        "2?4",
+        "3*"
+    ],
+    "custom_non_bug_codes": [
+        "404",
+        "500"
+    ]
 }


### PR DESCRIPTION
## Summary of the Pull Request
Added custom_bug_codes and custom_non_bug_codes to restler settings and HttpResponse has_bug_code logic.

## PR Checklist
* [x] Applies to work item: Closes #8
* [x] CLA signed.
* [ ] Tests added/passed.  
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach.

## Info on Pull Request

* If custom_bug_codes list is specified in settings file, any status codes specified in the list will trigger bugs if received from the service in test.
* If custom_non_bug_codes list is specified, all status codes that are _not_ specified in this list will be trigger bugs.
* custom_bug_codes and custom_non_bug_codes list must be mutually exclusive - if both are specified then an error is raised.
* The * and ? wildcards can be used when specifying status codes
* Added new settings to SettingsFile.md

## Validation Steps Performed

cd restler-fuzzer/restler
python -m pytest ./unit_tests

Ran quick-start script

Tested on unit test server with:
* No lists specified
  * Passed with no change
* Both lists specified
  * Error handled
* Non-string type specified in list
  * Error handled
* custom_bug_codes with various codes specified
  * Successfully logged bugs included in list and 500 bugs
* custom_non_bug_codes with various codes specified
  * Successfully logged any code not in the list
* custom_non_bug_codes with '500' in the list
  * Ignored 500 code
* Tested wildcard handling for * and ?
