### PR TITLE
Fixed bug in payload body checker that occurred if the request body did not start with a '{'.

### DIFF
--- a/restler/checkers/examples_checker.py
+++ b/restler/checkers/examples_checker.py
@@ -87,7 +87,7 @@ class ExamplesChecker(CheckerBase):
             if new_request:
                 _send_request(new_request)
             else:
-                self._log('Failed to substitute body')
+                self._log(f"Failed to substitute body for request {request.endpoint}.")
         # Send new request for each query example.
         # For now don't try to match these up with body examples.
         # There will soon be IDs associated with the examples, so they can be matched.

--- a/restler/checkers/payload_body_checker.py
+++ b/restler/checkers/payload_body_checker.py
@@ -1107,6 +1107,9 @@ class PayloadBodyChecker(CheckerBase):
         """
         # substitute to the original request
         new_request = substitute_body(request, body_blocks)
+        if new_request is None:
+            self._log(f"Failed to substitute body for request {request.endpoint}.")
+            return
 
         seq = copy(self._sequence)
         cnt = 0


### PR DESCRIPTION
Fixed bug in payload body checker that occurred if the request body did not start with a '{'.

The error occurred because substitute_body would return None if the '{' was not found and the payload body checker did not check for None prior to rendering it as a Request object.