### PR TITLE
Improved error handling when no auth token was specified when running a replay log

### DIFF
--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -21,7 +21,8 @@ from engine.transport_layer.messaging import UTF8
 from engine.transport_layer.messaging import HttpSock
 
 last_refresh = 0
-latest_token_value = 'NO-TOKEN-SPECIFIED'
+NO_TOKEN_SPECIFIED = 'NO-TOKEN-SPECIFIED'
+latest_token_value = NO_TOKEN_SPECIFIED
 latest_shadow_token_value = 'NO-SHADOW-TOKEN-SPECIFIED'
 
 HOST_PREFIX = 'Host: '

--- a/restler/engine/core/sequences.py
+++ b/restler/engine/core/sequences.py
@@ -24,6 +24,7 @@ import engine.dependencies as dependencies
 from engine.errors import ResponseParsingException
 from engine.errors import TransportLayerException
 from engine.errors import TimeOutException
+from engine.errors import NoTokenSpecifiedException
 from engine.transport_layer.response import RESTLER_INVALID_CODE
 from utils.logger import raw_network_logging as RAW_LOGGING
 from utils.logger import custom_network_logging as CUSTOM_LOGGING
@@ -518,8 +519,11 @@ class Sequence(object):
         """
         rendered_data = data
         if AUTHORIZATION_TOKEN_PLACEHOLDER in data:
+            token = request_utilities.get_latest_token_value()
+            if token == request_utilities.NO_TOKEN_SPECIFIED:
+                raise NoTokenSpecifiedException
             rendered_data = data.replace(
-                f"{AUTHORIZATION_TOKEN_PLACEHOLDER}\r\n", request_utilities.get_latest_token_value()
+                f"{AUTHORIZATION_TOKEN_PLACEHOLDER}\r\n", token
             )
         return rendered_data
 

--- a/restler/engine/errors.py
+++ b/restler/engine/errors.py
@@ -99,3 +99,9 @@ class InvalidDictionaryException(Exception):
     """ To be raised when an invalid fuzzing dictionary is identified.
     """
     pass
+
+class NoTokenSpecifiedException(Exception):
+    """ To be raised when a token was expected in a request,
+    but no token was found when querying for get_token
+    """
+    pass

--- a/restler/restler.py
+++ b/restler/restler.py
@@ -33,6 +33,7 @@ import engine.core.fuzzer as fuzzer
 import engine.core.fuzzing_monitor as fuzzing_monitor
 import engine.core.requests as requests
 from engine.errors import InvalidDictionaryException
+from engine.errors import NoTokenSpecifiedException
 from engine.primitives import InvalidDictPrimitiveException
 from engine.primitives import UnsupportedPrimitiveException
 
@@ -351,6 +352,15 @@ if __name__ == '__main__':
             driver.replay_sequence_from_log(args.replay_log, settings.token_refresh_cmd)
             print("Done playing sequence from log")
             sys.exit(0)
+        except NoTokenSpecifiedException:
+            logger.write_to_main(
+                "Failed to play sequence from log:\n"
+                "A valid authorization token was expected.\n"
+                "Retry with a token refresh script in the settings file or "
+                "update the request in the replay log with a valid authorization token.",
+                print_to_console=True
+            )
+            sys.exit(-1)
         except Exception as error:
             print(f"Failed to play sequence from log:\n{error!s}")
             sys.exit(-1)


### PR DESCRIPTION
Improved error handling when no auth token was specified when running a replay log.

Will now exit and send appropriate error message to stdout and print to main log instead of simply aborting with a substring error.

Closes #9 