### PR TITLE
Updated build for nuget 5.8

### DIFF
--- a/ci_build_pipelines/stages/build/steps/restlerfullbuild.yml
+++ b/ci_build_pipelines/stages/build/steps/restlerfullbuild.yml
@@ -1,8 +1,8 @@
 steps:
   - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet 5.4'
+    displayName: 'Use NuGet 5.8'
     inputs:
-      versionSpec: 5.4
+      versionSpec: 5.8
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore solution'

--- a/ci_build_pipelines/stages/build/steps/restlerfullbuild.yml
+++ b/ci_build_pipelines/stages/build/steps/restlerfullbuild.yml
@@ -2,12 +2,22 @@ steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.8'
     inputs:
-      versionSpec: 5.8
+      versionSpec: 5.8.0
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore solution'
     inputs:
       restoreSolution: '**\Restler.sln'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Clean solution'
+    inputs:
+      command: clean
+      projects: |
+        src/compiler/Restler.CompilerExe/Restler.CompilerExe.fsproj
+        src/driver/Restler.Driver.fsproj
+        src/ResultsAnalyzer/ResultsAnalyzer.fsproj
+      arguments: '-c $(buildConfiguration)'
 
   - task: DotNetCoreCLI@2
     displayName: 'Publish RESTler dotnet core projects'

--- a/ci_build_pipelines/stages/build/steps/restlerfullbuild.yml
+++ b/ci_build_pipelines/stages/build/steps/restlerfullbuild.yml
@@ -12,7 +12,8 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: 'Clean solution'
     inputs:
-      command: clean
+      command: custom
+      custom: clean
       projects: |
         src/compiler/Restler.CompilerExe/Restler.CompilerExe.fsproj
         src/driver/Restler.Driver.fsproj

--- a/ci_build_pipelines/stages/test/steps/compilerFunctionalTests.yml
+++ b/ci_build_pipelines/stages/test/steps/compilerFunctionalTests.yml
@@ -1,13 +1,22 @@
 steps:
   - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet 5.4'
+    displayName: 'Use NuGet 5.8'
     inputs:
-      versionSpec: 5.4
+      versionSpec: 5.8.0
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore solution'
     inputs:
       restoreSolution: '**\Restler.sln'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Clean solution'
+    inputs:
+      command: custom
+      custom: clean
+      projects: |
+        src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+      arguments: '-c $(buildConfiguration)'
 
   - task: DotNetCoreCLI@2
     displayName: 'Build functional tests'
@@ -16,7 +25,7 @@ steps:
       projects: |
         src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
       arguments: '--no-restore -c $(buildConfiguration)'
-      
+
   - task: DotNetCoreCLI@2
     displayName: "Run functional tests"
     inputs:


### PR DESCRIPTION
Resolve build errors due to nuget/dotnet version mismatch (external).

Closes #77 

Updated build for nuget 5.8 and added clean build step.