### PR TITLE
New pipeline to publish restler docker image. #78

### DIFF
--- a/ci_build_pipelines/publish-restler.yml
+++ b/ci_build_pipelines/publish-restler.yml
@@ -1,0 +1,64 @@
+trigger:
+  batch : true
+  branches:
+    include:
+      - 'main'
+
+parameters:
+  - name: RestlerBuildTag
+    displayName: Restler Tag or Commit
+    default: "Tag Name"
+  - name: Production
+    displayName: Publish For Production?
+    default: No
+    values:
+    - Yes
+    - No
+
+variables:
+  - template: 'variables/version-variables.yml'
+  - name: version.revision
+    value: $[counter(variables['devRevision'], 1)]
+  - name: versionNumber
+    value: $(version.major).$(version.minor).$(version.revision)
+
+stages:
+  - template: stages/build/build.yml
+
+  - stage: publish
+    jobs:
+      - job: PublishDockerImage
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+        - checkout: self
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifact: restler-fuzzer-drop-for-docker
+            path: $(Build.SourcesDirectory)/artifacts/restler-fuzzer-drop
+
+        - task: Docker@2
+          displayName: 'Publish Restler Test'
+          condition: and(succeeded(), eq('${{parameters.Production}}', 'No'))
+          inputs:
+              buildContext: $(Build.SourcesDirectory)/artifacts/restler-fuzzer-drop
+              command: buildAndPush
+              containerRegistry: acrrestler
+              repository: restler
+              Dockerfile: $(Build.SourcesDirectory)/docker/Dockerfile
+              tags: |
+                Test-$(Build.BuildNumber)
+
+        - task: Docker@2
+          displayName: 'Publish Restler Production'
+          condition: and(succeeded(), eq('${{parameters.Production}}', 'Yes'))
+          inputs:
+              buildContext: $(Build.SourcesDirectory)/artifacts/restler-fuzzer-drop
+              command: buildAndPush
+              containerRegistry: RAFTProductionRegistry
+              repository: public/restlerfuzzer/restler
+              Dockerfile: $(Build.SourcesDirectory)/docker/Dockerfile
+              tags: |
+                ${{ parameters.RestlerBuildTag }}
+      

--- a/ci_build_pipelines/stages/build/steps/restlerfullbuild.yml
+++ b/ci_build_pipelines/stages/build/steps/restlerfullbuild.yml
@@ -64,3 +64,7 @@ steps:
       artifactName: 'restler-fuzzer-drop-$(versionNumber)'
       publishLocation: 'Container'
 
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: $(Agent.BuildDirectory)/restler_drop/
+      artifactName: restler-fuzzer-drop-for-docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
+
+COPY ./compiler /RESTler/compiler
+COPY ./restler /RESTler/restler
+
+#Get the source code for the engine, and
+#copy source code to the image
+#RESTler Python dependency
+RUN apk add --no-cache python3
+RUN python3 -m ensurepip
+RUN pip3 install --upgrade pip
+RUN pip3 install requests
+RUN pip3 install requests
+RUN pip3 install applicationinsights
+COPY ./engine /RESTler/engine
+RUN python3 -m compileall -b /RESTler/engine
+COPY ./resultsAnalyzer /RESTler/resultsAnalyzer


### PR DESCRIPTION
## Summary of the Pull Request

We need to be able to create a public restler docker image. This PR adds a yaml file so that a pipeline that can be run from the private restler project as well as the dockerfile describing how the image is built. 



## PR Checklist
* [X] Applies to work item: #78 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign.
* [ ] Tests added/passed.  
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach. Issue number where discussion took place: #xxx

## Info on Pull Request

*What does this include?*
Includes the yaml file, and the docker file.

The yaml file is setup to be able to create the restler image in a test repository that can be used for validation before publishing it publicly. 

There is also a change to the build yaml to create a drop that is used to pull data into the image. The existing drop contained a zip that I didn't want to touch. 

## Validation Steps Performed

*How does someone test & validate?*
Created a pipeline with the appropriate service connections that give the rights to the respective repositories. Created a test image and a production image (the production image is not published to docker hub yet) to verify the naming scheme. 
Run a RAFT BVT against the test image to verify it's constructed as we expected. 