### PR TITLE
Added retry count for bugs that were not able to reproduce the first time

### DIFF
--- a/restler/engine/bug_bucketing.py
+++ b/restler/engine/bug_bucketing.py
@@ -14,6 +14,13 @@ class NewSingletonError(Exception):
 class UninitializedError(Exception):
     pass
 
+class BugBucket(object):
+    def __init__(self, sequence, reproducible, retry_count, reproduce_count):
+        self.sequence = sequence
+        self.reproducible = reproducible
+        self.retry_count = retry_count
+        self.reproduce_count = reproduce_count
+
 class BugBuckets(object):
     __instance = None
 
@@ -50,8 +57,8 @@ class BugBuckets(object):
 
         """
         # Iterate through each sequence in the bug buckets
-        for s in bug_buckets.values():
-            if s[0].last_request.hex_definition == sequence.last_request.hex_definition:
+        for b in bug_buckets.values():
+            if b.sequence.last_request.hex_definition == sequence.last_request.hex_definition:
                 return True
 
         return False
@@ -147,6 +154,41 @@ class BugBuckets(object):
 
         return f'{origin}_{str_to_hex_def(request_str)}'
 
+    def _attempt_reproduce(self, reproduce, sequence, bug_code, bucket):
+        """ Attempts to reproduce a bug, if requested
+
+        @param reproduce: If False, do not attempt to reproduce
+        @type  reproduce: Bool
+        @param sequence: The bug sequence to replay
+        @type  sequence: Sequence
+        @param bug_code: The status code that was received when the bug was identified.
+        @type  bug_code: Str
+        @param bucket: Pointer to the bug bucket related to this bug
+        @type  bucket: OrderedDict - {seq_hex: BugBucket}
+        @return: Tuple containing whether the bug was reproduced,
+                 the new retry count, and the new reproduced count
+        @rtype : Tuple(bool, int, int)
+
+        """
+        if reproduce:
+            seq_hex = sequence.hex_definition
+            logger.raw_network_logging("Attempting to reproduce bug...")
+            reproducible = self._test_bug_reproducibility(sequence, bug_code)
+            logger.raw_network_logging("Done replaying sequence.")
+            # Gather reproduce retry counts to apply to bucket
+            retry_count = 0
+            reproduce_count = 0
+            first_bug_was_reproducible = reproducible
+            if seq_hex in bucket:
+                retry_count = bucket[seq_hex].retry_count + 1
+                reproduce_count = bucket[seq_hex].reproduce_count
+                if bucket[seq_hex].reproducible == False:
+                    first_bug_was_reproducible = bucket[seq_hex].reproducible
+            reproduce_count = reproduce_count + 1 if reproducible else reproduce_count
+            return (first_bug_was_reproducible, retry_count, reproduce_count)
+        else:
+            return (False, 0, 0)
+
     def update_bug_buckets(self, sequence, bug_code, origin='main_driver', reproduce=True, additional_log_str=None, checker_str=None, hash_full_request=False, lock=None):
         """ Update buckets of error-triggering test case buckets by potentially
         adding sequence.
@@ -173,17 +215,6 @@ class BugBuckets(object):
             https://arxiv.org/pdf/1806.09739.pdf (section: 4.5)
 
         """
-        def is_duplicate(seq_hex_def):
-            """ Helper to avoid reporting duplicate bugs. There is no
-                distinction between the main driver and the checker. That is,
-                whichever checker or main driver triggers the bug first,
-                registers it in its bug buckets.
-            """
-            for k in self._bug_buckets:
-                if seq_hex_def in self._bug_buckets[k]:
-                    return True
-            return False
-
         if lock is not None:
             lock.acquire()
 
@@ -191,15 +222,13 @@ class BugBuckets(object):
             bucket_origin = self._get_bucket_origin(origin, bug_code)
             if bucket_origin not in self._bug_buckets:
                 self._bug_buckets[bucket_origin] = OrderedDict()
+            bucket = self._bug_buckets[bucket_origin]
+            seq_hex = sequence.hex_definition
 
-            if sequence.hex_definition not in self._bug_buckets[bucket_origin] and\
-            not self._ending_request_exists(sequence, self._bug_buckets[bucket_origin]):
-                reproducible = False
-                if reproduce:
-                    logger.raw_network_logging("Attempting to reproduce bug...")
-                    reproducible = self._test_bug_reproducibility(sequence, bug_code)
-                    logger.raw_network_logging("Done replaying sequence.")
-                self._bug_buckets[bucket_origin][sequence.hex_definition] = (sequence, reproducible)
+            if (seq_hex not in bucket and not self._ending_request_exists(sequence, bucket)) or\
+            (reproduce and seq_hex in bucket and bucket[seq_hex].reproducible == False):
+                (reproducible, retry_count, reproduce_count) = self._attempt_reproduce(reproduce, sequence, bug_code, bucket)
+                bucket[seq_hex] = BugBucket(sequence, reproducible, retry_count, reproduce_count)
 
             sent_request_data_list = sequence.sent_request_data_list
             create_once_requests = self._get_create_once_requests(sequence)

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -12,6 +12,7 @@ import statistics
 import json
 from collections import OrderedDict
 from shutil import copyfile
+from collections import namedtuple
 
 import engine.primitives as primitives
 import engine.dependencies as dependencies
@@ -348,8 +349,9 @@ def custom_network_logging(sequence, candidate_values_pool, **kwargs):
                 network_log.write(f"\t\t- {primitive}: {print_val!r}")
     network_log.write("")
 
+BugTuple = namedtuple('BugTuple', ['filename_of_replay_log', 'bug_hash', 'reproduce_attempts', 'reproduce_successes'])
 # Dict to track whether or not a bug was already logged:
-#   {"{seq_hash}_{bucket_class}": tuple(filename_of_replay_log, bug_hash)}
+#   {"{seq_hash}_{bucket_class}": BugTuple()}
 Bugs_Logged = dict()
 # Dict of bug hashes to be printed to bug_buckets.json
 #   {bug_hash: {"file_path": replay_log_relative_path}}
@@ -434,28 +436,30 @@ def update_bug_buckets(bug_buckets, bug_request_data, bug_hash, additional_log_s
         print("-------------", file=log_file)
         for bucket_class in bug_buckets:
             for seq_hash in bug_buckets[bucket_class]:
-                # seq_obj = (sequence definition, bug reproduced boolean)
-                seq_obj = bug_buckets[bucket_class][seq_hash]
-                name_header = bucket_class
+                bug_bucket = bug_buckets[bucket_class][seq_hash]
                 bucket_hash = f"{seq_hash}_{bucket_class}"
+                name_header = bucket_class
                 if bucket_hash not in Bugs_Logged:
                     try:
                         filename = log_new_bug()
-                        Bugs_Logged[bucket_hash] = (filename, bug_hash)
+                        Bugs_Logged[bucket_hash] = BugTuple(filename, bug_hash, bug_bucket.retry_count, bug_bucket.reproduce_count)
                         add_hash(filename)
                     except Exception as error:
                         write_to_main(f"Failed to write bug bucket log: {error!s}")
                         filename = 'Failed to create replay log.'
                 else:
-                    filename = Bugs_Logged[bucket_hash][0]
-                if seq_obj[1]:
-                    name_header = f'{name_header} - Bug was reproduced - {filename}'
+                    filename = Bugs_Logged[bucket_hash].filename_of_replay_log
+                    this_bug_hash = Bugs_Logged[bucket_hash].bug_hash
+                    Bugs_Logged[bucket_hash] = BugTuple(filename, this_bug_hash, bug_bucket.retry_count, bug_bucket.reproduce_count)
+
+                if bug_bucket.reproducible:
+                    print(f'{name_header} - Bug was reproduced - {filename}', file=log_file)
                 else:
-                    name_header = f'{name_header} - Unable to reproduce bug - {filename}'
-                print(name_header, file=log_file)
-                print(f"Hash: {Bugs_Logged[bucket_hash][1]}", file=log_file)
-                sequence = seq_obj[0]
-                for request in sequence:
+                    print(f'{name_header} - Unable to reproduce bug - {filename}', file=log_file)
+                    print(f'Attempted to reproduce {Bugs_Logged[bucket_hash].reproduce_attempts} additional time(s); '
+                          f'Reproduced {Bugs_Logged[bucket_hash].reproduce_successes} time(s)', file=log_file)
+                print(f"Hash: {Bugs_Logged[bucket_hash].bug_hash}", file=log_file)
+                for request in bug_bucket.sequence:
                     for payload in list(map(lambda x: x[1], request.definition)):
                         print(repr(payload)[1:-1], end='', file=log_file)
                     print(file=log_file)

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -442,7 +442,7 @@ def update_bug_buckets(bug_buckets, bug_request_data, bug_hash, additional_log_s
                 if bucket_hash not in Bugs_Logged:
                     try:
                         filename = log_new_bug()
-                        Bugs_Logged[bucket_hash] = BugTuple(filename, bug_hash, bug_bucket.retry_count, bug_bucket.reproduce_count)
+                        Bugs_Logged[bucket_hash] = BugTuple(filename, bug_hash, bug_bucket.reproduce_attempts, bug_bucket.reproduce_successes)
                         add_hash(filename)
                     except Exception as error:
                         write_to_main(f"Failed to write bug bucket log: {error!s}")
@@ -450,13 +450,13 @@ def update_bug_buckets(bug_buckets, bug_request_data, bug_hash, additional_log_s
                 else:
                     filename = Bugs_Logged[bucket_hash].filename_of_replay_log
                     this_bug_hash = Bugs_Logged[bucket_hash].bug_hash
-                    Bugs_Logged[bucket_hash] = BugTuple(filename, this_bug_hash, bug_bucket.retry_count, bug_bucket.reproduce_count)
+                    Bugs_Logged[bucket_hash] = BugTuple(filename, this_bug_hash, bug_bucket.reproduce_attempts, bug_bucket.reproduce_successes)
 
                 if bug_bucket.reproducible:
                     print(f'{name_header} - Bug was reproduced - {filename}', file=log_file)
                 else:
                     print(f'{name_header} - Unable to reproduce bug - {filename}', file=log_file)
-                    print(f'Attempted to reproduce {Bugs_Logged[bucket_hash].reproduce_attempts} additional time(s); '
+                    print(f'Attempted to reproduce {Bugs_Logged[bucket_hash].reproduce_attempts} time(s); '
                           f'Reproduced {Bugs_Logged[bucket_hash].reproduce_successes} time(s)', file=log_file)
                 print(f"Hash: {Bugs_Logged[bucket_hash].bug_hash}", file=log_file)
                 for request in bug_bucket.sequence:


### PR DESCRIPTION
## Summary of the Pull Request
Added retry count for bugs that were not able to reproduce the first time

## PR Checklist
* [x] Applies to work item: Closes #72
* [x] CLA signed.
* [ ] Tests added/passed.  
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach.

## Info on Pull Request

* Added counts for number of reproduce retries
* Added counts for number of reproduce successes
* Will now replay bugs again if they were marked as not reproducible the first time
* Counts are printed to bug_buckets.txt
* Created new namedtuple and BugBucket class to improve readability of tuples

## Validation Steps Performed

cd restler-fuzzer/restler
python -m pytest ./unit_tests

Used debugger to force reproduce failures when running against unit test server (see below)

## Example:
In the below example, the bug failed to reproduce the first time, then it retried and succeeded twice.

InvalidDynamicObjectChecker_20x - Unable to reproduce bug - InvalidDynamicObjectChecker_20x_1.txt
Attempted to reproduce 3 time(s); Reproduced 2 time(s)
Hash: InvalidDynamicObjectChecker_20x_0c7bc79adedde76524a357aaa4f73dc367f6a19d
PUT /city/cityName HTTP/1.1\r\nHost: unittest\r\n\r\n{}\r\n
GET /city/_READER_DELIM_city_put_name_READER_DELIM HTTP/1.1\r\nHost: unittest\r\n\r\n

