### PR TITLE
Workaround for issue #61.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="DictionaryTests.fs" />
     <Compile Include="ExampleTests.fs" />
     <Compile Include="ReferencesTests.fs" />
+    <Compile Include="SchemaTests.fs" />
     <Compile Include="RealWorldTests.fs" />
     <Content Include="packages.lock.json" />
     <Content Include="baselines\dependencyTests\path_annotation_grammar.py">
@@ -62,6 +63,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\dictionaryTests\dict.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\schemaTests\requiredHeader.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\dictionaryTests\customPayloadSwagger.json">

--- a/src/compiler/Restler.Compiler.Test/SchemaTests.fs
+++ b/src/compiler/Restler.Compiler.Test/SchemaTests.fs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Restler.Test
+open System
+open System.IO
+open Xunit
+open Restler.Test.Utilities
+open Restler.Config
+open Microsoft.FSharpLu.File
+
+/// This test suite contains coverage for corner cases / regression tests in how
+/// RESTler handles the API specification schema.
+[<Trait("TestCategory", "ApiSpecSchema")>]
+module ApiSpecSchema =
+    type SchemaTests(ctx:Fixtures.TestSetupAndCleanup, output:Xunit.Abstractions.ITestOutputHelper) =
+
+        let compileSpec specFileName =
+            let filePath = Path.Combine(Environment.CurrentDirectory, specFileName)
+            let config = { Restler.Config.SampleConfig with
+                             IncludeOptionalParameters = true
+                             GrammarOutputDirectoryPath = Some ctx.testRootDirPath
+                             ResolveBodyDependencies = true
+                             UseBodyExamples = Some false
+                             SwaggerSpecFilePath = Some [filePath]
+                             CustomDictionaryFilePath = None
+                         }
+            Restler.Workflow.generateRestlerGrammar None config
+            let grammarOutputFilePath =
+                config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
+            Assert.True(File.Exists(grammarOutputFilePath))
+
+        [<Fact>]
+        let ``required header is parsed successfully`` () =
+            compileSpec @"swagger\schemaTests\requiredHeader.yml"
+
+
+        interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/requiredHeader.yml
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/requiredHeader.yml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: example api
+  version: 1.2.3
+paths:
+  "/test_endpoint_1":
+    post:
+      responses:
+        '200':
+          description: OK
+          headers:
+            X-API-Revision:
+              required: true
+              description: API Revision
+              schema:
+                type: string

--- a/src/compiler/Restler.Compiler/SwaggerSpecPreprocessor.fs
+++ b/src/compiler/Restler.Compiler/SwaggerSpecPreprocessor.fs
@@ -175,7 +175,16 @@ let rec private inlineFileRefs2
                                             if ref.Count() > 0 then
                                                 ref
                                             else
-                                                obj.Properties()
+                                                // TODO: Temporary workaround for issue #61 - NSWag failure to parse
+                                                // required boolean in Headers.  Remove this when the NSWag bug is fixed.
+                                                // The workaround is to remove the required property.
+                                                // This is fine for now, since RESTler does not currently fuzz or
+                                                // learn from header values.
+                                                let headerInPath = sprintf "%s.%s" "headers" x.Name
+                                                if obj.Path.EndsWith(headerInPath) then
+                                                    obj.Properties() |> Seq.filter (fun o -> o.Name <> "required")
+                                                else
+                                                    obj.Properties()
                                         let newChildProperties =
                                             inlineFileRefs2 childProperties
                                                             normalizedDocumentFilePath


### PR DESCRIPTION
NSWag currently fails to parse a header definition with a boolean required property.

Work around this by removing the required.
There is currently no impact for RESTler correctness, because it does not
exclude optional properties.