### PR TITLE
Fix regression in user-specified uuid4_suffix

### DIFF
--- a/src/compiler/Restler.Compiler.Test/DictionaryTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DictionaryTests.fs
@@ -34,4 +34,29 @@ module Dictionary =
             let message = sprintf "Grammar Does not match baseline.  First difference: %A" grammarDiff
             Assert.True(grammarDiff.IsNone, message)
 
+        [<Fact>]
+        /// Test for custom payload uuid suffix
+        let ``path and body parameter set to the same uuid suffix payload`` () =
+            let grammarOutputDirPath = @"c:\temp\restlertest" //ctx.testRootDirPath
+            let config = { Restler.Config.SampleConfig with
+                             IncludeOptionalParameters = true
+                             GrammarOutputDirectoryPath = Some grammarOutputDirPath
+                             ResolveBodyDependencies = true
+                             ResolveQueryDependencies = true
+                             UseBodyExamples = Some false
+                             UseQueryExamples = Some false
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\multipleIdenticalUuidSuffix.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\multipleIdenticalUuidSuffixDict.json"))
+                         }
+            Restler.Workflow.generateRestlerGrammar None config
+
+            let grammarFilePath = Path.Combine(grammarOutputDirPath,
+                                               Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
+            let grammar = File.ReadAllText(grammarFilePath)
+
+            // The grammar should contain both of the custom payload uuid suffixes from the dictionary
+            Assert.True(grammar.Contains("""primitives.restler_custom_payload_uuid4_suffix("resourceId"),"""))
+            Assert.True(grammar.Contains("""primitives.restler_custom_payload_uuid4_suffix("/resource/id"),"""))
+
+
         interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -62,6 +62,12 @@
     <Content Include="swagger\dictionaryTests\pathDictionaryPayload.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\dictionaryTests\multipleIdenticalUuidSuffix.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\dictionaryTests\multipleIdenticalUuidSuffixDict.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\dictionaryTests\dict.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/multipleIdenticalUuidSuffix.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/multipleIdenticalUuidSuffix.json
@@ -1,0 +1,78 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "definitions": {
+    "Parameters": {
+      "properties": {
+        "resource": {
+            "$ref": "#/definitions/Resource"
+        }
+      }
+    },
+    "Resource": {
+      "properties": {
+        "id": {
+          "description": "The unique identifier of a resource",
+          "type": "integer"
+        },
+        "name": {
+          "description": "The name of the resource",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "host": "localhost:8888",
+  "info": {
+    "description": "A simple swagger spec that uses examples",
+    "title": "My Resource API",
+    "version": "1.0"
+  },
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "post_stores",
+
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          }
+        }
+      }
+    },
+    "/resource/{resourceId}": {
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resourceId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "bodyParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Parameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/multipleIdenticalUuidSuffixDict.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/multipleIdenticalUuidSuffixDict.json
@@ -1,0 +1,9 @@
+{
+  "restler_fuzzable_string": [ "global" ],
+  "restler_fuzzable_int": [ "0", "1" ],
+  "restler_fuzzable_bool": [ "true", "false" ],
+  "restler_custom_payload_uuid4_suffix": {
+      "resourceId": "resourceprefix",
+      "/resource/id": "resourceprefix"
+    }
+  }


### PR DESCRIPTION
The user should be able to specify a restler_custom_payload_uuid4_suffix
in the dictionary, similarly to how restler_custom_payload is specified.
This use case was regressed when auto-inferred uuid4_suffixes were added.

This change fixes the bug and adds a test for the user-specified case.

Closes #88.