### PR TITLE
Fixed namespace rule checker exception

### DIFF
--- a/restler/checkers/namespace_rule_checker.py
+++ b/restler/checkers/namespace_rule_checker.py
@@ -12,6 +12,8 @@ from engine.bug_bucketing import BugBuckets
 import engine.dependencies as dependencies
 import engine.primitives as primitives
 from utils.logger import raw_network_logging as RAW_LOGGING
+from engine.core.request_utilities import NO_TOKEN_SPECIFIED
+from engine.core.request_utilities import NO_SHADOW_TOKEN_SPECIFIED
 
 STATIC_OAUTH_TOKEN = 'static_oauth_token'
 
@@ -213,13 +215,11 @@ class NameSpaceRuleChecker(CheckerBase):
             return STATIC_OAUTH_TOKEN
         except Exception:
             pass
-        try:
-            from engine.core.requests import latest_token_value as token1
-            from engine.core.requests import latest_shadow_token_value as token2
-            if token1 is not None and token2 is not None:
-                return primitives.REFRESHABLE_AUTHENTICATION_TOKEN
-        except Exception:
-            pass
+
+        from engine.core.request_utilities import latest_token_value as token1
+        from engine.core.request_utilities import latest_shadow_token_value as token2
+        if token1 is not NO_TOKEN_SPECIFIED and token2 is not NO_SHADOW_TOKEN_SPECIFIED:
+            return primitives.REFRESHABLE_AUTHENTICATION_TOKEN
 
         return 'ONLY_ONE_USER'
 
@@ -236,8 +236,8 @@ class NameSpaceRuleChecker(CheckerBase):
         """
         # print(repr(data))
         if self._authentication_method == primitives.REFRESHABLE_AUTHENTICATION_TOKEN:
-            from engine.core.requests import latest_token_value
-            from engine.core.requests import latest_shadow_token_value
+            from engine.core.request_utilities import latest_token_value
+            from engine.core.request_utilities import latest_shadow_token_value
             token1 = latest_token_value
             token2 = latest_shadow_token_value
             data = data.replace(token1, token2)

--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -23,7 +23,8 @@ from engine.transport_layer.messaging import HttpSock
 last_refresh = 0
 NO_TOKEN_SPECIFIED = 'NO-TOKEN-SPECIFIED'
 latest_token_value = NO_TOKEN_SPECIFIED
-latest_shadow_token_value = 'NO-SHADOW-TOKEN-SPECIFIED'
+NO_SHADOW_TOKEN_SPECIFIED = 'NO-SHADOW-TOKEN-SPECIFIED'
+latest_shadow_token_value = NO_SHADOW_TOKEN_SPECIFIED
 
 HOST_PREFIX = 'Host: '
 


### PR DESCRIPTION
Fixed import errors in namespace rule checker. The exceptions were causing the namespace rule checker to be ignored without warning.

Moved imports out of try block, so this will be caught in the future if the directories change again.

Closes #98 