### PR TITLE
Added generic exception catch to fuzzing thread class.

### DIFF
--- a/restler/engine/core/fuzzer.py
+++ b/restler/engine/core/fuzzer.py
@@ -28,6 +28,11 @@ class FuzzingThread(threading.Thread):
         self._checkers = checkers
         self._fuzzing_jobs = fuzzing_jobs
         self._num_total_sequences = 0
+        self._exception = None
+
+    @property
+    def exception(self):
+        return self._exception
 
     def run(self):
         """ Thread entrance - performs fuzzing
@@ -46,6 +51,8 @@ class FuzzingThread(threading.Thread):
             )
         except InvalidDictionaryException:
             pass
+        except Exception as err:
+            self._exception = str(err)
 
     def join(self, *args):
         """ Overrides thread join function

--- a/restler/restler.py
+++ b/restler/restler.py
@@ -562,4 +562,8 @@ if __name__ == '__main__':
     # Print the end of the run generation stats
     logger.print_generation_stats(req_collection, monitor, None, final=True)
 
+    if fuzz_thread.exception is not None:
+        print(fuzz_thread.exception)
+        sys.exit(-1)
+
     print("Done.")


### PR DESCRIPTION
Added generic exception catch to fuzzing thread class. 
Restler.py now exits with -1 code if the fuzzing thread caught an exception.

Closes #110 