### PR TITLE
Updated namespace rule checker to no longer re-render the final target request

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,7 +68,9 @@
                 "c:\\restler\\restlertest\\test_settings.json",
                 "--use_test_socket",
                 "--garbage_collection_interval", "30",
-                "--target_ip", "1", "--target_port", "1"
+                "--target_ip", "1", "--target_port", "1",
+                "--token_refresh_cmd", "python restler\\unit_tests\\log_baseline_test_files\\unit_test_server_auth.py",
+                "--token_refresh_interval", "30"
             ]
         },
         {

--- a/restler/checkers/namespace_rule_checker.py
+++ b/restler/checkers/namespace_rule_checker.py
@@ -47,9 +47,9 @@ class NameSpaceRuleChecker(CheckerBase):
 
         self._namespace_rule()
 
-    def _render_original_sequence(self, seq):
-        """ Helper to re-render original sequence to have better checkers'
-        independence.
+    def _render_original_sequence_start(self, seq):
+        """ Helper to re-render the start of the original sequence to create
+        the appropriate dynamic objects. Does not send the final target request.
 
         @param seq: The sequence whose last request we will try to render.
         @type  seq: Sequence Class object.
@@ -58,10 +58,10 @@ class NameSpaceRuleChecker(CheckerBase):
         @rtype : None
 
         """
-        self._checker_log.checker_print("\nRe-rendering original sequence")
-        RAW_LOGGING("Re-rendering original sequence")
+        self._checker_log.checker_print("\nRe-rendering start of original sequence")
+        RAW_LOGGING("Re-rendering start of original sequence")
 
-        for request in seq:
+        for request in seq.requests[:-1]:
             rendered_data, parser = request.render_current(
                 self._req_collection.candidate_values_pool
             )
@@ -97,7 +97,7 @@ class NameSpaceRuleChecker(CheckerBase):
         if self._mode != 'exhaustive' and not self._sequence.last_request.consumes:
             return
 
-        self._render_original_sequence(self._sequence)
+        self._render_original_sequence_start(self._sequence)
 
         for type in consumed_types:
            hijacked_values[type] = dependencies.get_variable(type)

--- a/restler/unit_tests/log_baseline_test_files/checkers_bug_buckets.txt
+++ b/restler/unit_tests/log_baseline_test_files/checkers_bug_buckets.txt
@@ -1,10 +1,10 @@
 LeakageRuleChecker_20x: 1
 InvalidDynamicObjectChecker_20x: 13
+NameSpaceRuleChecker_20x: 2
 UseAfterFreeChecker_20x: 1
-NameSpaceRuleChecker_20x: 1
 main_driver_500: 1
 ResourceHierarchyChecker_20x: 1
-Total Buckets: 18
+Total Buckets: 19
 -------------
 LeakageRuleChecker_20x - Bug was reproduced - LeakageRuleChecker_20x_1.txt
 Hash: LeakageRuleChecker_20x_862884a058ddaaebe2c8d479c75b44b294ff4684
@@ -79,17 +79,23 @@ PUT /resourcehierarchytest/resourcehierarchyTest HTTP/1.1\r\nAccept: application
 PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n{}\r\n
 GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n
 --------------------------------------------------------------------------------
+NameSpaceRuleChecker_20x - Unable to reproduce bug - NameSpaceRuleChecker_20x_1.txt
+Attempted to reproduce 0 time(s); Reproduced 0 time(s)
+Hash: NameSpaceRuleChecker_20x_52116bf01989e9aef30515fe60bac5fb5f667509
+PUT /namespaceruletest/namespaceruleTest HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n{}\r\n
+DELETE /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n
+--------------------------------------------------------------------------------
+NameSpaceRuleChecker_20x - Unable to reproduce bug - NameSpaceRuleChecker_20x_2.txt
+Attempted to reproduce 0 time(s); Reproduced 0 time(s)
+Hash: NameSpaceRuleChecker_20x_577e9b24b6d395beae4cb5ddb5ce5d6df29e33f6
+PUT /namespaceruletest/namespaceruleTest HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n{}\r\n
+GET /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n
+--------------------------------------------------------------------------------
 UseAfterFreeChecker_20x - Bug was reproduced - UseAfterFreeChecker_20x_1.txt
 Hash: UseAfterFreeChecker_20x_8ccb62ff5e82bc905b633f5c228fecaf59b8c379
 PUT /useafterfreetest/useafterfreeTest HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n{}\r\n
 DELETE /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n
 GET /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n
---------------------------------------------------------------------------------
-NameSpaceRuleChecker_20x - Unable to reproduce bug - NameSpaceRuleChecker_20x_1.txt
-Attempted to reproduce 0 time(s); Reproduced 0 time(s)
-Hash: NameSpaceRuleChecker_20x_577e9b24b6d395beae4cb5ddb5ce5d6df29e33f6
-PUT /namespaceruletest/namespaceruleTest HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n{}\r\n
-GET /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nauthentication_token_tag\r\n
 --------------------------------------------------------------------------------
 main_driver_500 - Bug was reproduced - main_driver_500_1.txt
 Hash: main_driver_500_a6e432e533efe1aa006445e4d76075393bc0848f

--- a/restler/unit_tests/log_baseline_test_files/checkers_gc_log.txt
+++ b/restler/unit_tests/log_baseline_test_files/checkers_gc_log.txt
@@ -1,204 +1,204 @@
-2020-12-15 16:31:05.028: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.507: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.034: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-a49121130d"'
+2020-12-16 15:03:59.514: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-1779fbc12c"'
 
-2020-12-15 16:31:05.045: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.535: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.053: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.545: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.061: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3e152d4366 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.554: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-f38d1c74cb HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.069: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-3e152d4366"'
+2020-12-16 15:03:59.562: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-f38d1c74cb"'
 
-2020-12-15 16:31:05.078: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3e152d4366 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.570: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-f38d1c74cb HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.085: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.586: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.094: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-423fef2e6d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.595: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3f798393a3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.102: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-423fef2e6d"'
+2020-12-16 15:03:59.612: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-3f798393a3"'
 
-2020-12-15 16:31:05.110: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-423fef2e6d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.625: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3f798393a3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.119: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.635: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.128: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ad31a6e1c3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.645: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-183399ee10 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.136: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-ad31a6e1c3"'
+2020-12-16 15:03:59.662: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-183399ee10"'
 
-2020-12-15 16:31:05.145: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.674: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.153: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.692: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.163: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.703: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.172: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.712: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.180: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-e2183b53de HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.720: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-97c3cfa62a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.188: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-e2183b53de"'
+2020-12-16 15:03:59.730: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-97c3cfa62a"'
 
-2020-12-15 16:31:05.196: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-e2183b53de HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.738: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-97c3cfa62a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.205: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.748: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.214: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-aab0a77974 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.757: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-47fc459a65 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.222: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-aab0a77974"'
+2020-12-16 15:03:59.765: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-47fc459a65"'
 
-2020-12-15 16:31:05.231: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.776: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.241: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-d997e93fe7"'
+2020-12-16 15:03:59.793: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-7e3aab2c65"'
 
-2020-12-15 16:31:05.249: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.804: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.259: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.814: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.268: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-b7bb82b4a2 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.832: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-606a6c6d75 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.277: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-b7bb82b4a2"'
+2020-12-16 15:03:59.844: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-606a6c6d75"'
 
-2020-12-15 16:31:05.287: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-b7bb82b4a2 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.862: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-606a6c6d75 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.295: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.873: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.304: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-a393419d4e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.884: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-e9abb91ee1 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.316: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-a393419d4e"'
+2020-12-16 15:03:59.903: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-e9abb91ee1"'
 
-2020-12-15 16:31:05.324: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.915: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.333: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.925: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.342: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.942: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.351: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.954: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.360: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-b83f3033a3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.973: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-95163bd142 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.369: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.985: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-95163bd142"'
 
-2020-12-15 16:31:05.378: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-b83f3033a3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.003: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-95163bd142 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.387: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.016: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.397: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-6d25903130 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.026: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ed9965e50a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.406: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.035: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.415: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.043: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.425: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-bf16f764cc"'
+2020-12-16 15:04:00.052: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-b0d364a185"'
 
-2020-12-15 16:31:05.434: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.061: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.443: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.070: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.452: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ab04e6b7eb HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.078: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-4869c90b47 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.462: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-ab04e6b7eb"'
+2020-12-16 15:04:00.088: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-4869c90b47"'
 
-2020-12-15 16:31:05.471: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ab04e6b7eb HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.097: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-4869c90b47 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.481: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.106: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.491: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-dbc9b0809d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.116: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-33ec65f0ac HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.500: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-dbc9b0809d"'
+2020-12-16 15:04:00.133: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-33ec65f0ac"'
 
-2020-12-15 16:31:05.511: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-7c115a39c4 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.143: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-709622f237 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.522: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-7c115a39c4"'
+2020-12-16 15:04:00.153: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-709622f237"'
 
-2020-12-15 16:31:05.543: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-0f3a1e616a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.173: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-29750d0ce9 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.552: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-0f3a1e616a"'
+2020-12-16 15:04:00.182: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-29750d0ce9"'
 
-2020-12-15 16:31:05.561: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-0f3a1e616a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.191: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-29750d0ce9 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.572: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.201: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.581: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-b1bb398f11 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.209: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-ad2046f3dd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.590: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-b1bb398f11"'
+2020-12-16 15:04:00.219: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-ad2046f3dd"'
 
-2020-12-15 16:31:05.600: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-b1bb398f11 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.241: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-ad2046f3dd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.609: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.252: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.618: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-5c2eb2619a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.262: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-c4cdd1bbc1 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.627: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-5c2eb2619a"'
+2020-12-16 15:04:00.270: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-c4cdd1bbc1"'
 
-2020-12-15 16:31:05.637: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.281: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.646: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.298: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.655: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.311: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.665: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.330: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.674: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-fdb517977c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.350: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-244bca4cc6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.684: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.362: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.693: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-fdb517977c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.371: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-244bca4cc6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.705: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.380: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.717: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-46974522ba HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.398: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-5d9e911333 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.728: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:04:00.410: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:05.737: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-d781bf774e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.420: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-6cdfedb2e5 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.748: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-d781bf774e"'
+2020-12-16 15:04:00.429: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-6cdfedb2e5"'
 
-2020-12-15 16:31:05.772: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a03a5cd766 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.462: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.781: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-a03a5cd766"'
+2020-12-16 15:04:00.471: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-d0f0bb96e6"'
 
-2020-12-15 16:31:05.799: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a03a5cd766 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.480: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.811: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-a03a5cd766"'
+2020-12-16 15:04:00.490: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-d0f0bb96e6"'
 
-2020-12-15 16:31:05.820: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a425d51754 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.508: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-bfacca7139 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.829: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-a425d51754"'
+2020-12-16 15:04:00.520: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-bfacca7139"'
 
-2020-12-15 16:31:05.839: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a425d51754 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.542: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-bfacca7139 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.848: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-a425d51754"'
+2020-12-16 15:04:00.553: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-bfacca7139"'
 
-2020-12-15 16:31:05.858: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-9fd46a5e83 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.564: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-79c4609ba3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.867: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-9fd46a5e83"'
+2020-12-16 15:04:00.583: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-79c4609ba3"'
 
-2020-12-15 16:31:05.876: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.595: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.886: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-a7d842a876"'
+2020-12-16 15:04:00.606: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-f400d84511"'
 
-2020-12-15 16:31:05.895: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.615: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.903: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-a7d842a876"'
+2020-12-16 15:04:00.637: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-f400d84511"'
 
-2020-12-15 16:31:05.912: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-3f51ee76e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.650: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-161cff211c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.921: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-3f51ee76e6"'
+2020-12-16 15:04:00.660: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-161cff211c"'
 
-2020-12-15 16:31:05.930: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-3f51ee76e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.678: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-161cff211c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.939: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-3f51ee76e6"'
+2020-12-16 15:04:00.689: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-161cff211c"'
 
-2020-12-15 16:31:05.948: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-e913348acd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.708: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-93c11dbf4f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.956: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-e913348acd"'
+2020-12-16 15:04:00.720: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-93c11dbf4f"'
 
-2020-12-15 16:31:05.966: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-e913348acd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.739: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-93c11dbf4f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.975: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-e913348acd"'
+2020-12-16 15:04:00.750: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-93c11dbf4f"'
 
-2020-12-15 16:31:05.984: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-dab9623d20 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:04:00.762: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-b918f0d121 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:05.993: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-dab9623d20"'
+2020-12-16 15:04:00.779: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-b918f0d121"'
 

--- a/restler/unit_tests/log_baseline_test_files/checkers_testing_log.txt
+++ b/restler/unit_tests/log_baseline_test_files/checkers_testing_log.txt
@@ -1,5 +1,5 @@
-2020-12-15 16:30:39.649: Will refresh token: C:\RESTlerRepo\restler-fuzzer\restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
-2020-12-15 16:30:39.833: New value: {'user1':{}, 'user2':{}}
+2020-12-16 15:03:33.401: Will refresh token: python C:\RESTlerRepo\restler-fuzzer\restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
+2020-12-16 15:03:33.471: New value: {'user1':{}, 'user2':{}}
 Authorization: valid_unit_test_token
 Authorization: shadow_unit_test_token
 
@@ -21,43 +21,43 @@ Generation-1: Rendering Sequence-1
 		- restler_static_string: '}'
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:40.047: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-7c115a39c4 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:33.670: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-709622f237 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:40.056: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-7c115a39c4"}'
+2020-12-16 15:03:33.680: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-709622f237"}'
 
-2020-12-15 16:30:40.066: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:33.690: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:40.074: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:33.698: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:40.083: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:33.707: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:40.092: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:33.717: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:40.099: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:33.726: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:40.108: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:33.737: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:40.116: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:33.746: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:40.124: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:33.755: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:40.132: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:33.763: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:40.141: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:33.772: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:40.149: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:33.782: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:40.159: PayloadBodyChecker fuzzing valid True
-2020-12-15 16:30:40.172: PayloadBodyChecker fuzzing invalid True
-2020-12-15 16:30:40.185: PayloadBodyChecker start with examples True
-2020-12-15 16:30:40.198: PayloadBodyChecker size dep budget True
-2020-12-15 16:30:40.211: PayloadBodyChecker use feedback True
-2020-12-15 16:30:40.223: PayloadBodyChecker recipe None
-2020-12-15 16:30:40.232: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:33.792: PayloadBodyChecker fuzzing valid True
+2020-12-16 15:03:33.805: PayloadBodyChecker fuzzing invalid True
+2020-12-16 15:03:33.816: PayloadBodyChecker start with examples True
+2020-12-16 15:03:33.826: PayloadBodyChecker size dep budget True
+2020-12-16 15:03:33.837: PayloadBodyChecker use feedback True
+2020-12-16 15:03:33.848: PayloadBodyChecker recipe None
+2020-12-16 15:03:33.856: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:40.240: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:33.865: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:40.249: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:33.875: Checker: ExamplesChecker kicks out
 
 
 Generation-1: Rendering Sequence-1
@@ -73,37 +73,37 @@ Generation-1: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:40.462: Sending: 'GET /item HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:34.099: Sending: 'GET /item HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:40.471: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"item": {}}'
+2020-12-16 15:03:34.107: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"item": {}}'
 
-2020-12-15 16:30:40.480: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:34.116: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:40.489: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:34.127: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:40.497: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:34.136: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:40.506: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:34.145: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:40.515: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:34.154: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:40.524: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:34.164: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:40.533: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:34.174: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:40.542: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:34.183: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:40.551: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:34.195: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:40.559: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:34.205: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:40.569: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:34.214: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:40.579: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:34.225: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:40.587: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:34.234: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:40.596: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:34.243: Checker: ExamplesChecker kicks out
 
 
 Generation-1: Rendering Sequence-1
@@ -124,37 +124,37 @@ Generation-1: Rendering Sequence-1
 		- restler_static_string: '}'
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:40.852: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-d781bf774e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:34.503: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-6cdfedb2e5 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:40.861: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-d781bf774e"}'
+2020-12-16 15:03:34.514: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-6cdfedb2e5"}'
 
-2020-12-15 16:30:40.870: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:34.525: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:40.879: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:34.535: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:40.887: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:34.544: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:40.896: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:34.553: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:40.906: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:34.561: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:40.916: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:34.570: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:40.924: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:34.580: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:40.932: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:34.589: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:40.940: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:34.598: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:40.949: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:34.608: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:40.958: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:34.617: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:40.966: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:34.626: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:40.974: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:34.636: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:40.982: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:34.644: Checker: ExamplesChecker kicks out
 
 
 Generation-1: Rendering Sequence-1
@@ -168,37 +168,37 @@ Generation-1: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:41.184: Sending: 'GET /city HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:34.863: Sending: 'GET /city HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:41.193: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"city": {}}'
+2020-12-16 15:03:34.874: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"city": {}}'
 
-2020-12-15 16:30:41.211: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:34.882: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:41.224: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:34.892: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:41.234: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:34.902: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:41.244: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:34.911: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:41.253: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:34.921: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:41.263: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:34.931: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:41.271: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:34.940: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:41.284: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:34.950: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:41.293: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:34.959: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:41.302: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:34.968: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:41.314: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:34.977: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:41.327: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:34.987: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:41.337: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:34.996: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:41.347: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:35.005: Checker: ExamplesChecker kicks out
 
 
 Generation-1: Rendering Sequence-1
@@ -219,37 +219,37 @@ Generation-1: Rendering Sequence-1
 		- restler_static_string: '}'
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:41.588: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-dab9623d20 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:35.252: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-b918f0d121 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:41.598: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-dab9623d20"}'
+2020-12-16 15:03:35.262: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-b918f0d121"}'
 
-2020-12-15 16:30:41.608: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:35.271: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:41.617: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:35.280: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:41.627: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:35.288: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:41.638: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:35.298: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:41.649: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:35.309: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:41.659: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:35.328: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:41.669: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:35.341: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:41.678: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:35.351: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:41.689: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:35.360: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:41.700: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:35.371: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:41.711: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:35.381: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:41.721: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:35.392: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:41.733: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:35.402: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:41.743: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:35.411: Checker: ExamplesChecker kicks out
 
 
 Generation-1: Rendering Sequence-1
@@ -270,87 +270,87 @@ Generation-1: Rendering Sequence-1
 		- restler_static_string: '}'
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:42.046: Sending: 'PUT /leakageruletest/leakageTest<test!>-5d699615e3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:35.690: Sending: 'PUT /leakageruletest/leakageTest<test!>-50360211ad HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:42.059: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': FailedToCreateResource()}"
+2020-12-16 15:03:35.700: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': FailedToCreateResource()}"
 
-2020-12-15 16:30:42.069: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
-2020-12-15 16:30:42.080: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:35.709: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
+2020-12-16 15:03:35.721: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:42.097: LeakageRuleChecker 
+2020-12-16 15:03:35.739: LeakageRuleChecker 
 Target type: _leakageruletest_put_name
-2020-12-15 16:30:42.107: Sending: 'GET /leakageruletest/leakageTest<test!>-5d699615e3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:35.750: Sending: 'GET /leakageruletest/leakageTest<test!>-50360211ad HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:42.117: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "leakageTest<test!>-5d699615e3"}'
+2020-12-16 15:03:35.760: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "leakageTest<test!>-50360211ad"}'
 
-2020-12-15 16:30:42.135: LeakageRuleChecker 
+2020-12-16 15:03:35.785: LeakageRuleChecker 
 Suspect sequence: 200
-2020-12-15 16:30:42.155: LeakageRuleChecker PUT /leakageruletest/leakageTest
-2020-12-15 16:30:42.175: LeakageRuleChecker GET /leakageruletest/_READER_DELIM_leakageruletest_put_name_READER_DELIM
-2020-12-15 16:30:42.188: Attempting to reproduce bug...
-2020-12-15 16:30:42.200: Sending: 'PUT /leakageruletest/leakageTest<test!>-5d699615e3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:35.799: LeakageRuleChecker PUT /leakageruletest/leakageTest
+2020-12-16 15:03:35.809: LeakageRuleChecker GET /leakageruletest/_READER_DELIM_leakageruletest_put_name_READER_DELIM
+2020-12-16 15:03:35.818: Attempting to reproduce bug...
+2020-12-16 15:03:35.830: Sending: 'PUT /leakageruletest/leakageTest<test!>-50360211ad HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:42.217: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': FailedToCreateResource()}"
+2020-12-16 15:03:35.851: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': FailedToCreateResource()}"
 
-2020-12-15 16:30:42.233: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
-2020-12-15 16:30:42.248: Sending: 'GET /leakageruletest/leakageTest<test!>-5d699615e3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:35.863: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
+2020-12-16 15:03:35.874: Sending: 'GET /leakageruletest/leakageTest<test!>-50360211ad HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:42.264: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "leakageTest<test!>-5d699615e3"}'
+2020-12-16 15:03:35.893: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "leakageTest<test!>-50360211ad"}'
 
-2020-12-15 16:30:42.279: Done replaying sequence.
-2020-12-15 16:30:42.307: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:35.905: Done replaying sequence.
+2020-12-16 15:03:35.926: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:42.324: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:35.937: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:42.338: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:35.948: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:42.353: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:35.958: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:42.367: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:35.970: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:42.381: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:35.980: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:42.396: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:35.989: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:42.410: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:35.999: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:42.422: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:36.008: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:42.436: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:36.018: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:42.450: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:36.029: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:42.464: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:36.039: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:42.479: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:36.049: Checker: ExamplesChecker kicks out
 
-2020-12-15 16:30:42.490: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:36.057: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:42.501: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:36.067: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:42.512: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:36.077: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:42.525: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:36.086: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:42.537: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:36.096: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:42.548: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:36.105: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:42.558: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:36.114: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:42.567: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:36.133: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:42.579: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:36.145: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:42.591: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:36.162: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:42.603: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:36.171: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:42.614: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:36.180: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:42.624: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:36.200: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:42.634: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:36.212: Checker: ExamplesChecker kicks out
 
 
 Generation-1: Rendering Sequence-1
@@ -369,37 +369,37 @@ Generation-1: Rendering Sequence-1
 		- restler_static_string: '}'
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:42.909: Sending: 'PUT /city/cityName<test!>-f768b43d50 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:36.508: Sending: 'PUT /city/cityName<test!>-b845528b1b HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:42.918: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-f768b43d50", "properties": {}}'
+2020-12-16 15:03:36.518: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-b845528b1b", "properties": {}}'
 
-2020-12-15 16:30:42.928: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:36.527: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:42.937: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:36.537: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:42.947: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:36.545: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:42.956: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:36.554: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:42.967: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:36.565: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:42.976: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:36.583: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:42.988: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:36.595: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:43.005: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:36.605: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:43.033: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:36.615: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:43.051: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:36.624: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:43.065: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:36.634: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:43.080: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:36.653: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:43.096: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:36.665: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:43.109: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:36.675: Checker: ExamplesChecker kicks out
 
 
 Generation-1: Rendering Sequence-1
@@ -415,37 +415,37 @@ Generation-1: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:43.387: Sending: 'GET /farm HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:36.925: Sending: 'GET /farm HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:43.396: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"farm": {}}'
+2020-12-16 15:03:36.936: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"farm": {}}'
 
-2020-12-15 16:30:43.406: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:36.945: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:43.416: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:36.955: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:43.425: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:36.964: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:43.436: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:36.974: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:43.453: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:36.993: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:43.466: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:37.005: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:43.477: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:37.015: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:43.490: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:37.024: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:43.503: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:37.033: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:43.515: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:37.042: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:43.525: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:37.052: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:43.538: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:37.061: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:43.548: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:37.071: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:43.557: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:37.081: Checker: ExamplesChecker kicks out
 
 
 Generation-2: Rendering Sequence-1
@@ -477,117 +477,113 @@ Generation-2: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:43.912: Sending: 'PUT /city/cityName<test!>-3fae16cd13 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:37.462: Sending: 'PUT /city/cityName<test!>-9710aead20 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:43.922: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3fae16cd13", "properties": {}}'
+2020-12-16 15:03:37.471: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-9710aead20", "properties": {}}'
 
-2020-12-15 16:30:43.931: Sending: 'GET /city/cityName<test!>-3fae16cd13 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:37.481: Sending: 'GET /city/cityName<test!>-9710aead20 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:43.941: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3fae16cd13", "properties": {}}'
+2020-12-16 15:03:37.489: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-9710aead20", "properties": {}}'
 
-2020-12-15 16:30:43.951: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:37.498: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:43.964: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:37.508: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:43.974: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:37.517: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:43.983: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:37.526: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:43.993: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:37.535: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:44.003: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:37.544: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:44.013: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:37.552: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:44.024: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:44.033: Re-rendering original sequence
-2020-12-15 16:30:44.042: Sending: 'PUT /city/cityName<test!>-c8aaaf6448 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:37.561: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:37.570: Re-rendering start of original sequence
+2020-12-16 15:03:37.579: Sending: 'PUT /city/cityName<test!>-61dcdc8a47 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:44.051: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-c8aaaf6448", "properties": {}}'
+2020-12-16 15:03:37.588: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-61dcdc8a47", "properties": {}}'
 
-2020-12-15 16:30:44.061: Sending: 'GET /city/cityName<test!>-c8aaaf6448 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:37.602: NameSpaceRuleChecker Hijacked values: {'_city_put_name': 'cityName<test!>-61dcdc8a47'}
+2020-12-16 15:03:37.611: Hijacked values: {'_city_put_name': 'cityName<test!>-61dcdc8a47'}
+2020-12-16 15:03:37.625: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:37.635: Subsequence rendering  up to: 0
+2020-12-16 15:03:37.660: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:37.670: Hijack request rendering
+2020-12-16 15:03:37.679: Sending: 'GET /city/cityName<test!>-61dcdc8a47 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:44.070: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-c8aaaf6448", "properties": {}}'
+2020-12-16 15:03:37.688: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:30:44.085: NameSpaceRuleChecker Hijacked values: {'_city_put_name': 'cityName<test!>-c8aaaf6448'}
-2020-12-15 16:30:44.094: Hijacked values: {'_city_put_name': 'cityName<test!>-c8aaaf6448'}
-2020-12-15 16:30:44.114: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:44.125: Subsequence rendering  up to: 0
-2020-12-15 16:30:44.139: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:44.149: Hijack request rendering
-2020-12-15 16:30:44.158: Sending: 'GET /city/cityName<test!>-c8aaaf6448 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:37.698: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:44.168: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
+2020-12-16 15:03:37.707: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:44.178: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:37.717: Re-rendering and sending start of sequence
+2020-12-16 15:03:37.728: Sending: 'PUT /city/cityName<test!>-844143586d HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:44.187: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:37.738: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-844143586d", "properties": {}}'
 
-2020-12-15 16:30:44.198: Re-rendering and sending start of sequence
-2020-12-15 16:30:44.207: Sending: 'PUT /city/cityName<test!>-e3bff23788 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:44.217: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e3bff23788", "properties": {}}'
-
-2020-12-15 16:30:44.227: InvalidDynamicObjectChecker 
+2020-12-16 15:03:37.749: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:30:44.237: Preparing requests with invalid objects
-2020-12-15 16:30:44.252: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-e3bff23788?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:44.262: Sending: 'GET /city/cityName<test!>-e3bff23788?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:37.758: Preparing requests with invalid objects
+2020-12-16 15:03:37.768: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-844143586d?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:37.777: Sending: 'GET /city/cityName<test!>-844143586d?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:44.271: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e3bff23788", "properties": {}}'
+2020-12-16 15:03:37.786: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-844143586d", "properties": {}}'
 
-2020-12-15 16:30:44.281: Attempting to reproduce bug...
-2020-12-15 16:30:44.290: Sending: 'PUT /city/cityName<test!>-e3bff23788 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:37.796: Attempting to reproduce bug...
+2020-12-16 15:03:37.806: Sending: 'PUT /city/cityName<test!>-844143586d HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:44.299: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e3bff23788", "properties": {}}'
+2020-12-16 15:03:37.817: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-844143586d", "properties": {}}'
 
-2020-12-15 16:30:44.309: Sending: 'GET /city/cityName<test!>-e3bff23788?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:37.827: Sending: 'GET /city/cityName<test!>-844143586d?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:44.319: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e3bff23788", "properties": {}}'
+2020-12-16 15:03:37.837: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-844143586d", "properties": {}}'
 
-2020-12-15 16:30:44.329: Done replaying sequence.
-2020-12-15 16:30:44.354: InvalidDynamicObjectChecker 
+2020-12-16 15:03:37.847: Done replaying sequence.
+2020-12-16 15:03:37.871: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:44.372: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:44.387: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM
-2020-12-15 16:30:44.402: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-e3bff23788/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:44.411: Sending: 'GET /city/cityName<test!>-e3bff23788/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:37.886: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:37.903: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM
+2020-12-16 15:03:37.918: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-844143586d/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:37.927: Sending: 'GET /city/cityName<test!>-844143586d/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:44.420: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e3bff23788", "properties": {}}'
+2020-12-16 15:03:37.938: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-844143586d", "properties": {}}'
 
-2020-12-15 16:30:44.438: InvalidDynamicObjectChecker 
+2020-12-16 15:03:37.958: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:44.453: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:44.468: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM
-2020-12-15 16:30:44.484: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-e3bff23788?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:44.495: Sending: 'GET /city/cityName<test!>-e3bff23788?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:37.972: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:37.987: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM
+2020-12-16 15:03:38.001: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-844143586d?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:38.010: Sending: 'GET /city/cityName<test!>-844143586d?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:44.505: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e3bff23788", "properties": {}}'
+2020-12-16 15:03:38.019: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-844143586d", "properties": {}}'
 
-2020-12-15 16:30:44.525: InvalidDynamicObjectChecker 
+2020-12-16 15:03:38.041: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:44.541: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:44.556: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM
-2020-12-15 16:30:44.573: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-e3bff23788/cityName<test!>-e3bff23788 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:44.585: Sending: 'GET /city/cityName<test!>-e3bff23788/cityName<test!>-e3bff23788 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:38.056: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:38.071: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM
+2020-12-16 15:03:38.086: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-844143586d/cityName<test!>-844143586d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:38.095: Sending: 'GET /city/cityName<test!>-844143586d/cityName<test!>-844143586d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:44.597: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:38.105: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:44.615: InvalidDynamicObjectChecker 'GET /city/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:44.625: Sending: 'GET /city/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:38.119: InvalidDynamicObjectChecker 'GET /city/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:38.128: Sending: 'GET /city/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:44.635: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:38.138: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:44.644: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:38.148: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:44.655: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:38.160: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:44.664: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:38.169: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:44.673: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:38.179: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:44.683: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:38.190: Checker: ExamplesChecker kicks out
 
 
 Generation-2: Rendering Sequence-1
@@ -621,117 +617,117 @@ Generation-2: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:45.068: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-46974522ba HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:38.613: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-5d9e911333 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:45.077: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-46974522ba"}'
+2020-12-16 15:03:38.622: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-5d9e911333"}'
 
-2020-12-15 16:30:45.086: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-46974522ba HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:38.630: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-5d9e911333 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:45.104: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-46974522ba"'
+2020-12-16 15:03:38.639: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-5d9e911333"'
 
-2020-12-15 16:30:45.116: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:38.649: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:45.126: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:38.657: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:45.135: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:38.667: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:45.144: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:38.676: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:45.153: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:38.685: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:45.163: UseAfterFreeChecker 
+2020-12-16 15:03:38.695: UseAfterFreeChecker 
 Target types: {'_namespaceruletest_put_name'}
-2020-12-15 16:30:45.176: UseAfterFreeChecker Clean tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': None, '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': 'namespaceruletest<test!>-46974522ba'}
-2020-12-15 16:30:45.189: UseAfterFreeChecker Found * 1 * consumers.
-2020-12-15 16:30:45.197: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-46974522ba HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:38.713: UseAfterFreeChecker Clean tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': None, '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': 'namespaceruletest<test!>-5d9e911333'}
+2020-12-16 15:03:38.737: UseAfterFreeChecker Found * 1 * consumers.
+2020-12-16 15:03:38.747: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-5d9e911333 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:45.206: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:38.757: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:45.215: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:38.767: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:45.225: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:38.785: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:45.239: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:45.248: Re-rendering original sequence
-2020-12-15 16:30:45.258: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-fdb517977c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:38.799: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:38.810: Re-rendering start of original sequence
+2020-12-16 15:03:38.820: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-244bca4cc6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:45.267: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-fdb517977c"}'
+2020-12-16 15:03:38.840: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-244bca4cc6"}'
 
-2020-12-15 16:30:45.275: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-fdb517977c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:38.872: NameSpaceRuleChecker Hijacked values: {'_namespaceruletest_put_name': 'namespaceruletest<test!>-244bca4cc6'}
+2020-12-16 15:03:38.886: Hijacked values: {'_namespaceruletest_put_name': 'namespaceruletest<test!>-244bca4cc6'}
+2020-12-16 15:03:38.902: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:38.911: Subsequence rendering  up to: 0
+2020-12-16 15:03:38.926: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:38.936: Hijack request rendering
+2020-12-16 15:03:38.946: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-244bca4cc6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:45.284: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-fdb517977c"'
+2020-12-16 15:03:38.955: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-244bca4cc6"'
 
-2020-12-15 16:30:45.298: NameSpaceRuleChecker Hijacked values: {'_namespaceruletest_put_name': 'namespaceruletest<test!>-fdb517977c'}
-2020-12-15 16:30:45.307: Hijacked values: {'_namespaceruletest_put_name': 'namespaceruletest<test!>-fdb517977c'}
-2020-12-15 16:30:45.321: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:45.330: Subsequence rendering  up to: 0
-2020-12-15 16:30:45.344: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:45.353: Hijack request rendering
-2020-12-15 16:30:45.363: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-fdb517977c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
-
-2020-12-15 16:30:45.372: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
-
-2020-12-15 16:30:45.381: Checker: NameSpaceRuleChecker kicks out
-
-2020-12-15 16:30:45.391: Checker: InvalidDynamicObjectChecker kicks in
-
-2020-12-15 16:30:45.400: Re-rendering and sending start of sequence
-2020-12-15 16:30:45.409: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-b4d796c751 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:45.418: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-b4d796c751"}'
-
-2020-12-15 16:30:45.434: InvalidDynamicObjectChecker 
-Sending invalid request(s):
-2020-12-15 16:30:45.443: Preparing requests with invalid objects
-2020-12-15 16:30:45.457: InvalidDynamicObjectChecker 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:45.466: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
-
-2020-12-15 16:30:45.474: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-b4d796c751"'
-
-2020-12-15 16:30:45.483: Attempting to reproduce bug...
-2020-12-15 16:30:45.494: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-b4d796c751 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:45.505: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-b4d796c751"}'
-
-2020-12-15 16:30:45.515: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
-
-2020-12-15 16:30:45.524: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-b4d796c751"'
-
-2020-12-15 16:30:45.533: Done replaying sequence.
-2020-12-15 16:30:45.558: InvalidDynamicObjectChecker 
+2020-12-16 15:03:38.970: NameSpaceRuleChecker 
 Suspect sequence: 202
-2020-12-15 16:30:45.573: InvalidDynamicObjectChecker PUT /namespaceruletest/namespaceruleTest
-2020-12-15 16:30:45.588: InvalidDynamicObjectChecker DELETE /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
-2020-12-15 16:30:45.603: InvalidDynamicObjectChecker 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:45.612: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:38.995: NameSpaceRuleChecker PUT /namespaceruletest/namespaceruleTest
+2020-12-16 15:03:39.024: NameSpaceRuleChecker DELETE /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
+2020-12-16 15:03:39.046: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:45.621: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
+2020-12-16 15:03:39.058: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:45.636: InvalidDynamicObjectChecker 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:45.644: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:39.068: Re-rendering and sending start of sequence
+2020-12-16 15:03:39.077: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-01a93b2911 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:45.653: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:39.088: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-01a93b2911"}'
 
-2020-12-15 16:30:45.669: InvalidDynamicObjectChecker 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751/namespaceruletest<test!>-b4d796c751 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:45.678: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-b4d796c751/namespaceruletest<test!>-b4d796c751 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:39.115: InvalidDynamicObjectChecker 
+Sending invalid request(s):
+2020-12-16 15:03:39.128: Preparing requests with invalid objects
+2020-12-16 15:03:39.144: InvalidDynamicObjectChecker 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:39.154: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:45.687: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: namespaceruletest<test!>-b4d796c751"}'
+2020-12-16 15:03:39.174: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-01a93b2911"'
 
-2020-12-15 16:30:45.703: InvalidDynamicObjectChecker 'DELETE /namespaceruletest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:45.714: Sending: 'DELETE /namespaceruletest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:39.186: Attempting to reproduce bug...
+2020-12-16 15:03:39.196: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-01a93b2911 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:45.725: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:39.206: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-01a93b2911"}'
 
-2020-12-15 16:30:45.735: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:39.216: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:45.744: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:39.226: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"namespaceruletest<test!>-01a93b2911"'
 
-2020-12-15 16:30:45.753: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:39.235: Done replaying sequence.
+2020-12-16 15:03:39.261: InvalidDynamicObjectChecker 
+Suspect sequence: 202
+2020-12-16 15:03:39.282: InvalidDynamicObjectChecker PUT /namespaceruletest/namespaceruleTest
+2020-12-16 15:03:39.300: InvalidDynamicObjectChecker DELETE /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
+2020-12-16 15:03:39.317: InvalidDynamicObjectChecker 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:39.327: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:45.764: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:39.337: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
 
-2020-12-15 16:30:45.773: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:39.354: InvalidDynamicObjectChecker 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:39.364: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2020-12-16 15:03:39.385: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+
+2020-12-16 15:03:39.423: InvalidDynamicObjectChecker 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911/namespaceruletest<test!>-01a93b2911 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:39.435: Sending: 'DELETE /namespaceruletest/namespaceruletest<test!>-01a93b2911/namespaceruletest<test!>-01a93b2911 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2020-12-16 15:03:39.446: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: namespaceruletest<test!>-01a93b2911"}'
+
+2020-12-16 15:03:39.470: InvalidDynamicObjectChecker 'DELETE /namespaceruletest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:39.483: Sending: 'DELETE /namespaceruletest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2020-12-16 15:03:39.494: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+
+2020-12-16 15:03:39.513: Checker: InvalidDynamicObjectChecker kicks out
+
+2020-12-16 15:03:39.526: Checker: PayloadBodyChecker kicks in
+
+2020-12-16 15:03:39.535: Checker: PayloadBodyChecker kicks out
+
+2020-12-16 15:03:39.545: Checker: ExamplesChecker kicks in
+
+2020-12-16 15:03:39.556: Checker: ExamplesChecker kicks out
 
 
 Generation-2: Rendering Sequence-1
@@ -765,140 +761,136 @@ Generation-2: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:46.251: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-e913348acd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:40.050: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-93c11dbf4f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:46.261: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-e913348acd"}'
+2020-12-16 15:03:40.070: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-93c11dbf4f"}'
 
-2020-12-15 16:30:46.279: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-e913348acd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.083: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-93c11dbf4f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:46.290: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-e913348acd"'
+2020-12-16 15:03:40.092: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-93c11dbf4f"'
 
-2020-12-15 16:30:46.301: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:40.102: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:46.310: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:40.111: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:46.320: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:40.121: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:46.330: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:40.130: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:46.340: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:40.140: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:46.355: UseAfterFreeChecker 
+2020-12-16 15:03:40.172: UseAfterFreeChecker 
 Target types: {'_useafterfreetest_put_name'}
-2020-12-15 16:30:46.369: UseAfterFreeChecker Clean tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': 'useafterfreeTest<test!>-e913348acd', '_resourcehierarchytest_put_name': None, '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': None}
-2020-12-15 16:30:46.384: UseAfterFreeChecker Found * 1 * consumers.
-2020-12-15 16:30:46.394: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-e913348acd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.193: UseAfterFreeChecker Clean tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': 'useafterfreeTest<test!>-93c11dbf4f', '_resourcehierarchytest_put_name': None, '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': None}
+2020-12-16 15:03:40.208: UseAfterFreeChecker Found * 1 * consumers.
+2020-12-16 15:03:40.221: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-93c11dbf4f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:46.403: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-e913348acd"}'
+2020-12-16 15:03:40.231: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-93c11dbf4f"}'
 
-2020-12-15 16:30:46.417: UseAfterFreeChecker 
+2020-12-16 15:03:40.246: UseAfterFreeChecker 
 Suspect sequence: 200
-2020-12-15 16:30:46.431: UseAfterFreeChecker PUT /useafterfreetest/useafterfreeTest
-2020-12-15 16:30:46.446: UseAfterFreeChecker DELETE /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
-2020-12-15 16:30:46.460: UseAfterFreeChecker GET /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
-2020-12-15 16:30:46.469: Attempting to reproduce bug...
-2020-12-15 16:30:46.478: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-e913348acd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:40.261: UseAfterFreeChecker PUT /useafterfreetest/useafterfreeTest
+2020-12-16 15:03:40.276: UseAfterFreeChecker DELETE /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
+2020-12-16 15:03:40.290: UseAfterFreeChecker GET /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
+2020-12-16 15:03:40.300: Attempting to reproduce bug...
+2020-12-16 15:03:40.310: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-93c11dbf4f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:46.487: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-e913348acd"}'
+2020-12-16 15:03:40.319: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-93c11dbf4f"}'
 
-2020-12-15 16:30:46.500: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-e913348acd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.330: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-93c11dbf4f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:46.510: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-e913348acd"'
+2020-12-16 15:03:40.348: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-93c11dbf4f"'
 
-2020-12-15 16:30:46.520: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-e913348acd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.361: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-93c11dbf4f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:46.530: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-e913348acd"}'
+2020-12-16 15:03:40.372: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-93c11dbf4f"}'
 
-2020-12-15 16:30:46.539: Done replaying sequence.
-2020-12-15 16:30:46.556: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:40.381: Done replaying sequence.
+2020-12-16 15:03:40.400: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:46.566: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:40.411: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:46.580: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:46.590: Re-rendering original sequence
-2020-12-15 16:30:46.599: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-3f51ee76e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:40.427: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:40.437: Re-rendering start of original sequence
+2020-12-16 15:03:40.447: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-161cff211c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:46.608: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-3f51ee76e6"}'
+2020-12-16 15:03:40.456: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-161cff211c"}'
 
-2020-12-15 16:30:46.617: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-3f51ee76e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.473: NameSpaceRuleChecker Hijacked values: {'_useafterfreetest_put_name': 'useafterfreeTest<test!>-161cff211c'}
+2020-12-16 15:03:40.482: Hijacked values: {'_useafterfreetest_put_name': 'useafterfreeTest<test!>-161cff211c'}
+2020-12-16 15:03:40.498: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:40.506: Subsequence rendering  up to: 0
+2020-12-16 15:03:40.521: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:40.530: Hijack request rendering
+2020-12-16 15:03:40.540: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-161cff211c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:46.627: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-3f51ee76e6"'
+2020-12-16 15:03:40.549: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:30:46.642: NameSpaceRuleChecker Hijacked values: {'_useafterfreetest_put_name': 'useafterfreeTest<test!>-3f51ee76e6'}
-2020-12-15 16:30:46.650: Hijacked values: {'_useafterfreetest_put_name': 'useafterfreeTest<test!>-3f51ee76e6'}
-2020-12-15 16:30:46.664: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:46.673: Subsequence rendering  up to: 0
-2020-12-15 16:30:46.687: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:46.696: Hijack request rendering
-2020-12-15 16:30:46.707: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-3f51ee76e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.558: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:46.717: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
+2020-12-16 15:03:40.567: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:46.726: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:40.577: Re-rendering and sending start of sequence
+2020-12-16 15:03:40.586: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-f400d84511 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:46.738: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:40.596: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-f400d84511"}'
 
-2020-12-15 16:30:46.749: Re-rendering and sending start of sequence
-2020-12-15 16:30:46.758: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-a7d842a876 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:46.769: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-a7d842a876"}'
-
-2020-12-15 16:30:46.789: InvalidDynamicObjectChecker 
+2020-12-16 15:03:40.615: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:30:46.798: Preparing requests with invalid objects
-2020-12-15 16:30:46.814: InvalidDynamicObjectChecker 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:46.823: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.625: Preparing requests with invalid objects
+2020-12-16 15:03:40.641: InvalidDynamicObjectChecker 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:40.650: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:46.833: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-a7d842a876"'
+2020-12-16 15:03:40.660: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-f400d84511"'
 
-2020-12-15 16:30:46.842: Attempting to reproduce bug...
-2020-12-15 16:30:46.853: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-a7d842a876 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:40.669: Attempting to reproduce bug...
+2020-12-16 15:03:40.679: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-f400d84511 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:46.862: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-a7d842a876"}'
+2020-12-16 15:03:40.689: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-f400d84511"}'
 
-2020-12-15 16:30:46.871: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.698: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:46.882: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-a7d842a876"'
+2020-12-16 15:03:40.708: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-f400d84511"'
 
-2020-12-15 16:30:46.900: Done replaying sequence.
-2020-12-15 16:30:46.929: InvalidDynamicObjectChecker 
+2020-12-16 15:03:40.717: Done replaying sequence.
+2020-12-16 15:03:40.743: InvalidDynamicObjectChecker 
 Suspect sequence: 202
-2020-12-15 16:30:46.944: InvalidDynamicObjectChecker PUT /useafterfreetest/useafterfreeTest
-2020-12-15 16:30:46.959: InvalidDynamicObjectChecker DELETE /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
-2020-12-15 16:30:46.975: InvalidDynamicObjectChecker 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:46.984: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.762: InvalidDynamicObjectChecker PUT /useafterfreetest/useafterfreeTest
+2020-12-16 15:03:40.778: InvalidDynamicObjectChecker DELETE /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
+2020-12-16 15:03:40.794: InvalidDynamicObjectChecker 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:40.804: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:46.994: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
+2020-12-16 15:03:40.814: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
 
-2020-12-15 16:30:47.010: InvalidDynamicObjectChecker 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:47.019: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.831: InvalidDynamicObjectChecker 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:40.840: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:47.030: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-a7d842a876"'
+2020-12-16 15:03:40.852: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"useafterfreeTest<test!>-f400d84511"'
 
-2020-12-15 16:30:47.050: InvalidDynamicObjectChecker 
+2020-12-16 15:03:40.872: InvalidDynamicObjectChecker 
 Suspect sequence: 202
-2020-12-15 16:30:47.065: InvalidDynamicObjectChecker PUT /useafterfreetest/useafterfreeTest
-2020-12-15 16:30:47.081: InvalidDynamicObjectChecker DELETE /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
-2020-12-15 16:30:47.096: InvalidDynamicObjectChecker 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876/useafterfreeTest<test!>-a7d842a876 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:47.106: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-a7d842a876/useafterfreeTest<test!>-a7d842a876 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.888: InvalidDynamicObjectChecker PUT /useafterfreetest/useafterfreeTest
+2020-12-16 15:03:40.906: InvalidDynamicObjectChecker DELETE /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
+2020-12-16 15:03:40.922: InvalidDynamicObjectChecker 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511/useafterfreeTest<test!>-f400d84511 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:40.931: Sending: 'DELETE /useafterfreetest/useafterfreeTest<test!>-f400d84511/useafterfreeTest<test!>-f400d84511 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:47.115: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: useafterfreeTest<test!>-a7d842a876"}'
+2020-12-16 15:03:40.941: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: useafterfreeTest<test!>-f400d84511"}'
 
-2020-12-15 16:30:47.133: InvalidDynamicObjectChecker 'DELETE /useafterfreetest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:47.143: Sending: 'DELETE /useafterfreetest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:40.958: InvalidDynamicObjectChecker 'DELETE /useafterfreetest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:40.967: Sending: 'DELETE /useafterfreetest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:47.152: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:40.977: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:47.162: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:40.985: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:47.171: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:40.995: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:47.181: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:41.005: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:47.191: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:41.014: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:47.200: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:41.023: Checker: ExamplesChecker kicks out
 
 
 Generation-2: Rendering Sequence-1
@@ -932,121 +924,117 @@ Generation-2: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:47.588: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-5c2eb2619a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:41.461: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-c4cdd1bbc1 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:47.598: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-5c2eb2619a"}'
+2020-12-16 15:03:41.471: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-c4cdd1bbc1"}'
 
-2020-12-15 16:30:47.607: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-5c2eb2619a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:41.482: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-c4cdd1bbc1 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:47.617: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-5c2eb2619a"}'
+2020-12-16 15:03:41.494: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-c4cdd1bbc1"}'
 
-2020-12-15 16:30:47.628: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:41.503: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:47.638: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:41.514: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:47.648: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:41.524: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:47.658: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:41.534: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:47.667: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:41.543: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:47.677: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:41.552: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:47.686: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:41.562: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:47.702: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:47.712: Re-rendering original sequence
-2020-12-15 16:30:47.721: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-b1bb398f11 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:41.577: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:41.588: Re-rendering start of original sequence
+2020-12-16 15:03:41.597: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-ad2046f3dd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:47.731: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-b1bb398f11"}'
+2020-12-16 15:03:41.607: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-ad2046f3dd"}'
 
-2020-12-15 16:30:47.743: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-b1bb398f11 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:41.622: NameSpaceRuleChecker Hijacked values: {'_namespaceruletest_put_name': 'namespaceruletest<test!>-ad2046f3dd'}
+2020-12-16 15:03:41.630: Hijacked values: {'_namespaceruletest_put_name': 'namespaceruletest<test!>-ad2046f3dd'}
+2020-12-16 15:03:41.647: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:41.656: Subsequence rendering  up to: 0
+2020-12-16 15:03:41.671: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:41.680: Hijack request rendering
+2020-12-16 15:03:41.689: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-ad2046f3dd HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:47.753: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-b1bb398f11"}'
+2020-12-16 15:03:41.700: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-ad2046f3dd"}'
 
-2020-12-15 16:30:47.769: NameSpaceRuleChecker Hijacked values: {'_namespaceruletest_put_name': 'namespaceruletest<test!>-b1bb398f11'}
-2020-12-15 16:30:47.779: Hijacked values: {'_namespaceruletest_put_name': 'namespaceruletest<test!>-b1bb398f11'}
-2020-12-15 16:30:47.794: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:47.804: Subsequence rendering  up to: 0
-2020-12-15 16:30:47.819: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:47.828: Hijack request rendering
-2020-12-15 16:30:47.837: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-b1bb398f11 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
-
-2020-12-15 16:30:47.847: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-b1bb398f11"}'
-
-2020-12-15 16:30:47.863: NameSpaceRuleChecker 
+2020-12-16 15:03:41.714: NameSpaceRuleChecker 
 Suspect sequence: 200
-2020-12-15 16:30:47.881: NameSpaceRuleChecker PUT /namespaceruletest/namespaceruleTest
-2020-12-15 16:30:47.896: NameSpaceRuleChecker GET /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
-2020-12-15 16:30:47.913: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:41.729: NameSpaceRuleChecker PUT /namespaceruletest/namespaceruleTest
+2020-12-16 15:03:41.744: NameSpaceRuleChecker GET /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
+2020-12-16 15:03:41.764: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:47.922: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:41.773: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:47.932: Re-rendering and sending start of sequence
-2020-12-15 16:30:47.944: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-0f3a1e616a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:41.783: Re-rendering and sending start of sequence
+2020-12-16 15:03:41.793: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-29750d0ce9 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:47.952: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-0f3a1e616a"}'
+2020-12-16 15:03:41.802: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-29750d0ce9"}'
 
-2020-12-15 16:30:47.968: InvalidDynamicObjectChecker 
+2020-12-16 15:03:41.819: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:30:47.980: Preparing requests with invalid objects
-2020-12-15 16:30:47.996: InvalidDynamicObjectChecker 'GET /namespaceruletest/namespaceruletest<test!>-0f3a1e616a?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:48.006: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-0f3a1e616a?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:41.829: Preparing requests with invalid objects
+2020-12-16 15:03:41.845: InvalidDynamicObjectChecker 'GET /namespaceruletest/namespaceruletest<test!>-29750d0ce9?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:41.854: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-29750d0ce9?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:48.015: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-0f3a1e616a"}'
+2020-12-16 15:03:41.864: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-29750d0ce9"}'
 
-2020-12-15 16:30:48.026: Attempting to reproduce bug...
-2020-12-15 16:30:48.036: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-0f3a1e616a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:41.877: Attempting to reproduce bug...
+2020-12-16 15:03:41.886: Sending: 'PUT /namespaceruletest/namespaceruletest<test!>-29750d0ce9 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:48.046: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-0f3a1e616a"}'
+2020-12-16 15:03:41.895: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-29750d0ce9"}'
 
-2020-12-15 16:30:48.057: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-0f3a1e616a?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:41.906: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-29750d0ce9?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:48.067: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-0f3a1e616a"}'
+2020-12-16 15:03:41.916: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-29750d0ce9"}'
 
-2020-12-15 16:30:48.077: Done replaying sequence.
-2020-12-15 16:30:48.102: InvalidDynamicObjectChecker 
+2020-12-16 15:03:41.926: Done replaying sequence.
+2020-12-16 15:03:41.954: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:48.118: InvalidDynamicObjectChecker PUT /namespaceruletest/namespaceruleTest
-2020-12-15 16:30:48.134: InvalidDynamicObjectChecker GET /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
-2020-12-15 16:30:48.150: InvalidDynamicObjectChecker 'GET /namespaceruletest/namespaceruletest<test!>-0f3a1e616a/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:48.159: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-0f3a1e616a/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:41.970: InvalidDynamicObjectChecker PUT /namespaceruletest/namespaceruleTest
+2020-12-16 15:03:41.986: InvalidDynamicObjectChecker GET /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
+2020-12-16 15:03:42.002: InvalidDynamicObjectChecker 'GET /namespaceruletest/namespaceruletest<test!>-29750d0ce9/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:42.011: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-29750d0ce9/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:48.168: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-0f3a1e616a"}'
+2020-12-16 15:03:42.020: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-29750d0ce9"}'
 
-2020-12-15 16:30:48.189: InvalidDynamicObjectChecker 
+2020-12-16 15:03:42.042: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:48.204: InvalidDynamicObjectChecker PUT /namespaceruletest/namespaceruleTest
-2020-12-15 16:30:48.220: InvalidDynamicObjectChecker GET /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
-2020-12-15 16:30:48.235: InvalidDynamicObjectChecker 'GET /namespaceruletest/namespaceruletest<test!>-0f3a1e616a?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:48.245: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-0f3a1e616a?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:42.057: InvalidDynamicObjectChecker PUT /namespaceruletest/namespaceruleTest
+2020-12-16 15:03:42.073: InvalidDynamicObjectChecker GET /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
+2020-12-16 15:03:42.088: InvalidDynamicObjectChecker 'GET /namespaceruletest/namespaceruletest<test!>-29750d0ce9?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:42.097: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-29750d0ce9?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:48.255: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-0f3a1e616a"}'
+2020-12-16 15:03:42.107: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "namespaceruletest<test!>-29750d0ce9"}'
 
-2020-12-15 16:30:48.276: InvalidDynamicObjectChecker 
+2020-12-16 15:03:42.127: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:48.293: InvalidDynamicObjectChecker PUT /namespaceruletest/namespaceruleTest
-2020-12-15 16:30:48.308: InvalidDynamicObjectChecker GET /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
-2020-12-15 16:30:48.324: InvalidDynamicObjectChecker 'GET /namespaceruletest/namespaceruletest<test!>-0f3a1e616a/namespaceruletest<test!>-0f3a1e616a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:48.333: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-0f3a1e616a/namespaceruletest<test!>-0f3a1e616a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:42.144: InvalidDynamicObjectChecker PUT /namespaceruletest/namespaceruleTest
+2020-12-16 15:03:42.161: InvalidDynamicObjectChecker GET /namespaceruletest/_READER_DELIM_namespaceruletest_put_name_READER_DELIM
+2020-12-16 15:03:42.179: InvalidDynamicObjectChecker 'GET /namespaceruletest/namespaceruletest<test!>-29750d0ce9/namespaceruletest<test!>-29750d0ce9 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:42.190: Sending: 'GET /namespaceruletest/namespaceruletest<test!>-29750d0ce9/namespaceruletest<test!>-29750d0ce9 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:48.343: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:42.201: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:48.359: InvalidDynamicObjectChecker 'GET /namespaceruletest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:48.367: Sending: 'GET /namespaceruletest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:42.218: InvalidDynamicObjectChecker 'GET /namespaceruletest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:42.227: Sending: 'GET /namespaceruletest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:48.377: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:42.238: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:48.386: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:42.248: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:48.396: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:42.258: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:48.406: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:42.268: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:48.415: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:42.278: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:48.428: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:42.287: Checker: ExamplesChecker kicks out
 
 
 Generation-2: Rendering Sequence-1
@@ -1085,117 +1073,113 @@ Generation-2: Rendering Sequence-1
 		- restler_static_string: '}'
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:48.876: Sending: 'PUT /city/cityName<test!>-9bf4c64aa4 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:42.737: Sending: 'PUT /city/cityName<test!>-5da1f0497d HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:48.886: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-9bf4c64aa4", "properties": {}}'
+2020-12-16 15:03:42.747: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-5da1f0497d", "properties": {}}'
 
-2020-12-15 16:30:48.897: Sending: 'PUT /city/cityName<test!>-9bf4c64aa4/house/houseName<test!>-30f564f819 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:42.757: Sending: 'PUT /city/cityName<test!>-5da1f0497d/house/houseName<test!>-92211e10ab HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:48.907: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-30f564f819"}'
+2020-12-16 15:03:42.767: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-92211e10ab"}'
 
-2020-12-15 16:30:48.917: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:42.777: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:48.926: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:42.788: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:48.935: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:42.798: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:48.945: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:42.807: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:48.956: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:42.818: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:48.966: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:42.827: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:48.976: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:42.839: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:48.992: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:49.002: Re-rendering original sequence
-2020-12-15 16:30:49.011: Sending: 'PUT /city/cityName<test!>-b757a970ad HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:42.853: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:42.862: Re-rendering start of original sequence
+2020-12-16 15:03:42.870: Sending: 'PUT /city/cityName<test!>-2f1649116a HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:49.021: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-b757a970ad", "properties": {}}'
+2020-12-16 15:03:42.880: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-2f1649116a", "properties": {}}'
 
-2020-12-15 16:30:49.032: Sending: 'PUT /city/cityName<test!>-b757a970ad/house/houseName<test!>-efd9f99c40 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:42.897: NameSpaceRuleChecker Hijacked values: {'_city_put_name': 'cityName<test!>-2f1649116a'}
+2020-12-16 15:03:42.906: Hijacked values: {'_city_put_name': 'cityName<test!>-2f1649116a'}
+2020-12-16 15:03:42.920: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:42.931: Subsequence rendering  up to: 0
+2020-12-16 15:03:42.953: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:42.965: Hijack request rendering
+2020-12-16 15:03:42.984: Sending: 'PUT /city/cityName<test!>-2f1649116a/house/houseName<test!>-df94607dbf HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:49.042: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-efd9f99c40"}'
+2020-12-16 15:03:42.995: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:30:49.056: NameSpaceRuleChecker Hijacked values: {'_city_put_name': 'cityName<test!>-b757a970ad'}
-2020-12-15 16:30:49.065: Hijacked values: {'_city_put_name': 'cityName<test!>-b757a970ad'}
-2020-12-15 16:30:49.079: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:49.089: Subsequence rendering  up to: 0
-2020-12-15 16:30:49.103: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:49.113: Hijack request rendering
-2020-12-15 16:30:49.123: Sending: 'PUT /city/cityName<test!>-b757a970ad/house/houseName<test!>-45d505bb02 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.006: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
+2020-12-16 15:03:43.014: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:49.135: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
+2020-12-16 15:03:43.025: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:49.146: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
-2020-12-15 16:30:49.155: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:43.035: Re-rendering and sending start of sequence
+2020-12-16 15:03:43.045: Sending: 'PUT /city/cityName<test!>-0865030d4d HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:49.164: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:43.055: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0865030d4d", "properties": {}}'
 
-2020-12-15 16:30:49.175: Re-rendering and sending start of sequence
-2020-12-15 16:30:49.185: Sending: 'PUT /city/cityName<test!>-3771ec3393 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:49.194: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3771ec3393", "properties": {}}'
-
-2020-12-15 16:30:49.210: InvalidDynamicObjectChecker 
+2020-12-16 15:03:43.072: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:30:49.220: Preparing requests with invalid objects
-2020-12-15 16:30:49.236: InvalidDynamicObjectChecker 'PUT /city/cityName<test!>-3771ec3393?injected_query_string=123/house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
-2020-12-15 16:30:49.246: Sending: 'PUT /city/cityName<test!>-3771ec3393?injected_query_string=123/house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.081: Preparing requests with invalid objects
+2020-12-16 15:03:43.097: InvalidDynamicObjectChecker 'PUT /city/cityName<test!>-0865030d4d?injected_query_string=123/house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.106: Sending: 'PUT /city/cityName<test!>-0865030d4d?injected_query_string=123/house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:49.256: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3771ec3393", "properties": {}}'
+2020-12-16 15:03:43.116: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0865030d4d", "properties": {}}'
 
-2020-12-15 16:30:49.265: Attempting to reproduce bug...
-2020-12-15 16:30:49.276: Sending: 'PUT /city/cityName<test!>-3771ec3393 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.125: Attempting to reproduce bug...
+2020-12-16 15:03:43.140: Sending: 'PUT /city/cityName<test!>-0865030d4d HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:49.286: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3771ec3393", "properties": {}}'
+2020-12-16 15:03:43.158: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0865030d4d", "properties": {}}'
 
-2020-12-15 16:30:49.298: Sending: 'PUT /city/cityName<test!>-3771ec3393?injected_query_string=123/house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.169: Sending: 'PUT /city/cityName<test!>-0865030d4d?injected_query_string=123/house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:49.308: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3771ec3393", "properties": {}}'
+2020-12-16 15:03:43.178: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0865030d4d", "properties": {}}'
 
-2020-12-15 16:30:49.317: Done replaying sequence.
-2020-12-15 16:30:49.342: InvalidDynamicObjectChecker 
+2020-12-16 15:03:43.187: Done replaying sequence.
+2020-12-16 15:03:43.213: InvalidDynamicObjectChecker 
 Suspect sequence: 201
-2020-12-15 16:30:49.359: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:49.375: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:49.391: InvalidDynamicObjectChecker 'PUT /city/cityName<test!>-3771ec3393/?//house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
-2020-12-15 16:30:49.400: Sending: 'PUT /city/cityName<test!>-3771ec3393/?//house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.228: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:43.244: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:43.259: InvalidDynamicObjectChecker 'PUT /city/cityName<test!>-0865030d4d/?//house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.268: Sending: 'PUT /city/cityName<test!>-0865030d4d/?//house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:49.409: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': UnsupportedResource()}"
+2020-12-16 15:03:43.280: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': UnsupportedResource()}"
 
-2020-12-15 16:30:49.419: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
-2020-12-15 16:30:49.435: InvalidDynamicObjectChecker 'PUT /city/cityName<test!>-3771ec3393??/house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
-2020-12-15 16:30:49.444: Sending: 'PUT /city/cityName<test!>-3771ec3393??/house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.298: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
+2020-12-16 15:03:43.317: InvalidDynamicObjectChecker 'PUT /city/cityName<test!>-0865030d4d??/house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.326: Sending: 'PUT /city/cityName<test!>-0865030d4d??/house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:49.453: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3771ec3393", "properties": {}}'
+2020-12-16 15:03:43.336: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0865030d4d", "properties": {}}'
 
-2020-12-15 16:30:49.474: InvalidDynamicObjectChecker 
+2020-12-16 15:03:43.366: InvalidDynamicObjectChecker 
 Suspect sequence: 201
-2020-12-15 16:30:49.490: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:49.505: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:49.520: InvalidDynamicObjectChecker 'PUT /city/cityName<test!>-3771ec3393/cityName<test!>-3771ec3393/house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
-2020-12-15 16:30:49.529: Sending: 'PUT /city/cityName<test!>-3771ec3393/cityName<test!>-3771ec3393/house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.386: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:43.402: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:43.416: InvalidDynamicObjectChecker 'PUT /city/cityName<test!>-0865030d4d/cityName<test!>-0865030d4d/house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.426: Sending: 'PUT /city/cityName<test!>-0865030d4d/cityName<test!>-0865030d4d/house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:49.539: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': UnsupportedResource()}"
+2020-12-16 15:03:43.436: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': UnsupportedResource()}"
 
-2020-12-15 16:30:49.558: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
-2020-12-15 16:30:49.576: InvalidDynamicObjectChecker 'PUT /city/{}/house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
-2020-12-15 16:30:49.585: Sending: 'PUT /city/{}/house/houseName<test!>-9225e7e30d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.453: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
+2020-12-16 15:03:43.474: InvalidDynamicObjectChecker 'PUT /city/{}/house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
+2020-12-16 15:03:43.483: Sending: 'PUT /city/{}/house/houseName<test!>-81a43c2399 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:49.595: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:43.493: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:49.603: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
-2020-12-15 16:30:49.614: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:43.502: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
+2020-12-16 15:03:43.512: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:49.625: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:43.522: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:49.634: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:43.531: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:49.645: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:43.540: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:49.654: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:43.549: Checker: ExamplesChecker kicks out
 
 
 Generation-2: Rendering Sequence-1
@@ -1229,121 +1213,117 @@ Generation-2: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:50.087: Will refresh token: C:\RESTlerRepo\restler-fuzzer\restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
-2020-12-15 16:30:50.266: New value: {'user1':{}, 'user2':{}}
+2020-12-16 15:03:43.997: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-79c4609ba3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+
+2020-12-16 15:03:44.008: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-79c4609ba3"}'
+
+2020-12-16 15:03:44.019: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-79c4609ba3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2020-12-16 15:03:44.029: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-79c4609ba3"}'
+
+2020-12-16 15:03:44.039: Checker: LeakageRuleChecker kicks in
+
+2020-12-16 15:03:44.049: Checker: LeakageRuleChecker kicks out
+
+2020-12-16 15:03:44.059: Checker: ResourceHierarchyChecker kicks in
+
+2020-12-16 15:03:44.069: Checker: ResourceHierarchyChecker kicks out
+
+2020-12-16 15:03:44.078: Checker: UseAfterFreeChecker kicks in
+
+2020-12-16 15:03:44.088: Checker: UseAfterFreeChecker kicks out
+
+2020-12-16 15:03:44.097: Checker: NameSpaceRuleChecker kicks in
+
+2020-12-16 15:03:44.111: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:44.122: Re-rendering start of original sequence
+2020-12-16 15:03:44.131: Will refresh token: python C:\RESTlerRepo\restler-fuzzer\restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
+2020-12-16 15:03:44.200: New value: {'user1':{}, 'user2':{}}
 Authorization: valid_unit_test_token
 Authorization: shadow_unit_test_token
-2020-12-15 16:30:50.276: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-9fd46a5e83 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:44.211: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-bfacca7139 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:50.285: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-9fd46a5e83"}'
+2020-12-16 15:03:44.221: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-bfacca7139"}'
 
-2020-12-15 16:30:50.294: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-9fd46a5e83 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:44.236: NameSpaceRuleChecker Hijacked values: {'_useafterfreetest_put_name': 'useafterfreeTest<test!>-bfacca7139'}
+2020-12-16 15:03:44.245: Hijacked values: {'_useafterfreetest_put_name': 'useafterfreeTest<test!>-bfacca7139'}
+2020-12-16 15:03:44.260: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:44.269: Subsequence rendering  up to: 0
+2020-12-16 15:03:44.285: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:44.295: Hijack request rendering
+2020-12-16 15:03:44.304: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-bfacca7139 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:50.304: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-9fd46a5e83"}'
+2020-12-16 15:03:44.315: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:30:50.314: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:44.325: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:50.323: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:44.334: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:50.333: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:44.345: Re-rendering and sending start of sequence
+2020-12-16 15:03:44.355: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:50.343: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:44.365: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-d0f0bb96e6"}'
 
-2020-12-15 16:30:50.355: Checker: UseAfterFreeChecker kicks in
-
-2020-12-15 16:30:50.365: Checker: UseAfterFreeChecker kicks out
-
-2020-12-15 16:30:50.375: Checker: NameSpaceRuleChecker kicks in
-
-2020-12-15 16:30:50.389: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:50.399: Re-rendering original sequence
-2020-12-15 16:30:50.409: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-a425d51754 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:50.418: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-a425d51754"}'
-
-2020-12-15 16:30:50.428: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-a425d51754 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
-
-2020-12-15 16:30:50.437: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-a425d51754"}'
-
-2020-12-15 16:30:50.455: NameSpaceRuleChecker Hijacked values: {'_useafterfreetest_put_name': 'useafterfreeTest<test!>-a425d51754'}
-2020-12-15 16:30:50.465: Hijacked values: {'_useafterfreetest_put_name': 'useafterfreeTest<test!>-a425d51754'}
-2020-12-15 16:30:50.478: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:50.487: Subsequence rendering  up to: 0
-2020-12-15 16:30:50.502: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:50.512: Hijack request rendering
-2020-12-15 16:30:50.521: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-a425d51754 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
-
-2020-12-15 16:30:50.531: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
-
-2020-12-15 16:30:50.541: Checker: NameSpaceRuleChecker kicks out
-
-2020-12-15 16:30:50.551: Checker: InvalidDynamicObjectChecker kicks in
-
-2020-12-15 16:30:50.561: Re-rendering and sending start of sequence
-2020-12-15 16:30:50.570: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-a03a5cd766 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:50.583: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-a03a5cd766"}'
-
-2020-12-15 16:30:50.599: InvalidDynamicObjectChecker 
+2020-12-16 15:03:44.384: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:30:50.609: Preparing requests with invalid objects
-2020-12-15 16:30:50.626: InvalidDynamicObjectChecker 'GET /useafterfreetest/useafterfreeTest<test!>-a03a5cd766?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:50.635: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-a03a5cd766?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:44.393: Preparing requests with invalid objects
+2020-12-16 15:03:44.410: InvalidDynamicObjectChecker 'GET /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:44.420: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:50.645: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-a03a5cd766"}'
+2020-12-16 15:03:44.429: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-d0f0bb96e6"}'
 
-2020-12-15 16:30:50.655: Attempting to reproduce bug...
-2020-12-15 16:30:50.664: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-a03a5cd766 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:44.438: Attempting to reproduce bug...
+2020-12-16 15:03:44.448: Sending: 'PUT /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:50.673: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-a03a5cd766"}'
+2020-12-16 15:03:44.457: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-d0f0bb96e6"}'
 
-2020-12-15 16:30:50.683: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-a03a5cd766?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:44.467: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:50.693: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-a03a5cd766"}'
+2020-12-16 15:03:44.479: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-d0f0bb96e6"}'
 
-2020-12-15 16:30:50.702: Done replaying sequence.
-2020-12-15 16:30:50.727: InvalidDynamicObjectChecker 
+2020-12-16 15:03:44.498: Done replaying sequence.
+2020-12-16 15:03:44.528: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:50.744: InvalidDynamicObjectChecker PUT /useafterfreetest/useafterfreeTest
-2020-12-15 16:30:50.760: InvalidDynamicObjectChecker GET /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
-2020-12-15 16:30:50.776: InvalidDynamicObjectChecker 'GET /useafterfreetest/useafterfreeTest<test!>-a03a5cd766/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:50.785: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-a03a5cd766/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:44.543: InvalidDynamicObjectChecker PUT /useafterfreetest/useafterfreeTest
+2020-12-16 15:03:44.560: InvalidDynamicObjectChecker GET /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
+2020-12-16 15:03:44.575: InvalidDynamicObjectChecker 'GET /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:44.584: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:50.795: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-a03a5cd766"}'
+2020-12-16 15:03:44.594: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-d0f0bb96e6"}'
 
-2020-12-15 16:30:50.816: InvalidDynamicObjectChecker 
+2020-12-16 15:03:44.615: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:50.832: InvalidDynamicObjectChecker PUT /useafterfreetest/useafterfreeTest
-2020-12-15 16:30:50.848: InvalidDynamicObjectChecker GET /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
-2020-12-15 16:30:50.865: InvalidDynamicObjectChecker 'GET /useafterfreetest/useafterfreeTest<test!>-a03a5cd766?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:50.874: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-a03a5cd766?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:44.632: InvalidDynamicObjectChecker PUT /useafterfreetest/useafterfreeTest
+2020-12-16 15:03:44.648: InvalidDynamicObjectChecker GET /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
+2020-12-16 15:03:44.665: InvalidDynamicObjectChecker 'GET /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:44.675: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:50.885: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-a03a5cd766"}'
+2020-12-16 15:03:44.685: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest<test!>-d0f0bb96e6"}'
 
-2020-12-15 16:30:50.908: InvalidDynamicObjectChecker 
+2020-12-16 15:03:44.705: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:50.923: InvalidDynamicObjectChecker PUT /useafterfreetest/useafterfreeTest
-2020-12-15 16:30:50.941: InvalidDynamicObjectChecker GET /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
-2020-12-15 16:30:50.957: InvalidDynamicObjectChecker 'GET /useafterfreetest/useafterfreeTest<test!>-a03a5cd766/useafterfreeTest<test!>-a03a5cd766 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:50.966: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-a03a5cd766/useafterfreeTest<test!>-a03a5cd766 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:44.722: InvalidDynamicObjectChecker PUT /useafterfreetest/useafterfreeTest
+2020-12-16 15:03:44.738: InvalidDynamicObjectChecker GET /useafterfreetest/_READER_DELIM_useafterfreetest_put_name_READER_DELIM
+2020-12-16 15:03:44.754: InvalidDynamicObjectChecker 'GET /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6/useafterfreeTest<test!>-d0f0bb96e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:44.763: Sending: 'GET /useafterfreetest/useafterfreeTest<test!>-d0f0bb96e6/useafterfreeTest<test!>-d0f0bb96e6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:50.976: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:44.773: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:50.993: InvalidDynamicObjectChecker 'GET /useafterfreetest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:51.002: Sending: 'GET /useafterfreetest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:44.791: InvalidDynamicObjectChecker 'GET /useafterfreetest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:44.801: Sending: 'GET /useafterfreetest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:51.012: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:44.811: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:51.021: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:44.820: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:51.031: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:44.829: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:51.041: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:44.839: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:51.050: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:44.848: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:51.060: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:44.858: Checker: ExamplesChecker kicks out
 
 
 Generation-2: Rendering Sequence-1
@@ -1377,117 +1357,113 @@ Generation-2: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:51.458: Sending: 'PUT /city/cityName<test!>-dd196599f3 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:45.289: Sending: 'PUT /city/cityName<test!>-3eaeab5843 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:51.467: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-dd196599f3", "properties": {}}'
+2020-12-16 15:03:45.299: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3eaeab5843", "properties": {}}'
 
-2020-12-15 16:30:51.477: Sending: 'GET /city/cityName<test!>-dd196599f3/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:45.308: Sending: 'GET /city/cityName<test!>-3eaeab5843/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:51.486: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"house": {}}'
+2020-12-16 15:03:45.318: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"house": {}}'
 
-2020-12-15 16:30:51.498: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:45.328: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:51.509: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:45.336: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:51.518: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:45.347: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:51.528: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:45.356: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:51.538: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:45.366: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:51.548: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:45.376: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:51.558: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:45.386: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:51.573: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:51.582: Re-rendering original sequence
-2020-12-15 16:30:51.595: Sending: 'PUT /city/cityName<test!>-89480e1845 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:45.401: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:45.411: Re-rendering start of original sequence
+2020-12-16 15:03:45.420: Sending: 'PUT /city/cityName<test!>-493ed00968 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:51.606: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-89480e1845", "properties": {}}'
+2020-12-16 15:03:45.430: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-493ed00968", "properties": {}}'
 
-2020-12-15 16:30:51.616: Sending: 'GET /city/cityName<test!>-89480e1845/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:45.455: NameSpaceRuleChecker Hijacked values: {'_city_put_name': 'cityName<test!>-493ed00968'}
+2020-12-16 15:03:45.466: Hijacked values: {'_city_put_name': 'cityName<test!>-493ed00968'}
+2020-12-16 15:03:45.482: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:45.491: Subsequence rendering  up to: 0
+2020-12-16 15:03:45.506: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:45.516: Hijack request rendering
+2020-12-16 15:03:45.534: Sending: 'GET /city/cityName<test!>-493ed00968/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:51.626: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"house": {}}'
+2020-12-16 15:03:45.546: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:30:51.641: NameSpaceRuleChecker Hijacked values: {'_city_put_name': 'cityName<test!>-89480e1845'}
-2020-12-15 16:30:51.651: Hijacked values: {'_city_put_name': 'cityName<test!>-89480e1845'}
-2020-12-15 16:30:51.666: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:51.675: Subsequence rendering  up to: 0
-2020-12-15 16:30:51.688: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:51.698: Hijack request rendering
-2020-12-15 16:30:51.707: Sending: 'GET /city/cityName<test!>-89480e1845/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:45.555: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:51.717: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
+2020-12-16 15:03:45.566: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:51.727: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:45.574: Re-rendering and sending start of sequence
+2020-12-16 15:03:45.583: Sending: 'PUT /city/cityName<test!>-733a02c3bf HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:51.737: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:45.594: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-733a02c3bf", "properties": {}}'
 
-2020-12-15 16:30:51.746: Re-rendering and sending start of sequence
-2020-12-15 16:30:51.755: Sending: 'PUT /city/cityName<test!>-a9e076522c HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:51.767: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a9e076522c", "properties": {}}'
-
-2020-12-15 16:30:51.783: InvalidDynamicObjectChecker 
+2020-12-16 15:03:45.624: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:30:51.794: Preparing requests with invalid objects
-2020-12-15 16:30:51.810: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-a9e076522c?injected_query_string=123/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:51.820: Sending: 'GET /city/cityName<test!>-a9e076522c?injected_query_string=123/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:45.633: Preparing requests with invalid objects
+2020-12-16 15:03:45.649: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-733a02c3bf?injected_query_string=123/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:45.660: Sending: 'GET /city/cityName<test!>-733a02c3bf?injected_query_string=123/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:51.830: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a9e076522c", "properties": {}}'
+2020-12-16 15:03:45.678: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-733a02c3bf", "properties": {}}'
 
-2020-12-15 16:30:51.839: Attempting to reproduce bug...
-2020-12-15 16:30:51.849: Sending: 'PUT /city/cityName<test!>-a9e076522c HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:45.690: Attempting to reproduce bug...
+2020-12-16 15:03:45.708: Sending: 'PUT /city/cityName<test!>-733a02c3bf HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:51.859: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a9e076522c", "properties": {}}'
+2020-12-16 15:03:45.721: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-733a02c3bf", "properties": {}}'
 
-2020-12-15 16:30:51.868: Sending: 'GET /city/cityName<test!>-a9e076522c?injected_query_string=123/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:45.740: Sending: 'GET /city/cityName<test!>-733a02c3bf?injected_query_string=123/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:51.878: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a9e076522c", "properties": {}}'
+2020-12-16 15:03:45.758: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-733a02c3bf", "properties": {}}'
 
-2020-12-15 16:30:51.887: Done replaying sequence.
-2020-12-15 16:30:51.913: InvalidDynamicObjectChecker 
+2020-12-16 15:03:45.770: Done replaying sequence.
+2020-12-16 15:03:45.810: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:51.928: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:51.944: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house
-2020-12-15 16:30:51.960: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-a9e076522c/?//house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:51.969: Sending: 'GET /city/cityName<test!>-a9e076522c/?//house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:45.830: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:45.847: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house
+2020-12-16 15:03:45.864: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-733a02c3bf/?//house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:45.873: Sending: 'GET /city/cityName<test!>-733a02c3bf/?//house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:51.979: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a9e076522c", "properties": {}}'
+2020-12-16 15:03:45.883: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-733a02c3bf", "properties": {}}'
 
-2020-12-15 16:30:52.000: InvalidDynamicObjectChecker 
+2020-12-16 15:03:45.905: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:52.017: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:52.032: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house
-2020-12-15 16:30:52.048: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-a9e076522c??/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:52.058: Sending: 'GET /city/cityName<test!>-a9e076522c??/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:45.922: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:45.938: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house
+2020-12-16 15:03:45.956: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-733a02c3bf??/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:45.965: Sending: 'GET /city/cityName<test!>-733a02c3bf??/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:52.069: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a9e076522c", "properties": {}}'
+2020-12-16 15:03:45.976: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-733a02c3bf", "properties": {}}'
 
-2020-12-15 16:30:52.089: InvalidDynamicObjectChecker 
+2020-12-16 15:03:46.006: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:52.106: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:52.123: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house
-2020-12-15 16:30:52.139: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-a9e076522c/cityName<test!>-a9e076522c/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:52.149: Sending: 'GET /city/cityName<test!>-a9e076522c/cityName<test!>-a9e076522c/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:46.025: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:46.042: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house
+2020-12-16 15:03:46.057: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-733a02c3bf/cityName<test!>-733a02c3bf/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:46.067: Sending: 'GET /city/cityName<test!>-733a02c3bf/cityName<test!>-733a02c3bf/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:52.159: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:46.076: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:52.183: InvalidDynamicObjectChecker 'GET /city/{}/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:52.193: Sending: 'GET /city/{}/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:46.091: InvalidDynamicObjectChecker 'GET /city/{}/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:46.101: Sending: 'GET /city/{}/house HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:52.212: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:46.111: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:52.223: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:46.121: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:52.234: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:46.139: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:52.253: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:46.161: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:52.265: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:46.173: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:52.275: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:46.183: Checker: ExamplesChecker kicks out
 
 
 Generation-2: Rendering Sequence-1
@@ -1528,117 +1504,113 @@ Generation-2: Rendering Sequence-1
 		- restler_static_string: '}'
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:52.747: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-dbc9b0809d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:46.773: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-33ec65f0ac HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:52.756: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-dbc9b0809d"}'
+2020-12-16 15:03:46.786: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-33ec65f0ac"}'
 
-2020-12-15 16:30:52.766: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-dbc9b0809d/resourcehierarchychild/resourcehierarchyChild<test!>-382084a4fb HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:46.795: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-33ec65f0ac/resourcehierarchychild/resourcehierarchyChild<test!>-51c10416d3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:52.787: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-382084a4fb"}'
+2020-12-16 15:03:46.806: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-51c10416d3"}'
 
-2020-12-15 16:30:52.800: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:46.818: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:52.811: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:46.835: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:52.830: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:46.853: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:52.842: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:46.864: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:52.852: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:46.875: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:52.863: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:46.894: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:52.873: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:46.905: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:52.887: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:52.896: Re-rendering original sequence
-2020-12-15 16:30:52.906: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-ab04e6b7eb HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:46.930: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:46.941: Re-rendering start of original sequence
+2020-12-16 15:03:46.951: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-4869c90b47 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:52.916: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-ab04e6b7eb"}'
+2020-12-16 15:03:46.969: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-4869c90b47"}'
 
-2020-12-15 16:30:52.926: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-ab04e6b7eb/resourcehierarchychild/resourcehierarchyChild<test!>-ef622c3f6e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:46.990: NameSpaceRuleChecker Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-4869c90b47'}
+2020-12-16 15:03:47.001: Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-4869c90b47'}
+2020-12-16 15:03:47.016: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:47.027: Subsequence rendering  up to: 0
+2020-12-16 15:03:47.042: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:47.051: Hijack request rendering
+2020-12-16 15:03:47.061: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-4869c90b47/resourcehierarchychild/resourcehierarchyChild<test!>-0f61fb3ca8 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:52.936: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-ef622c3f6e"}'
+2020-12-16 15:03:47.071: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:30:52.952: NameSpaceRuleChecker Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-ab04e6b7eb'}
-2020-12-15 16:30:52.961: Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-ab04e6b7eb'}
-2020-12-15 16:30:52.976: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:52.986: Subsequence rendering  up to: 0
-2020-12-15 16:30:53.001: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:53.011: Hijack request rendering
-2020-12-15 16:30:53.020: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-ab04e6b7eb/resourcehierarchychild/resourcehierarchyChild<test!>-4adb571cf9 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.081: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
+2020-12-16 15:03:47.091: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:53.030: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
+2020-12-16 15:03:47.101: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:53.040: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
-2020-12-15 16:30:53.050: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:47.111: Re-rendering and sending start of sequence
+2020-12-16 15:03:47.121: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:53.060: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:47.131: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-b0d364a185"}'
 
-2020-12-15 16:30:53.070: Re-rendering and sending start of sequence
-2020-12-15 16:30:53.080: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:53.090: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-bf16f764cc"}'
-
-2020-12-15 16:30:53.107: InvalidDynamicObjectChecker 
+2020-12-16 15:03:47.148: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:30:53.116: Preparing requests with invalid objects
-2020-12-15 16:30:53.133: InvalidDynamicObjectChecker 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
-2020-12-15 16:30:53.142: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.157: Preparing requests with invalid objects
+2020-12-16 15:03:47.174: InvalidDynamicObjectChecker 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.184: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:53.152: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-bf16f764cc"}'
+2020-12-16 15:03:47.193: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-b0d364a185"}'
 
-2020-12-15 16:30:53.162: Attempting to reproduce bug...
-2020-12-15 16:30:53.171: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.203: Attempting to reproduce bug...
+2020-12-16 15:03:47.212: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:53.181: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-bf16f764cc"}'
+2020-12-16 15:03:47.222: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-b0d364a185"}'
 
-2020-12-15 16:30:53.191: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.232: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:53.200: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-bf16f764cc"}'
+2020-12-16 15:03:47.241: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-b0d364a185"}'
 
-2020-12-15 16:30:53.210: Done replaying sequence.
-2020-12-15 16:30:53.235: InvalidDynamicObjectChecker 
+2020-12-16 15:03:47.251: Done replaying sequence.
+2020-12-16 15:03:47.279: InvalidDynamicObjectChecker 
 Suspect sequence: 201
-2020-12-15 16:30:53.252: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:30:53.269: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:30:53.286: InvalidDynamicObjectChecker 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc/?//resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
-2020-12-15 16:30:53.295: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc/?//resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.294: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:47.311: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:47.327: InvalidDynamicObjectChecker 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185/?//resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.337: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185/?//resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:53.305: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': UnsupportedResource()}"
+2020-12-16 15:03:47.347: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': UnsupportedResource()}"
 
-2020-12-15 16:30:53.315: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
-2020-12-15 16:30:53.331: InvalidDynamicObjectChecker 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc??/resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
-2020-12-15 16:30:53.341: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc??/resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.358: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
+2020-12-16 15:03:47.374: InvalidDynamicObjectChecker 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185??/resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.383: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185??/resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:53.361: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-bf16f764cc"}'
+2020-12-16 15:03:47.392: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-b0d364a185"}'
 
-2020-12-15 16:30:53.386: InvalidDynamicObjectChecker 
+2020-12-16 15:03:47.414: InvalidDynamicObjectChecker 
 Suspect sequence: 201
-2020-12-15 16:30:53.404: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:30:53.422: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:30:53.440: InvalidDynamicObjectChecker 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc/resourcehierarchyTest<test!>-bf16f764cc/resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
-2020-12-15 16:30:53.452: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-bf16f764cc/resourcehierarchyTest<test!>-bf16f764cc/resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.432: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:47.450: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:47.467: InvalidDynamicObjectChecker 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185/resourcehierarchyTest<test!>-b0d364a185/resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.477: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b0d364a185/resourcehierarchyTest<test!>-b0d364a185/resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:53.461: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': UnsupportedResource()}"
+2020-12-16 15:03:47.487: Received: "HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{'error': UnsupportedResource()}"
 
-2020-12-15 16:30:53.471: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
-2020-12-15 16:30:53.488: InvalidDynamicObjectChecker 'PUT /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
-2020-12-15 16:30:53.498: Sending: 'PUT /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-b44aaff73c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.497: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
+2020-12-16 15:03:47.515: InvalidDynamicObjectChecker 'PUT /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n{}\r\n'
+2020-12-16 15:03:47.524: Sending: 'PUT /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-8439a7340d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:53.508: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:47.534: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:53.517: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
-2020-12-15 16:30:53.527: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:47.545: 'Exception parsing response, data was not valid json: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)'
+2020-12-16 15:03:47.555: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:53.536: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:47.565: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:53.546: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:47.576: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:53.555: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:47.586: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:53.564: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:47.596: Checker: ExamplesChecker kicks out
 
 
 Generation-2: Rendering Sequence-1
@@ -1672,117 +1644,113 @@ Generation-2: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:54.046: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-6d25903130 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:48.105: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-ed9965e50a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:54.055: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-6d25903130"}'
+2020-12-16 15:03:48.115: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-ed9965e50a"}'
 
-2020-12-15 16:30:54.065: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-6d25903130 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:48.126: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ed9965e50a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:54.076: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-6d25903130"'
+2020-12-16 15:03:48.136: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-ed9965e50a"'
 
-2020-12-15 16:30:54.085: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:48.145: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:54.096: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:48.155: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:54.105: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:48.164: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:54.114: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:48.174: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:54.125: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:48.183: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:54.139: UseAfterFreeChecker 
+2020-12-16 15:03:48.199: UseAfterFreeChecker 
 Target types: {'_resourcehierarchytest_put_name'}
-2020-12-15 16:30:54.154: UseAfterFreeChecker Clean tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-6d25903130', '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': None}
-2020-12-15 16:30:54.168: UseAfterFreeChecker Found * 2 * consumers.
-2020-12-15 16:30:54.177: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-6d25903130 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:48.214: UseAfterFreeChecker Clean tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-ed9965e50a', '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': None}
+2020-12-16 15:03:48.228: UseAfterFreeChecker Found * 2 * consumers.
+2020-12-16 15:03:48.238: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-ed9965e50a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:54.186: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:48.248: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:54.196: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:48.258: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:54.205: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:48.267: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:54.219: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:54.228: Re-rendering original sequence
-2020-12-15 16:30:54.237: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b83f3033a3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:48.286: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:48.295: Re-rendering start of original sequence
+2020-12-16 15:03:48.304: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-95163bd142 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:54.246: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-b83f3033a3"}'
+2020-12-16 15:03:48.315: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-95163bd142"}'
 
-2020-12-15 16:30:54.256: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-b83f3033a3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:48.330: NameSpaceRuleChecker Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-95163bd142'}
+2020-12-16 15:03:48.339: Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-95163bd142'}
+2020-12-16 15:03:48.356: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:48.365: Subsequence rendering  up to: 0
+2020-12-16 15:03:48.399: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:48.412: Hijack request rendering
+2020-12-16 15:03:48.423: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-95163bd142 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:54.266: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-b83f3033a3"'
+2020-12-16 15:03:48.433: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:30:54.280: NameSpaceRuleChecker Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-b83f3033a3'}
-2020-12-15 16:30:54.289: Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-b83f3033a3'}
-2020-12-15 16:30:54.304: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:54.314: Subsequence rendering  up to: 0
-2020-12-15 16:30:54.329: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:54.338: Hijack request rendering
-2020-12-15 16:30:54.347: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-b83f3033a3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:48.443: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:54.356: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
+2020-12-16 15:03:48.452: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:54.367: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:48.462: Re-rendering and sending start of sequence
+2020-12-16 15:03:48.472: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:54.376: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:48.481: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-d0263eb630"}'
 
-2020-12-15 16:30:54.386: Re-rendering and sending start of sequence
-2020-12-15 16:30:54.396: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:54.406: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-3996874e5f"}'
-
-2020-12-15 16:30:54.421: InvalidDynamicObjectChecker 
+2020-12-16 15:03:48.511: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:30:54.430: Preparing requests with invalid objects
-2020-12-15 16:30:54.449: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:54.459: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:48.521: Preparing requests with invalid objects
+2020-12-16 15:03:48.538: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:48.548: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:54.469: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-3996874e5f"'
+2020-12-16 15:03:48.557: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-d0263eb630"'
 
-2020-12-15 16:30:54.480: Attempting to reproduce bug...
-2020-12-15 16:30:54.491: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:48.567: Attempting to reproduce bug...
+2020-12-16 15:03:48.577: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:54.503: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-3996874e5f"}'
+2020-12-16 15:03:48.586: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-d0263eb630"}'
 
-2020-12-15 16:30:54.514: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:48.597: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:54.523: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-3996874e5f"'
+2020-12-16 15:03:48.606: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-d0263eb630"'
 
-2020-12-15 16:30:54.533: Done replaying sequence.
-2020-12-15 16:30:54.559: InvalidDynamicObjectChecker 
+2020-12-16 15:03:48.615: Done replaying sequence.
+2020-12-16 15:03:48.654: InvalidDynamicObjectChecker 
 Suspect sequence: 202
-2020-12-15 16:30:54.575: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:30:54.593: InvalidDynamicObjectChecker DELETE /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM
-2020-12-15 16:30:54.612: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:54.624: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:48.674: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:48.692: InvalidDynamicObjectChecker DELETE /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM
+2020-12-16 15:03:48.709: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:48.720: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:54.634: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
+2020-12-16 15:03:48.740: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
 
-2020-12-15 16:30:54.650: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:54.660: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:48.768: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:48.779: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:54.669: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:48.801: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:54.686: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f/resourcehierarchyTest<test!>-3996874e5f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:54.696: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-3996874e5f/resourcehierarchyTest<test!>-3996874e5f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:48.836: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630/resourcehierarchyTest<test!>-d0263eb630 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:48.849: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-d0263eb630/resourcehierarchyTest<test!>-d0263eb630 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:54.705: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: resourcehierarchyTest<test!>-3996874e5f"}'
+2020-12-16 15:03:48.868: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: resourcehierarchyTest<test!>-d0263eb630"}'
 
-2020-12-15 16:30:54.721: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:54.730: Sending: 'DELETE /resourcehierarchytest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:48.888: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:48.898: Sending: 'DELETE /resourcehierarchytest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:54.740: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:48.908: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:54.751: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:48.918: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:54.760: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:48.926: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:54.770: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:48.936: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:54.779: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:48.946: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:54.789: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:48.955: Checker: ExamplesChecker kicks out
 
 
 Generation-2: Rendering Sequence-1
@@ -1816,117 +1784,113 @@ Generation-2: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:55.186: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-a393419d4e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:49.421: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-e9abb91ee1 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:55.195: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a393419d4e"}'
+2020-12-16 15:03:49.432: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-e9abb91ee1"}'
 
-2020-12-15 16:30:55.204: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a393419d4e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:49.442: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-e9abb91ee1 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:55.213: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a393419d4e"}'
+2020-12-16 15:03:49.451: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-e9abb91ee1"}'
 
-2020-12-15 16:30:55.223: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:49.461: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:55.233: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:49.471: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:55.243: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:49.481: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:55.253: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:49.491: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:55.262: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:49.510: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:55.272: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:49.520: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:55.282: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:49.530: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:55.298: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:55.307: Re-rendering original sequence
-2020-12-15 16:30:55.318: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-b7bb82b4a2 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:49.544: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:49.554: Re-rendering start of original sequence
+2020-12-16 15:03:49.574: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-606a6c6d75 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:55.328: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-b7bb82b4a2"}'
+2020-12-16 15:03:49.585: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-606a6c6d75"}'
 
-2020-12-15 16:30:55.338: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-b7bb82b4a2 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:49.600: NameSpaceRuleChecker Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-606a6c6d75'}
+2020-12-16 15:03:49.609: Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-606a6c6d75'}
+2020-12-16 15:03:49.633: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:49.646: Subsequence rendering  up to: 0
+2020-12-16 15:03:49.662: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:49.671: Hijack request rendering
+2020-12-16 15:03:49.681: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-606a6c6d75 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:55.350: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-b7bb82b4a2"}'
+2020-12-16 15:03:49.700: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:30:55.365: NameSpaceRuleChecker Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-b7bb82b4a2'}
-2020-12-15 16:30:55.375: Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-b7bb82b4a2'}
-2020-12-15 16:30:55.390: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:55.399: Subsequence rendering  up to: 0
-2020-12-15 16:30:55.417: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:55.427: Hijack request rendering
-2020-12-15 16:30:55.436: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-b7bb82b4a2 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:49.719: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:55.446: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
+2020-12-16 15:03:49.745: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:55.456: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:49.757: Re-rendering and sending start of sequence
+2020-12-16 15:03:49.766: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:55.465: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:49.775: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-7e3aab2c65"}'
 
-2020-12-15 16:30:55.475: Re-rendering and sending start of sequence
-2020-12-15 16:30:55.485: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:55.494: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-d997e93fe7"}'
-
-2020-12-15 16:30:55.511: InvalidDynamicObjectChecker 
+2020-12-16 15:03:49.803: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:30:55.521: Preparing requests with invalid objects
-2020-12-15 16:30:55.538: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:55.552: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:49.815: Preparing requests with invalid objects
+2020-12-16 15:03:49.845: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:49.855: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:55.562: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-d997e93fe7"}'
+2020-12-16 15:03:49.874: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-7e3aab2c65"}'
 
-2020-12-15 16:30:55.575: Attempting to reproduce bug...
-2020-12-15 16:30:55.588: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:49.885: Attempting to reproduce bug...
+2020-12-16 15:03:49.895: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:55.599: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-d997e93fe7"}'
+2020-12-16 15:03:49.905: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-7e3aab2c65"}'
 
-2020-12-15 16:30:55.612: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:49.916: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:55.623: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-d997e93fe7"}'
+2020-12-16 15:03:49.935: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-7e3aab2c65"}'
 
-2020-12-15 16:30:55.636: Done replaying sequence.
-2020-12-15 16:30:55.667: InvalidDynamicObjectChecker 
+2020-12-16 15:03:49.954: Done replaying sequence.
+2020-12-16 15:03:50.007: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:55.683: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:30:55.699: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM
-2020-12-15 16:30:55.715: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:55.724: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:50.036: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:50.065: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM
+2020-12-16 15:03:50.083: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:50.094: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:55.734: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-d997e93fe7"}'
+2020-12-16 15:03:50.103: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-7e3aab2c65"}'
 
-2020-12-15 16:30:55.775: InvalidDynamicObjectChecker 
+2020-12-16 15:03:50.124: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:55.791: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:30:55.807: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM
-2020-12-15 16:30:55.826: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:55.835: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:50.142: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:50.160: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM
+2020-12-16 15:03:50.179: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:50.189: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:55.845: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-d997e93fe7"}'
+2020-12-16 15:03:50.209: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-7e3aab2c65"}'
 
-2020-12-15 16:30:55.865: InvalidDynamicObjectChecker 
+2020-12-16 15:03:50.233: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:55.882: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:30:55.899: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM
-2020-12-15 16:30:55.917: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7/resourcehierarchyTest<test!>-d997e93fe7 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:55.927: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-d997e93fe7/resourcehierarchyTest<test!>-d997e93fe7 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:50.250: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:50.277: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM
+2020-12-16 15:03:50.294: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65/resourcehierarchyTest<test!>-7e3aab2c65 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:50.303: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-7e3aab2c65/resourcehierarchyTest<test!>-7e3aab2c65 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:55.937: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:50.313: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:55.954: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:55.967: Sending: 'GET /resourcehierarchytest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:50.330: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:50.343: Sending: 'GET /resourcehierarchytest/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:55.979: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:50.356: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:55.988: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:50.365: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:55.999: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:50.375: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:56.009: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:50.385: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:56.018: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:50.395: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:56.029: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:50.405: Checker: ExamplesChecker kicks out
 
 
 Generation-3: Rendering Sequence-1
@@ -1990,90 +1954,90 @@ Generation-3: Rendering Sequence-1
 		- restler_static_string: '}'
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:56.723: Sending: 'PUT /city/cityName<test!>-0ee40127ac HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:51.206: Sending: 'PUT /city/cityName<test!>-3449a0a063 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:56.736: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0ee40127ac", "properties": {}}'
+2020-12-16 15:03:51.224: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3449a0a063", "properties": {}}'
 
-2020-12-15 16:30:56.745: Sending: 'PUT /city/cityName<test!>-0ee40127ac/house/houseName<test!>-9513a5939f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:51.243: Sending: 'PUT /city/cityName<test!>-3449a0a063/house/houseName<test!>-f9ee0f7567 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:56.755: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9513a5939f"}'
+2020-12-16 15:03:51.256: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f9ee0f7567"}'
 
-2020-12-15 16:30:56.765: Sending: 'PUT /city/cityName<test!>-0ee40127ac/house/houseName<test!>-9513a5939f/color/colorName<test!>-b9fe435c9c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 5\r\n\r\n{{}\r\n'
+2020-12-16 15:03:51.266: Sending: 'PUT /city/cityName<test!>-3449a0a063/house/houseName<test!>-f9ee0f7567/color/colorName<test!>-d1cecfb413 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 5\r\n\r\n{{}\r\n'
 
-2020-12-15 16:30:56.776: Received: 'HTTP/1.1 500 Internal Server Error\r\nRestler Test\r\n\r\n{"code": "InternalServerError", "message": "Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"}'
+2020-12-16 15:03:51.275: Received: 'HTTP/1.1 500 Internal Server Error\r\nRestler Test\r\n\r\n{"code": "InternalServerError", "message": "Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"}'
 
-2020-12-15 16:30:56.792: Failed to parse _city_house_color_put_name; is now set to None.
-2020-12-15 16:30:56.802: Attempting to reproduce bug...
-2020-12-15 16:30:56.812: Sending: 'PUT /city/cityName<test!>-0ee40127ac HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:51.290: Failed to parse _city_house_color_put_name; is now set to None.
+2020-12-16 15:03:51.300: Attempting to reproduce bug...
+2020-12-16 15:03:51.308: Sending: 'PUT /city/cityName<test!>-3449a0a063 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:56.822: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0ee40127ac", "properties": {}}'
+2020-12-16 15:03:51.318: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3449a0a063", "properties": {}}'
 
-2020-12-15 16:30:56.832: Sending: 'PUT /city/cityName<test!>-0ee40127ac/house/houseName<test!>-9513a5939f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:51.330: Sending: 'PUT /city/cityName<test!>-3449a0a063/house/houseName<test!>-f9ee0f7567 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:56.842: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9513a5939f"}'
+2020-12-16 15:03:51.350: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f9ee0f7567"}'
 
-2020-12-15 16:30:56.851: Sending: 'PUT /city/cityName<test!>-0ee40127ac/house/houseName<test!>-9513a5939f/color/colorName<test!>-b9fe435c9c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 5\r\n\r\n{{}\r\n'
+2020-12-16 15:03:51.370: Sending: 'PUT /city/cityName<test!>-3449a0a063/house/houseName<test!>-f9ee0f7567/color/colorName<test!>-d1cecfb413 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 5\r\n\r\n{{}\r\n'
 
-2020-12-15 16:30:56.861: Received: 'HTTP/1.1 500 Internal Server Error\r\nRestler Test\r\n\r\n{"code": "InternalServerError", "message": "Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"}'
+2020-12-16 15:03:51.389: Received: 'HTTP/1.1 500 Internal Server Error\r\nRestler Test\r\n\r\n{"code": "InternalServerError", "message": "Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"}'
 
-2020-12-15 16:30:56.871: Done replaying sequence.
-2020-12-15 16:30:56.893: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:51.400: Done replaying sequence.
+2020-12-16 15:03:51.422: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:56.908: LeakageRuleChecker 
+2020-12-16 15:03:51.437: LeakageRuleChecker 
 Target type: _city_house_color_put_name
-2020-12-15 16:30:56.917: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:51.447: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:56.928: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:51.459: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:56.938: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:51.469: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:56.960: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:51.478: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:56.973: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:51.488: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:56.984: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:51.497: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:56.995: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:51.506: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:57.004: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:51.518: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:57.014: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:51.527: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:57.023: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:51.537: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:57.034: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:51.546: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:57.043: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:51.556: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:57.053: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:51.565: Checker: ExamplesChecker kicks out
 
-2020-12-15 16:30:57.063: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:51.574: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:57.072: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:51.585: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:57.082: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:51.603: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:57.092: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:51.612: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:57.104: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:51.621: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:57.114: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:51.630: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:57.124: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:51.640: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:57.134: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:51.659: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:57.144: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:51.670: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:57.154: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:51.681: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:57.165: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:51.690: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:57.176: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:51.709: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:57.186: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:51.728: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:57.196: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:51.740: Checker: ExamplesChecker kicks out
 
 
 Generation-3: Rendering Sequence-1
@@ -2129,229 +2093,225 @@ Generation-3: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:30:57.879: Sending: 'PUT /city/cityName<test!>-4786019de7 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:52.410: Sending: 'PUT /city/cityName<test!>-fdc3ab7f49 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:57.888: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-4786019de7", "properties": {}}'
+2020-12-16 15:03:52.420: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-fdc3ab7f49", "properties": {}}'
 
-2020-12-15 16:30:57.897: Sending: 'PUT /city/cityName<test!>-4786019de7/house/houseName<test!>-4f7a13dc1c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:52.439: Sending: 'PUT /city/cityName<test!>-fdc3ab7f49/house/houseName<test!>-4e11d758f6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:57.907: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4f7a13dc1c"}'
+2020-12-16 15:03:52.451: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4e11d758f6"}'
 
-2020-12-15 16:30:57.916: Sending: 'GET /city/cityName<test!>-4786019de7/house/houseName<test!>-4f7a13dc1c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:52.461: Sending: 'GET /city/cityName<test!>-fdc3ab7f49/house/houseName<test!>-4e11d758f6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:57.927: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4f7a13dc1c"}'
+2020-12-16 15:03:52.469: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4e11d758f6"}'
 
-2020-12-15 16:30:57.937: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:52.483: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:30:57.947: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:52.500: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:30:57.957: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:52.514: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:30:57.966: Sending: 'PUT /city/cityName<test!>-69f017eaa2 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:52.525: Sending: 'PUT /city/cityName<test!>-d89e24b1c5 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:57.976: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-69f017eaa2", "properties": {}}'
+2020-12-16 15:03:52.534: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-d89e24b1c5", "properties": {}}'
 
-2020-12-15 16:30:57.986: ResourceHierarchyChecker 
+2020-12-16 15:03:52.546: ResourceHierarchyChecker 
 Target types: {'_city_house_put_name'}
-2020-12-15 16:30:58.002: ResourceHierarchyChecker Predecesor types: {'_city_put_name'}
-2020-12-15 16:30:58.015: ResourceHierarchyChecker Clean tlb: {'_city_put_name': 'cityName<test!>-69f017eaa2', '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': None, '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': None}
-2020-12-15 16:30:58.029: ResourceHierarchyChecker Poluted tlb: {'_city_put_name': 'cityName<test!>-69f017eaa2', '_city_house_put_name': 'houseName<test!>-4f7a13dc1c', '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': None, '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': None}
-2020-12-15 16:30:58.039: Sending: 'GET /city/cityName<test!>-69f017eaa2/house/houseName<test!>-4f7a13dc1c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:52.558: ResourceHierarchyChecker Predecesor types: {'_city_put_name'}
+2020-12-16 15:03:52.570: ResourceHierarchyChecker Clean tlb: {'_city_put_name': 'cityName<test!>-d89e24b1c5', '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': None, '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': None}
+2020-12-16 15:03:52.585: ResourceHierarchyChecker Poluted tlb: {'_city_put_name': 'cityName<test!>-d89e24b1c5', '_city_house_put_name': 'houseName<test!>-4e11d758f6', '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': None, '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': None}
+2020-12-16 15:03:52.594: Sending: 'GET /city/cityName<test!>-d89e24b1c5/house/houseName<test!>-4e11d758f6 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:58.049: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:52.604: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:58.059: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:52.614: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:30:58.069: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:52.624: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:30:58.081: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:52.642: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:30:58.098: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:52.653: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:30:58.115: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:30:58.124: Re-rendering original sequence
-2020-12-15 16:30:58.135: Sending: 'PUT /city/cityName<test!>-39a4e1c0f2 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:52.668: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:52.677: Re-rendering start of original sequence
+2020-12-16 15:03:52.687: Sending: 'PUT /city/cityName<test!>-1ffc9d03e3 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:58.145: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-39a4e1c0f2", "properties": {}}'
+2020-12-16 15:03:52.695: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-1ffc9d03e3", "properties": {}}'
 
-2020-12-15 16:30:58.156: Sending: 'PUT /city/cityName<test!>-39a4e1c0f2/house/houseName<test!>-f0e894210f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:52.704: Sending: 'PUT /city/cityName<test!>-1ffc9d03e3/house/houseName<test!>-ba050da702 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:58.173: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f0e894210f"}'
+2020-12-16 15:03:52.715: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-ba050da702"}'
 
-2020-12-15 16:30:58.185: Sending: 'GET /city/cityName<test!>-39a4e1c0f2/house/houseName<test!>-f0e894210f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:52.749: NameSpaceRuleChecker Hijacked values: {'_city_house_put_name': 'houseName<test!>-ba050da702', '_city_put_name': 'cityName<test!>-1ffc9d03e3'}
+2020-12-16 15:03:52.760: Hijacked values: {'_city_house_put_name': 'houseName<test!>-ba050da702', '_city_put_name': 'cityName<test!>-1ffc9d03e3'}
+2020-12-16 15:03:52.784: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:52.794: Subsequence rendering  up to: 0
+2020-12-16 15:03:52.808: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:52.816: Hijack request rendering
+2020-12-16 15:03:52.826: Sending: 'GET /city/cityName<test!>-1ffc9d03e3/house/houseName<test!>-ba050da702 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:58.195: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f0e894210f"}'
+2020-12-16 15:03:52.835: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:30:58.209: NameSpaceRuleChecker Hijacked values: {'_city_put_name': 'cityName<test!>-39a4e1c0f2', '_city_house_put_name': 'houseName<test!>-f0e894210f'}
-2020-12-15 16:30:58.218: Hijacked values: {'_city_put_name': 'cityName<test!>-39a4e1c0f2', '_city_house_put_name': 'houseName<test!>-f0e894210f'}
-2020-12-15 16:30:58.233: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:30:58.246: Subsequence rendering  up to: 0
-2020-12-15 16:30:58.266: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:30:58.275: Hijack request rendering
-2020-12-15 16:30:58.284: Sending: 'GET /city/cityName<test!>-39a4e1c0f2/house/houseName<test!>-f0e894210f HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:52.845: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:30:58.294: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
+2020-12-16 15:03:52.864: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:30:58.304: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:52.883: Re-rendering and sending start of sequence
+2020-12-16 15:03:52.896: Sending: 'PUT /city/cityName<test!>-30c24820a0 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:58.314: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:52.906: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-30c24820a0", "properties": {}}'
 
-2020-12-15 16:30:58.324: Re-rendering and sending start of sequence
-2020-12-15 16:30:58.333: Sending: 'PUT /city/cityName<test!>-41bc8b9576 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:52.917: Sending: 'PUT /city/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:58.343: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-41bc8b9576", "properties": {}}'
+2020-12-16 15:03:52.926: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9f6e11c94e"}'
 
-2020-12-15 16:30:58.353: Sending: 'PUT /city/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:30:58.365: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-0ba5a201ca"}'
-
-2020-12-15 16:30:58.382: InvalidDynamicObjectChecker 
+2020-12-16 15:03:52.951: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:30:58.392: Preparing requests with invalid objects
-2020-12-15 16:30:58.409: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576?injected_query_string=123/house/houseName<test!>-0ba5a201ca?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:58.419: Sending: 'GET /city/cityName<test!>-41bc8b9576?injected_query_string=123/house/houseName<test!>-0ba5a201ca?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:52.963: Preparing requests with invalid objects
+2020-12-16 15:03:52.980: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0?injected_query_string=123/house/houseName<test!>-9f6e11c94e?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:52.989: Sending: 'GET /city/cityName<test!>-30c24820a0?injected_query_string=123/house/houseName<test!>-9f6e11c94e?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:58.429: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-41bc8b9576", "properties": {}}'
+2020-12-16 15:03:52.998: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-30c24820a0", "properties": {}}'
 
-2020-12-15 16:30:58.439: Attempting to reproduce bug...
-2020-12-15 16:30:58.449: Sending: 'PUT /city/cityName<test!>-41bc8b9576 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:53.008: Attempting to reproduce bug...
+2020-12-16 15:03:53.018: Sending: 'PUT /city/cityName<test!>-30c24820a0 HTTP/1.1\r\nHost: unittest\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:58.461: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-41bc8b9576", "properties": {}}'
+2020-12-16 15:03:53.027: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-30c24820a0", "properties": {}}'
 
-2020-12-15 16:30:58.471: Sending: 'PUT /city/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:53.035: Sending: 'PUT /city/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:30:58.481: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-0ba5a201ca"}'
+2020-12-16 15:03:53.045: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9f6e11c94e"}'
 
-2020-12-15 16:30:58.491: Sending: 'GET /city/cityName<test!>-41bc8b9576?injected_query_string=123/house/houseName<test!>-0ba5a201ca?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:53.055: Sending: 'GET /city/cityName<test!>-30c24820a0?injected_query_string=123/house/houseName<test!>-9f6e11c94e?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:58.500: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-41bc8b9576", "properties": {}}'
+2020-12-16 15:03:53.073: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-30c24820a0", "properties": {}}'
 
-2020-12-15 16:30:58.511: Done replaying sequence.
-2020-12-15 16:30:58.539: InvalidDynamicObjectChecker 
+2020-12-16 15:03:53.085: Done replaying sequence.
+2020-12-16 15:03:53.121: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:58.555: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:58.572: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:58.589: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
-2020-12-15 16:30:58.606: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:58.616: Sending: 'GET /city/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:53.138: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:53.156: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:53.174: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
+2020-12-16 15:03:53.189: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:53.200: Sending: 'GET /city/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:58.625: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-0ba5a201ca"}'
+2020-12-16 15:03:53.218: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9f6e11c94e"}'
 
-2020-12-15 16:30:58.647: InvalidDynamicObjectChecker 
+2020-12-16 15:03:53.257: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:58.664: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:58.683: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:58.701: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
-2020-12-15 16:30:58.718: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576?injected_query_string=123/house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:58.727: Sending: 'GET /city/cityName<test!>-41bc8b9576?injected_query_string=123/house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:53.286: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:53.302: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:53.319: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
+2020-12-16 15:03:53.335: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0?injected_query_string=123/house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:53.343: Sending: 'GET /city/cityName<test!>-30c24820a0?injected_query_string=123/house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:58.737: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-41bc8b9576", "properties": {}}'
+2020-12-16 15:03:53.362: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-30c24820a0", "properties": {}}'
 
-2020-12-15 16:30:58.760: InvalidDynamicObjectChecker 
+2020-12-16 15:03:53.384: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:58.777: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:58.794: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:58.811: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
-2020-12-15 16:30:58.828: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576/?//house/houseName<test!>-0ba5a201ca/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:58.838: Sending: 'GET /city/cityName<test!>-41bc8b9576/?//house/houseName<test!>-0ba5a201ca/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:53.400: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:53.427: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:53.458: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
+2020-12-16 15:03:53.475: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0/?//house/houseName<test!>-9f6e11c94e/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:53.483: Sending: 'GET /city/cityName<test!>-30c24820a0/?//house/houseName<test!>-9f6e11c94e/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:58.848: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-41bc8b9576", "properties": {}}'
+2020-12-16 15:03:53.492: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-30c24820a0", "properties": {}}'
 
-2020-12-15 16:30:58.873: InvalidDynamicObjectChecker 
+2020-12-16 15:03:53.512: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:58.897: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:58.916: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:58.936: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
-2020-12-15 16:30:58.953: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:58.964: Sending: 'GET /city/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:53.528: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:53.544: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:53.560: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
+2020-12-16 15:03:53.576: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:53.584: Sending: 'GET /city/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:58.973: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-0ba5a201ca"}'
+2020-12-16 15:03:53.595: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9f6e11c94e"}'
 
-2020-12-15 16:30:58.996: InvalidDynamicObjectChecker 
+2020-12-16 15:03:53.637: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:59.013: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:59.031: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:59.048: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
-2020-12-15 16:30:59.067: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576/?//house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:59.076: Sending: 'GET /city/cityName<test!>-41bc8b9576/?//house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:53.661: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:53.678: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:53.697: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
+2020-12-16 15:03:53.714: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0/?//house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:53.722: Sending: 'GET /city/cityName<test!>-30c24820a0/?//house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:59.086: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-41bc8b9576", "properties": {}}'
+2020-12-16 15:03:53.734: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-30c24820a0", "properties": {}}'
 
-2020-12-15 16:30:59.108: InvalidDynamicObjectChecker 
+2020-12-16 15:03:53.770: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:59.125: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:59.143: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:59.161: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
-2020-12-15 16:30:59.179: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576??/house/houseName<test!>-0ba5a201ca?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:59.190: Sending: 'GET /city/cityName<test!>-41bc8b9576??/house/houseName<test!>-0ba5a201ca?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:53.789: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:53.806: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:53.822: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
+2020-12-16 15:03:53.838: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0??/house/houseName<test!>-9f6e11c94e?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:53.847: Sending: 'GET /city/cityName<test!>-30c24820a0??/house/houseName<test!>-9f6e11c94e?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:59.200: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-41bc8b9576", "properties": {}}'
+2020-12-16 15:03:53.858: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-30c24820a0", "properties": {}}'
 
-2020-12-15 16:30:59.224: InvalidDynamicObjectChecker 
+2020-12-16 15:03:53.881: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:59.243: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:59.260: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:59.276: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
-2020-12-15 16:30:59.292: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:59.303: Sending: 'GET /city/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:53.906: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:53.936: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:53.956: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
+2020-12-16 15:03:53.972: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:53.981: Sending: 'GET /city/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:59.313: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-0ba5a201ca"}'
+2020-12-16 15:03:53.989: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9f6e11c94e"}'
 
-2020-12-15 16:30:59.336: InvalidDynamicObjectChecker 
+2020-12-16 15:03:54.010: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:59.352: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:59.369: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:59.386: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
-2020-12-15 16:30:59.403: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576??/house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:59.413: Sending: 'GET /city/cityName<test!>-41bc8b9576??/house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:54.037: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:54.059: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:54.076: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
+2020-12-16 15:03:54.092: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0??/house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:54.100: Sending: 'GET /city/cityName<test!>-30c24820a0??/house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:59.422: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-41bc8b9576", "properties": {}}'
+2020-12-16 15:03:54.109: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-30c24820a0", "properties": {}}'
 
-2020-12-15 16:30:59.446: InvalidDynamicObjectChecker 
+2020-12-16 15:03:54.138: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:30:59.463: InvalidDynamicObjectChecker PUT /city/cityName
-2020-12-15 16:30:59.479: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
-2020-12-15 16:30:59.498: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
-2020-12-15 16:30:59.514: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:59.523: Sending: 'GET /city/cityName<test!>-41bc8b9576/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:54.155: InvalidDynamicObjectChecker PUT /city/cityName
+2020-12-16 15:03:54.170: InvalidDynamicObjectChecker PUT /city/_READER_DELIM_city_put_name_READER_DELIM/house/houseName
+2020-12-16 15:03:54.186: InvalidDynamicObjectChecker GET /city/_READER_DELIM_city_put_name_READER_DELIM/house/_READER_DELIM_city_house_put_name_READER_DELIM
+2020-12-16 15:03:54.202: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:54.211: Sending: 'GET /city/cityName<test!>-30c24820a0/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:59.533: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:54.220: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:59.552: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:59.563: Sending: 'GET /city/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:54.247: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:54.259: Sending: 'GET /city/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:59.573: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:54.272: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:59.591: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:59.600: Sending: 'GET /city/cityName<test!>-41bc8b9576/cityName<test!>-41bc8b9576/house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:54.301: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:54.314: Sending: 'GET /city/cityName<test!>-30c24820a0/cityName<test!>-30c24820a0/house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:59.610: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:54.333: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:59.628: InvalidDynamicObjectChecker 'GET /city/{}/house/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:59.638: Sending: 'GET /city/{}/house/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:54.350: InvalidDynamicObjectChecker 'GET /city/{}/house/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:54.361: Sending: 'GET /city/{}/house/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:59.648: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:54.378: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:59.665: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-41bc8b9576/house/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:59.677: Sending: 'GET /city/cityName<test!>-41bc8b9576/house/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:54.398: InvalidDynamicObjectChecker 'GET /city/cityName<test!>-30c24820a0/house/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:54.407: Sending: 'GET /city/cityName<test!>-30c24820a0/house/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:59.687: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:54.416: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:59.707: InvalidDynamicObjectChecker 'GET /city/{}/house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:30:59.717: Sending: 'GET /city/{}/house/houseName<test!>-0ba5a201ca HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:54.443: InvalidDynamicObjectChecker 'GET /city/{}/house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:54.455: Sending: 'GET /city/{}/house/houseName<test!>-9f6e11c94e HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:30:59.726: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:54.473: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:30:59.739: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:54.485: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:30:59.749: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:54.495: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:30:59.759: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:54.505: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:30:59.769: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:54.523: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:30:59.779: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:54.535: Checker: ExamplesChecker kicks out
 
 
 Generation-3: Rendering Sequence-1
@@ -2409,184 +2369,184 @@ Generation-3: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:31:00.499: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-aab0a77974 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:55.230: Will refresh token: python C:\RESTlerRepo\restler-fuzzer\restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
+2020-12-16 15:03:55.310: New value: {'user1':{}, 'user2':{}}
+Authorization: valid_unit_test_token
+Authorization: shadow_unit_test_token
+2020-12-16 15:03:55.321: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-47fc459a65 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:00.508: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-aab0a77974"}'
+2020-12-16 15:03:55.329: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-47fc459a65"}'
 
-2020-12-15 16:31:00.519: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-aab0a77974/resourcehierarchychild/resourcehierarchyChild<test!>-cc95540c35 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:55.338: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-47fc459a65/resourcehierarchychild/resourcehierarchyChild<test!>-3bc6eea0c7 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:00.530: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-cc95540c35"}'
+2020-12-16 15:03:55.349: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-3bc6eea0c7"}'
 
-2020-12-15 16:31:00.539: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-aab0a77974/resourcehierarchychild/resourcehierarchyChild<test!>-cc95540c35 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:55.358: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-47fc459a65/resourcehierarchychild/resourcehierarchyChild<test!>-3bc6eea0c7 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:00.552: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyChild<test!>-cc95540c35"'
+2020-12-16 15:03:55.368: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyChild<test!>-3bc6eea0c7"'
 
-2020-12-15 16:31:00.566: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:55.378: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:31:00.576: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:55.387: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:31:00.585: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:55.398: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:31:00.598: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:55.406: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:31:00.608: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:55.416: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:31:00.622: UseAfterFreeChecker 
-Target types: {'_resourcehierarchychild_put_name', '_resourcehierarchytest_put_name'}
-2020-12-15 16:31:00.637: UseAfterFreeChecker Clean tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-aab0a77974', '_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-cc95540c35', '_namespaceruletest_put_name': None}
-2020-12-15 16:31:00.654: UseAfterFreeChecker Found * 1 * consumers.
-2020-12-15 16:31:00.664: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-aab0a77974/resourcehierarchychild/resourcehierarchyChild<test!>-cc95540c35 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:55.430: UseAfterFreeChecker 
+Target types: {'_resourcehierarchytest_put_name', '_resourcehierarchychild_put_name'}
+2020-12-16 15:03:55.443: UseAfterFreeChecker Clean tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-47fc459a65', '_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-3bc6eea0c7', '_namespaceruletest_put_name': None}
+2020-12-16 15:03:55.459: UseAfterFreeChecker Found * 1 * consumers.
+2020-12-16 15:03:55.467: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-47fc459a65/resourcehierarchychild/resourcehierarchyChild<test!>-3bc6eea0c7 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:00.674: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:55.478: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:00.685: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:55.487: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:31:00.695: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:55.496: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:31:00.712: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:31:00.722: Re-rendering original sequence
-2020-12-15 16:31:00.731: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-e2183b53de HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:55.512: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:55.521: Re-rendering start of original sequence
+2020-12-16 15:03:55.531: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-97c3cfa62a HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:00.741: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-e2183b53de"}'
+2020-12-16 15:03:55.541: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-97c3cfa62a"}'
 
-2020-12-15 16:31:00.751: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-e2183b53de/resourcehierarchychild/resourcehierarchyChild<test!>-a2ab81effe HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:55.550: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-97c3cfa62a/resourcehierarchychild/resourcehierarchyChild<test!>-1865f6d089 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:00.761: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-a2ab81effe"}'
+2020-12-16 15:03:55.560: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-1865f6d089"}'
 
-2020-12-15 16:31:00.771: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-e2183b53de/resourcehierarchychild/resourcehierarchyChild<test!>-a2ab81effe HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:55.575: NameSpaceRuleChecker Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-97c3cfa62a', '_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-1865f6d089'}
+2020-12-16 15:03:55.585: Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-97c3cfa62a', '_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-1865f6d089'}
+2020-12-16 15:03:55.599: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:55.608: Subsequence rendering  up to: 0
+2020-12-16 15:03:55.622: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:55.631: Hijack request rendering
+2020-12-16 15:03:55.641: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-97c3cfa62a/resourcehierarchychild/resourcehierarchyChild<test!>-1865f6d089 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:00.781: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyChild<test!>-a2ab81effe"'
+2020-12-16 15:03:55.650: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:31:00.797: NameSpaceRuleChecker Hijacked values: {'_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-a2ab81effe', '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-e2183b53de'}
-2020-12-15 16:31:00.807: Hijacked values: {'_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-a2ab81effe', '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-e2183b53de'}
-2020-12-15 16:31:00.822: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:31:00.832: Subsequence rendering  up to: 0
-2020-12-15 16:31:00.846: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:31:00.856: Hijack request rendering
-2020-12-15 16:31:00.866: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-e2183b53de/resourcehierarchychild/resourcehierarchyChild<test!>-a2ab81effe HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:55.660: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:31:00.876: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
+2020-12-16 15:03:55.670: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:31:00.886: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:55.680: Re-rendering and sending start of sequence
+2020-12-16 15:03:55.689: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:00.897: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:55.699: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-ef0bfc1529"}'
 
-2020-12-15 16:31:00.906: Re-rendering and sending start of sequence
-2020-12-15 16:31:00.916: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:55.708: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:00.925: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-75373fe33b"}'
+2020-12-16 15:03:55.717: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-ebe6f81609"}'
 
-2020-12-15 16:31:00.935: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:31:00.945: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-8d51010440"}'
-
-2020-12-15 16:31:00.962: InvalidDynamicObjectChecker 
+2020-12-16 15:03:55.733: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:31:00.972: Preparing requests with invalid objects
-2020-12-15 16:31:00.989: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:00.999: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:55.744: Preparing requests with invalid objects
+2020-12-16 15:03:55.770: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:55.779: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.010: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-75373fe33b"'
+2020-12-16 15:03:55.788: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-ef0bfc1529"'
 
-2020-12-15 16:31:01.024: Attempting to reproduce bug...
-2020-12-15 16:31:01.034: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:55.797: Attempting to reproduce bug...
+2020-12-16 15:03:55.807: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:01.044: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-75373fe33b"}'
+2020-12-16 15:03:55.817: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-ef0bfc1529"}'
 
-2020-12-15 16:31:01.054: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:55.826: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:01.064: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-8d51010440"}'
+2020-12-16 15:03:55.836: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-ebe6f81609"}'
 
-2020-12-15 16:31:01.074: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:55.845: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.083: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-75373fe33b"'
+2020-12-16 15:03:55.854: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"resourcehierarchyTest<test!>-ef0bfc1529"'
 
-2020-12-15 16:31:01.095: Done replaying sequence.
-2020-12-15 16:31:01.128: InvalidDynamicObjectChecker 
+2020-12-16 15:03:55.864: Done replaying sequence.
+2020-12-16 15:03:55.895: InvalidDynamicObjectChecker 
 Suspect sequence: 202
-2020-12-15 16:31:01.150: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:01.173: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:31:01.197: InvalidDynamicObjectChecker DELETE /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:01.215: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.225: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:55.914: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:55.933: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:55.951: InvalidDynamicObjectChecker DELETE /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:55.968: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:55.979: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.234: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:55.988: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:01.265: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.278: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.017: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.032: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.289: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:56.042: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:01.307: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/?//resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.316: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/?//resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.067: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/?//resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.078: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/?//resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.327: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
+2020-12-16 15:03:56.088: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
 
-2020-12-15 16:31:01.343: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.353: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.104: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.113: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.364: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
+2020-12-16 15:03:56.122: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
 
-2020-12-15 16:31:01.380: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/?//resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.390: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/?//resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.137: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/?//resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.146: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/?//resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.400: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
+2020-12-16 15:03:56.155: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: "}'
 
-2020-12-15 16:31:01.428: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b??/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.439: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b??/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.172: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529??/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.181: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529??/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.449: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:56.190: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:01.466: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.476: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.208: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.218: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.486: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:56.227: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:01.503: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b??/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.514: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b??/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.244: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529??/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.254: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529??/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.522: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:56.264: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:01.540: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.550: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.293: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.303: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.570: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:56.313: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:01.590: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.599: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.330: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.340: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.617: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: resourcehierarchyChild<test!>-8d51010440"}'
+2020-12-16 15:03:56.358: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: resourcehierarchyChild<test!>-ebe6f81609"}'
 
-2020-12-15 16:31:01.637: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.647: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.378: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.388: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.657: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: resourcehierarchyChild<test!>-8d51010440"}'
+2020-12-16 15:03:56.397: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "Invalid resource: resourcehierarchyChild<test!>-ebe6f81609"}'
 
-2020-12-15 16:31:01.674: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/{}/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.684: Sending: 'DELETE /resourcehierarchytest/{}/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.414: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/{}/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.422: Sending: 'DELETE /resourcehierarchytest/{}/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.702: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:56.431: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:01.721: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.732: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-75373fe33b/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.449: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.457: Sending: 'DELETE /resourcehierarchytest/resourcehierarchyTest<test!>-ef0bfc1529/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.741: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:56.467: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:01.759: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:01.769: Sending: 'DELETE /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-8d51010440 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:56.483: InvalidDynamicObjectChecker 'DELETE /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:56.492: Sending: 'DELETE /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-ebe6f81609 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:01.778: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:56.501: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:01.788: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:56.511: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:31:01.798: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:56.520: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:31:01.808: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:56.529: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:31:01.818: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:56.539: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:31:01.829: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:56.558: Checker: ExamplesChecker kicks out
 
 
 Generation-3: Rendering Sequence-1
@@ -2644,245 +2604,237 @@ Generation-3: Rendering Sequence-1
 		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
 		- restler_static_string: '\r\n'
 
-2020-12-15 16:31:02.503: Will refresh token: C:\RESTlerRepo\restler-fuzzer\restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
-2020-12-15 16:31:02.688: New value: {'user1':{}, 'user2':{}}
-Authorization: valid_unit_test_token
-Authorization: shadow_unit_test_token
-2020-12-15 16:31:02.698: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-ad31a6e1c3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:57.208: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-183399ee10 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:02.707: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-ad31a6e1c3"}'
+2020-12-16 15:03:57.218: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-183399ee10"}'
 
-2020-12-15 16:31:02.717: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-ad31a6e1c3/resourcehierarchychild/resourcehierarchyChild<test!>-058f7f3c71 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:57.227: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-183399ee10/resourcehierarchychild/resourcehierarchyChild<test!>-e9e425ad8d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:02.726: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-058f7f3c71"}'
+2020-12-16 15:03:57.237: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-e9e425ad8d"}'
 
-2020-12-15 16:31:02.737: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-ad31a6e1c3/resourcehierarchychild/resourcehierarchyChild<test!>-058f7f3c71 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:57.246: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-183399ee10/resourcehierarchychild/resourcehierarchyChild<test!>-e9e425ad8d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:02.747: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-058f7f3c71"}'
+2020-12-16 15:03:57.256: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-e9e425ad8d"}'
 
-2020-12-15 16:31:02.758: Checker: LeakageRuleChecker kicks in
+2020-12-16 15:03:57.265: Checker: LeakageRuleChecker kicks in
 
-2020-12-15 16:31:02.768: Checker: LeakageRuleChecker kicks out
+2020-12-16 15:03:57.275: Checker: LeakageRuleChecker kicks out
 
-2020-12-15 16:31:02.778: Checker: ResourceHierarchyChecker kicks in
+2020-12-16 15:03:57.287: Checker: ResourceHierarchyChecker kicks in
 
-2020-12-15 16:31:02.789: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-423fef2e6d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:57.297: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-3f798393a3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:02.799: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-423fef2e6d"}'
+2020-12-16 15:03:57.307: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-3f798393a3"}'
 
-2020-12-15 16:31:02.814: ResourceHierarchyChecker 
+2020-12-16 15:03:57.322: ResourceHierarchyChecker 
 Target types: {'_resourcehierarchychild_put_name'}
-2020-12-15 16:31:02.829: ResourceHierarchyChecker Predecesor types: {'_resourcehierarchytest_put_name'}
-2020-12-15 16:31:02.844: ResourceHierarchyChecker Clean tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-423fef2e6d', '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': None}
-2020-12-15 16:31:02.859: ResourceHierarchyChecker Poluted tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-423fef2e6d', '_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-058f7f3c71', '_namespaceruletest_put_name': None}
-2020-12-15 16:31:02.869: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-423fef2e6d/resourcehierarchychild/resourcehierarchyChild<test!>-058f7f3c71 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:57.336: ResourceHierarchyChecker Predecesor types: {'_resourcehierarchytest_put_name'}
+2020-12-16 15:03:57.358: ResourceHierarchyChecker Clean tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-3f798393a3', '_resourcehierarchychild_put_name': None, '_namespaceruletest_put_name': None}
+2020-12-16 15:03:57.377: ResourceHierarchyChecker Poluted tlb: {'_city_put_name': None, '_city_house_put_name': None, '_city_house_color_put_name': None, '_leakageruletest_put_name': None, '_useafterfreetest_put_name': None, '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-3f798393a3', '_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-e9e425ad8d', '_namespaceruletest_put_name': None}
+2020-12-16 15:03:57.387: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-3f798393a3/resourcehierarchychild/resourcehierarchyChild<test!>-e9e425ad8d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:02.879: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-058f7f3c71"}'
+2020-12-16 15:03:57.396: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-e9e425ad8d"}'
 
-2020-12-15 16:31:02.893: ResourceHierarchyChecker 
+2020-12-16 15:03:57.411: ResourceHierarchyChecker 
 Suspect sequence: 200
-2020-12-15 16:31:02.908: ResourceHierarchyChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:02.923: ResourceHierarchyChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:02.933: Attempting to reproduce bug...
-2020-12-15 16:31:02.946: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-423fef2e6d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:57.427: ResourceHierarchyChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:57.441: ResourceHierarchyChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:57.450: Attempting to reproduce bug...
+2020-12-16 15:03:57.475: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-3f798393a3 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:02.959: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-423fef2e6d"}'
+2020-12-16 15:03:57.488: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-3f798393a3"}'
 
-2020-12-15 16:31:02.968: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-423fef2e6d/resourcehierarchychild/resourcehierarchyChild<test!>-058f7f3c71 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:57.498: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-3f798393a3/resourcehierarchychild/resourcehierarchyChild<test!>-e9e425ad8d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:02.978: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-058f7f3c71"}'
+2020-12-16 15:03:57.508: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-e9e425ad8d"}'
 
-2020-12-15 16:31:02.988: Done replaying sequence.
-2020-12-15 16:31:03.007: Checker: ResourceHierarchyChecker kicks out
+2020-12-16 15:03:57.517: Done replaying sequence.
+2020-12-16 15:03:57.536: Checker: ResourceHierarchyChecker kicks out
 
-2020-12-15 16:31:03.016: Checker: UseAfterFreeChecker kicks in
+2020-12-16 15:03:57.545: Checker: UseAfterFreeChecker kicks in
 
-2020-12-15 16:31:03.026: Checker: UseAfterFreeChecker kicks out
+2020-12-16 15:03:57.555: Checker: UseAfterFreeChecker kicks out
 
-2020-12-15 16:31:03.037: Checker: NameSpaceRuleChecker kicks in
+2020-12-16 15:03:57.564: Checker: NameSpaceRuleChecker kicks in
 
-2020-12-15 16:31:03.054: NameSpaceRuleChecker 
-Re-rendering original sequence
-2020-12-15 16:31:03.064: Re-rendering original sequence
-2020-12-15 16:31:03.074: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-3e152d4366 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:57.580: NameSpaceRuleChecker 
+Re-rendering start of original sequence
+2020-12-16 15:03:57.588: Re-rendering start of original sequence
+2020-12-16 15:03:57.599: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-f38d1c74cb HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:03.083: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-3e152d4366"}'
+2020-12-16 15:03:57.609: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-f38d1c74cb"}'
 
-2020-12-15 16:31:03.093: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-3e152d4366/resourcehierarchychild/resourcehierarchyChild<test!>-f397a9b088 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:57.620: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-f38d1c74cb/resourcehierarchychild/resourcehierarchyChild<test!>-9d6905b383 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:03.104: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-f397a9b088"}'
+2020-12-16 15:03:57.631: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-9d6905b383"}'
 
-2020-12-15 16:31:03.113: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-3e152d4366/resourcehierarchychild/resourcehierarchyChild<test!>-f397a9b088 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:57.647: NameSpaceRuleChecker Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-f38d1c74cb', '_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-9d6905b383'}
+2020-12-16 15:03:57.656: Hijacked values: {'_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-f38d1c74cb', '_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-9d6905b383'}
+2020-12-16 15:03:57.671: NameSpaceRuleChecker Subsequence rendering up to: 0
+2020-12-16 15:03:57.680: Subsequence rendering  up to: 0
+2020-12-16 15:03:57.696: NameSpaceRuleChecker Hijack request rendering
+2020-12-16 15:03:57.705: Hijack request rendering
+2020-12-16 15:03:57.714: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-f38d1c74cb/resourcehierarchychild/resourcehierarchyChild<test!>-9d6905b383 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:03.122: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-f397a9b088"}'
+2020-12-16 15:03:57.724: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
 
-2020-12-15 16:31:03.138: NameSpaceRuleChecker Hijacked values: {'_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-f397a9b088', '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-3e152d4366'}
-2020-12-15 16:31:03.147: Hijacked values: {'_resourcehierarchychild_put_name': 'resourcehierarchyChild<test!>-f397a9b088', '_resourcehierarchytest_put_name': 'resourcehierarchyTest<test!>-3e152d4366'}
-2020-12-15 16:31:03.163: NameSpaceRuleChecker Subsequence rendering up to: 0
-2020-12-15 16:31:03.172: Subsequence rendering  up to: 0
-2020-12-15 16:31:03.188: NameSpaceRuleChecker Hijack request rendering
-2020-12-15 16:31:03.197: Hijack request rendering
-2020-12-15 16:31:03.207: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-3e152d4366/resourcehierarchychild/resourcehierarchyChild<test!>-f397a9b088 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: shadow_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:57.733: Checker: NameSpaceRuleChecker kicks out
 
-2020-12-15 16:31:03.216: Received: "HTTP/1.1 403 Forbidden\r\nRestler Test\r\n\r\n{'User not authorized or no auth token specified.'}"
+2020-12-16 15:03:57.743: Checker: InvalidDynamicObjectChecker kicks in
 
-2020-12-15 16:31:03.226: Checker: NameSpaceRuleChecker kicks out
+2020-12-16 15:03:57.753: Re-rendering and sending start of sequence
+2020-12-16 15:03:57.762: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:03.235: Checker: InvalidDynamicObjectChecker kicks in
+2020-12-16 15:03:57.772: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-1779fbc12c"}'
 
-2020-12-15 16:31:03.245: Re-rendering and sending start of sequence
-2020-12-15 16:31:03.255: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:57.782: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:03.265: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a49121130d"}'
+2020-12-16 15:03:57.791: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-948f51e8ee"}'
 
-2020-12-15 16:31:03.275: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
-
-2020-12-15 16:31:03.285: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-cf4036e203"}'
-
-2020-12-15 16:31:03.305: InvalidDynamicObjectChecker 
+2020-12-16 15:03:57.807: InvalidDynamicObjectChecker 
 Sending invalid request(s):
-2020-12-15 16:31:03.314: Preparing requests with invalid objects
-2020-12-15 16:31:03.332: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:03.342: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:57.817: Preparing requests with invalid objects
+2020-12-16 15:03:57.834: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:57.843: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:03.352: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a49121130d"}'
+2020-12-16 15:03:57.853: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-1779fbc12c"}'
 
-2020-12-15 16:31:03.362: Attempting to reproduce bug...
-2020-12-15 16:31:03.373: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:57.864: Attempting to reproduce bug...
+2020-12-16 15:03:57.874: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:03.385: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a49121130d"}'
+2020-12-16 15:03:57.883: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-1779fbc12c"}'
 
-2020-12-15 16:31:03.400: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
+2020-12-16 15:03:57.894: Sending: 'PUT /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n{}\r\n'
 
-2020-12-15 16:31:03.410: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-cf4036e203"}'
+2020-12-16 15:03:57.903: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-948f51e8ee"}'
 
-2020-12-15 16:31:03.420: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:57.914: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:03.432: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a49121130d"}'
+2020-12-16 15:03:57.923: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-1779fbc12c"}'
 
-2020-12-15 16:31:03.440: Done replaying sequence.
-2020-12-15 16:31:03.467: InvalidDynamicObjectChecker 
+2020-12-16 15:03:57.934: Done replaying sequence.
+2020-12-16 15:03:57.973: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:31:03.482: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:03.499: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:31:03.525: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:03.545: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:03.554: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:57.990: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:58.007: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:58.024: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:58.042: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:58.052: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee?injected_query_string=123 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:03.563: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-cf4036e203"}'
+2020-12-16 15:03:58.062: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-948f51e8ee"}'
 
-2020-12-15 16:31:03.587: InvalidDynamicObjectChecker 
+2020-12-16 15:03:58.085: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:31:03.604: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:03.622: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:31:03.639: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:03.656: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:03.665: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:58.104: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:58.124: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:58.141: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:58.159: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:58.169: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c?injected_query_string=123/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:03.675: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a49121130d"}'
+2020-12-16 15:03:58.179: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-1779fbc12c"}'
 
-2020-12-15 16:31:03.698: InvalidDynamicObjectChecker 
+2020-12-16 15:03:58.201: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:31:03.715: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:03.732: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:31:03.750: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:03.770: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/?//resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:03.780: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/?//resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:58.218: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:58.234: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:58.253: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:58.271: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/?//resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:58.280: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/?//resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:03.790: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a49121130d"}'
+2020-12-16 15:03:58.290: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-1779fbc12c"}'
 
-2020-12-15 16:31:03.815: InvalidDynamicObjectChecker 
+2020-12-16 15:03:58.312: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:31:03.833: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:03.850: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:31:03.867: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:03.885: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:03.895: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:58.330: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:58.347: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:58.363: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:58.381: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:58.390: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee/?/ HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:03.906: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-cf4036e203"}'
+2020-12-16 15:03:58.399: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-948f51e8ee"}'
 
-2020-12-15 16:31:03.928: InvalidDynamicObjectChecker 
+2020-12-16 15:03:58.421: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:31:03.945: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:03.964: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:31:03.982: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:03.998: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/?//resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:04.008: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/?//resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:58.437: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:58.454: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:58.471: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:58.487: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/?//resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:58.497: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/?//resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:04.017: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a49121130d"}'
+2020-12-16 15:03:58.506: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-1779fbc12c"}'
 
-2020-12-15 16:31:04.038: InvalidDynamicObjectChecker 
+2020-12-16 15:03:58.528: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:31:04.055: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:04.073: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:31:04.089: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:04.107: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d??/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:04.117: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d??/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:58.545: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:58.572: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:58.592: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:58.612: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c??/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:58.621: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c??/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:04.127: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a49121130d"}'
+2020-12-16 15:03:58.630: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-1779fbc12c"}'
 
-2020-12-15 16:31:04.150: InvalidDynamicObjectChecker 
+2020-12-16 15:03:58.663: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:31:04.168: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:04.186: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:31:04.205: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:04.225: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:04.235: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:58.681: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:58.699: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:58.716: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:58.732: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:58.740: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee?? HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:04.244: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-cf4036e203"}'
+2020-12-16 15:03:58.750: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyChild<test!>-948f51e8ee"}'
 
-2020-12-15 16:31:04.266: InvalidDynamicObjectChecker 
+2020-12-16 15:03:58.783: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:31:04.284: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:04.301: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:31:04.319: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:04.337: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d??/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:04.347: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d??/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:58.804: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:58.821: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:58.839: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:58.855: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c??/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:58.864: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c??/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:04.356: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-a49121130d"}'
+2020-12-16 15:03:58.874: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "resourcehierarchyTest<test!>-1779fbc12c"}'
 
-2020-12-15 16:31:04.379: InvalidDynamicObjectChecker 
+2020-12-16 15:03:58.908: InvalidDynamicObjectChecker 
 Suspect sequence: 200
-2020-12-15 16:31:04.397: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
-2020-12-15 16:31:04.415: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
-2020-12-15 16:31:04.433: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
-2020-12-15 16:31:04.453: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:04.465: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:58.924: InvalidDynamicObjectChecker PUT /resourcehierarchytest/resourcehierarchyTest
+2020-12-16 15:03:58.941: InvalidDynamicObjectChecker PUT /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/resourcehierarchyChild
+2020-12-16 15:03:58.959: InvalidDynamicObjectChecker GET /resourcehierarchytest/_READER_DELIM_resourcehierarchytest_put_name_READER_DELIM/resourcehierarchychild/_READER_DELIM_resourcehierarchychild_put_name_READER_DELIM
+2020-12-16 15:03:58.976: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:58.986: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:04.475: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:58.995: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:04.497: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:04.507: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.012: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:59.021: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:04.521: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.031: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:04.542: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:04.552: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.049: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:59.057: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:04.563: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.066: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:04.581: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/{}/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:04.591: Sending: 'GET /resourcehierarchytest/{}/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.083: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/{}/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:59.093: Sending: 'GET /resourcehierarchytest/{}/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:04.601: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.102: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:04.619: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:04.628: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-a49121130d/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.119: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:59.128: Sending: 'GET /resourcehierarchytest/resourcehierarchyTest<test!>-1779fbc12c/resourcehierarchychild/{} HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:04.638: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.137: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:04.666: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
-2020-12-15 16:31:04.675: Sending: 'GET /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-cf4036e203 HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+2020-12-16 15:03:59.154: InvalidDynamicObjectChecker 'GET /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\n\r\n'
+2020-12-16 15:03:59.164: Sending: 'GET /resourcehierarchytest/{}/resourcehierarchychild/resourcehierarchyChild<test!>-948f51e8ee HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
 
-2020-12-15 16:31:04.685: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
+2020-12-16 15:03:59.174: Received: "HTTP/1.1 404 Not Found\r\nRestler Test\r\n\r\n{'Resource': ResourceDoesNotExist()}"
 
-2020-12-15 16:31:04.695: Checker: InvalidDynamicObjectChecker kicks out
+2020-12-16 15:03:59.184: Checker: InvalidDynamicObjectChecker kicks out
 
-2020-12-15 16:31:04.704: Checker: PayloadBodyChecker kicks in
+2020-12-16 15:03:59.196: Checker: PayloadBodyChecker kicks in
 
-2020-12-15 16:31:04.716: Checker: PayloadBodyChecker kicks out
+2020-12-16 15:03:59.205: Checker: PayloadBodyChecker kicks out
 
-2020-12-15 16:31:04.727: Checker: ExamplesChecker kicks in
+2020-12-16 15:03:59.215: Checker: ExamplesChecker kicks in
 
-2020-12-15 16:31:04.737: Checker: ExamplesChecker kicks out
+2020-12-16 15:03:59.224: Checker: ExamplesChecker kicks out
 


### PR DESCRIPTION
Updated namespace rule checker to no longer re-render the final target request.

This fixes the issue where DELETE requests give false negatives when the resource was deleted during re-rendering and the attack request receives a 404.

Closes #112 