### PR TITLE
Fixed bug that caused network logging to crash from certain response strings.

### DIFF
--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -96,7 +96,7 @@ class NetworkLog(object):
             self._current_log_path = build_logfile_path(
                 NETWORK_LOGS, self._log_name, self._thread_id, self._current_log_num)
 
-        with open(self._current_log_path, 'a+') as log_file:
+        with open(self._current_log_path, 'a+', encoding='utf-8') as log_file:
             print(data, file=log_file)
             log_file.flush()
             os.fsync(log_file.fileno())


### PR DESCRIPTION
Fixed bug that caused network logging to crash from certain response strings.

Unicode contained within a certain response was not being encoded properly, which caused the network log write to crash.  This fix forces a utf-8 encoding, which resolves the issue.