### PR TITLE
Updated to allow handling of request and response bodies that start as arrays.

### DIFF
--- a/restler/engine/fuzzing_parameters/fuzzing_utils.py
+++ b/restler/engine/fuzzing_parameters/fuzzing_utils.py
@@ -157,13 +157,17 @@ def get_response_body(response):
     response = response.replace("\\'", "'")
     response = response.replace("\'", "'")
 
-    # extract the response body
+    # extract the response body by separating at the known delimiter
+    # Ex: METHOD /end/point HTTP/1.1 DELIM{}
     body_start = response.find(DELIM)
     if body_start == -1:
         return None
 
+    # Save the index where the body begins
+    body_start = body_start + len(DELIM)
+
     try:
-        start_char = response[body_start + len(DELIM)]
+        start_char = response[body_start]
     except Exception:
         return None
 

--- a/restler/engine/fuzzing_parameters/fuzzing_utils.py
+++ b/restler/engine/fuzzing_parameters/fuzzing_utils.py
@@ -151,16 +151,31 @@ def get_response_body(response):
     @rtype:  JSON
 
     """
+    from engine.transport_layer.messaging import DELIM
     # sanity cleanup
     response = response.replace('\\"', "'")
     response = response.replace("\\'", "'")
     response = response.replace("\'", "'")
 
     # extract the response body
-    body_start = response.find('{')
-    body_end = response.rfind('}')
+    body_start = response.find(DELIM)
+    if body_start == -1:
+        return None
 
-    if (body_start == -1) or (body_end == -1):
+    try:
+        start_char = response[body_start + len(DELIM)]
+    except Exception:
+        return None
+
+    if start_char == '{':
+        end_char = '}'
+    elif start_char == '[':
+        end_char = ']'
+    else:
+        return None
+
+    body_end = response.rfind(end_char)
+    if body_end == -1 or body_end < body_start:
         return None
 
     try:
@@ -228,14 +243,29 @@ def get_body_start(request):
     @rtype:  Int or -1 on failure
 
     """
-    # search for this pattern in the request definition
-    body_start_pattern = primitives.restler_static_string('{')
+    # search for the first of these patterns in the request definition
+    body_start_pattern_dict = primitives.restler_static_string('{')
+    body_start_pattern_array = primitives.restler_static_string('[')
+
+    dict_index = -1
+    array_index = -1
 
     try:
-        body_start_index = request.definition.index(body_start_pattern)
-        return body_start_index
+        dict_index = request.definition.index(body_start_pattern_dict)
     except Exception:
-        return -1
+        pass
+
+    try:
+        array_index = request.definition.index(body_start_pattern_array)
+    except Exception:
+        pass
+
+    if dict_index == -1 or array_index == -1:
+        # If one of the indices is -1 then it wasn't found, return the other
+        return max(dict_index, array_index)
+    # Return the lowest index / first character found in body.
+    return min(dict_index, array_index)
+
 
 def get_query_start_end(request):
     """ Get the start and end index of a request's query

--- a/restler/engine/fuzzing_parameters/request_schema_parser.py
+++ b/restler/engine/fuzzing_parameters/request_schema_parser.py
@@ -106,10 +106,10 @@ def des_param_payload(param_payload_json, tag='', query_param=False):
                 values.append(value)
 
             array = ParamArray(values)
-            if not query_param:
-                param = ParamMember(name, array)
-            else:
+            if query_param or not name:
                 param = array
+            else:
+                param = ParamMember(name, array)
 
             array.tag = f'{next_tag}_array'
 

--- a/restler/engine/transport_layer/response.py
+++ b/restler/engine/transport_layer/response.py
@@ -86,11 +86,16 @@ class HttpResponse(object):
             for idx, c in enumerate(body):
                 if c == '{':
                     l_index = idx
+                    r_find = '}'
+                    break
+                elif c == '[':
+                    l_index = idx
+                    r_find = ']'
                     break
                 elif is_invalid(c):
                     return None
 
-            r_index = body.rindex('}') + 1
+            r_index = body.rindex(r_find) + 1
             return body[l_index : r_index]
         except:
             return None

--- a/restler/test_servers/parsed_requests.py
+++ b/restler/test_servers/parsed_requests.py
@@ -19,11 +19,17 @@ class ParsedRequest:
         endpoint_split = method_split[1].split(' HTTP', 1)
         # Handle query string if necessary
         self.endpoint = endpoint_split[0].split('?', 1)[0]
-        header_body_split = endpoint_split[1].split('{', 1)
+        Auth_Token_Str = 'authentication_token_tag\r\n'
+        delim = DELIM
+        if DELIM in endpoint_split[1]:
+            pass
+        elif Auth_Token_Str in endpoint_split[1]:
+            delim = Auth_Token_Str
+        header_body_split = endpoint_split[1].split(delim, 1)
         self.header = header_body_split[0]
         self.body = ''
         if len(header_body_split) > 1:
-            self.body = "{" + header_body_split[1].rstrip('\r\n')
+            self.body = header_body_split[1].rstrip('\r\n')
 
         if ignore_dynamic_objects:
             self._remove_dynamic_objects()

--- a/restler/test_servers/parsed_requests.py
+++ b/restler/test_servers/parsed_requests.py
@@ -19,6 +19,12 @@ class ParsedRequest:
         endpoint_split = method_split[1].split(' HTTP', 1)
         # Handle query string if necessary
         self.endpoint = endpoint_split[0].split('?', 1)[0]
+        # Some requests being parsed (e.g. from bug_buckets.txt) do not contain the
+        # full DELIM value in the logs when the authentication token tag exists
+        # in the request. For instances where the DELIM value is not found, try
+        # checking for the authentication tag when splitting the body.
+        # Ex-no-DELIM: METHOD /end/point HTTP/1.1 Auth_Token_Str{}
+        # Ex-DELIM: METHOD /end/point HTTP/1.1 DELIM{}
         Auth_Token_Str = 'authentication_token_tag\r\n'
         delim = DELIM
         if DELIM in endpoint_split[1]:
@@ -26,6 +32,7 @@ class ParsedRequest:
         elif Auth_Token_Str in endpoint_split[1]:
             delim = Auth_Token_Str
         header_body_split = endpoint_split[1].split(delim, 1)
+
         self.header = header_body_split[0]
         self.body = ''
         if len(header_body_split) > 1:

--- a/restler/unit_tests/log_baseline_test_files/payloadbody_advanced_testing_log.txt
+++ b/restler/unit_tests/log_baseline_test_files/payloadbody_advanced_testing_log.txt
@@ -1,0 +1,1859 @@
+2020-12-24 16:29:56.111: Will refresh token: python restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
+2020-12-24 16:29:56.229: New value: {'user1':{}, 'user2':{}}
+Authorization: valid_unit_test_token
+Authorization: shadow_unit_test_token
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 1)
+		- restler_static_string: 'GET '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2020-12-24 16:29:56.389: Sending: 'GET /city HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2020-12-24 16:29:56.398: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"city": {}}'
+
+2020-12-24 16:29:56.409: Checker: PayloadBodyChecker kicks in
+
+2020-12-24 16:29:56.417: PayloadBodyChecker fuzzing valid True
+2020-12-24 16:29:56.428: PayloadBodyChecker fuzzing invalid True
+2020-12-24 16:29:56.442: PayloadBodyChecker start with examples True
+2020-12-24 16:29:56.455: PayloadBodyChecker size dep budget True
+2020-12-24 16:29:56.469: PayloadBodyChecker use feedback True
+2020-12-24 16:29:56.485: PayloadBodyChecker recipe None
+2020-12-24 16:29:56.494: Checker: PayloadBodyChecker kicks out
+
+2020-12-24 16:29:56.503: Checker: ExamplesChecker kicks in
+
+2020-12-24 16:29:56.512: Checker: ExamplesChecker kicks out
+
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 16)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		+ restler_custom_payload_uuid4_suffix: cityName<test!>-
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"properties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"population":'
+		+ restler_fuzzable_int: ['"0"', '"1"']
+		- restler_static_string: ', "area": "5000",'
+		+ restler_fuzzable_string: ['"fuzzstring"', '"enable"']
+		- restler_static_string: ':'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: ',"subproperties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"subtest":'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+2020-12-24 16:29:56.933: Sending: 'PUT /city/cityName<test!>-f5bd7ebf91 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:29:56.950: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-f5bd7ebf91", "properties": {}}'
+
+2020-12-24 16:29:56.965: Checker: PayloadBodyChecker kicks in
+
+2020-12-24 16:29:56.979: PayloadBodyChecker Start fuzzing request: PUT /city/{cityName}
+2020-12-24 16:29:57.002: PayloadBodyChecker #node: 9
+2020-12-24 16:29:57.024: PayloadBodyChecker Fuzz using dynamic feedback
+2020-12-24 16:29:57.036: PayloadBodyChecker #N: 9, #max: 200, #width: 20
+2020-12-24 16:29:57.050: PayloadBodyChecker Task begin Invalid-JSON
+2020-12-24 16:29:57.063: Sending: 'PUT /city/cityName<test!>-cbe5f65d04 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 108\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.073: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-cbe5f65d04", "properties": {}}'
+
+2020-12-24 16:29:57.091: Sending: 'PUT /city/cityName<test!>-ea106e692e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 124\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false,"subtest":false}}}'
+
+2020-12-24 16:29:57.102: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-ea106e692e", "properties": {}}'
+
+2020-12-24 16:29:57.112: Sending: 'PUT /city/cityName<test!>-a7a9aa955d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 123\r\n\r\n{"properties":{"population":0,"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.121: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a7a9aa955d", "properties": {}}'
+
+2020-12-24 16:29:57.132: Sending: 'PUT /city/cityName<test!>-9d60392f16 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 128\r\n\r\n{"properties":{"area":"fuzzstring","population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.142: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-9d60392f16", "properties": {}}'
+
+2020-12-24 16:29:57.151: Sending: 'PUT /city/cityName<test!>-019256a353 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 131\r\n\r\n{"properties":{"strtest":"fuzzstring","population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.160: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-019256a353", "properties": {}}'
+
+2020-12-24 16:29:57.171: Sending: 'PUT /city/cityName<test!>-b498f922e3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 142\r\n\r\n{"properties":{"subproperties":{"subtest":false},"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.180: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-b498f922e3", "properties": {}}'
+
+2020-12-24 16:29:57.190: Sending: 'PUT /city/cityName<test!>-a56e91b7f2 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 215\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}},"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.200: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a56e91b7f2", "properties": {}}'
+
+2020-12-24 16:29:57.219: PayloadBodyChecker Tracker begin (Invalid-JSON):
+2020-12-24 16:29:57.238: PayloadBodyChecker     Valid: 7
+2020-12-24 16:29:57.255: PayloadBodyChecker     Invalid: 0
+2020-12-24 16:29:57.274: PayloadBodyChecker Tracker end
+2020-12-24 16:29:57.294: PayloadBodyChecker Task end Invalid-JSON
+
+2020-12-24 16:29:57.309: PayloadBodyChecker Task begin Structure
+2020-12-24 16:29:57.324: Sending: 'PUT /city/cityName<test!>-447395f747 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 36\r\n\r\n{"properties":{"area":"fuzzstring"}}'
+
+2020-12-24 16:29:57.338: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-447395f747", "properties": {}}'
+
+2020-12-24 16:29:57.351: Sending: 'PUT /city/cityName<test!>-8ef55560e0 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 31\r\n\r\n{"properties":{"population":0}}'
+
+2020-12-24 16:29:57.364: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8ef55560e0", "properties": {}}'
+
+2020-12-24 16:29:57.376: Sending: 'PUT /city/cityName<test!>-fefad53519 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 108\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.385: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-fefad53519", "properties": {}}'
+
+2020-12-24 16:29:57.397: Sending: 'PUT /city/cityName<test!>-b098b21485 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 50\r\n\r\n{"properties":{"subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.407: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-b098b21485", "properties": {}}'
+
+2020-12-24 16:29:57.417: Sending: 'PUT /city/cityName<test!>-7f419b6f5a HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 39\r\n\r\n{"properties":{"strtest":"fuzzstring"}}'
+
+2020-12-24 16:29:57.427: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-7f419b6f5a", "properties": {}}'
+
+2020-12-24 16:29:57.439: PayloadBodyChecker Tracker begin (Structure):
+2020-12-24 16:29:57.454: PayloadBodyChecker     Valid: 5
+2020-12-24 16:29:57.469: PayloadBodyChecker     Invalid: 0
+2020-12-24 16:29:57.482: PayloadBodyChecker Tracker end
+2020-12-24 16:29:57.494: PayloadBodyChecker Task end Structure
+
+2020-12-24 16:29:57.507: PayloadBodyChecker Task begin Type
+2020-12-24 16:29:57.521: Sending: 'PUT /city/cityName<test!>-852a52df17 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 42\r\n\r\n{"properties":{"area":{ "fuzz" : false }}}'
+
+2020-12-24 16:29:57.532: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-852a52df17", "properties": {}}'
+
+2020-12-24 16:29:57.541: Sending: 'PUT /city/cityName<test!>-27b6d78a01 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 5\r\n\r\nfalse'
+
+2020-12-24 16:29:57.550: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-27b6d78a01", "properties": {}}'
+
+2020-12-24 16:29:57.560: Sending: 'PUT /city/cityName<test!>-5a9b477cf3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 20\r\n\r\n{"properties":false}'
+
+2020-12-24 16:29:57.569: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-5a9b477cf3", "properties": {}}'
+
+2020-12-24 16:29:57.581: Sending: 'PUT /city/cityName<test!>-0c122939a5 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 48\r\n\r\n{"properties":{"population":{ "fuzz" : false }}}'
+
+2020-12-24 16:29:57.590: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0c122939a5", "properties": {}}'
+
+2020-12-24 16:29:57.601: Sending: 'PUT /city/cityName<test!>-7d7e3f3325 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 96\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":false}}'
+
+2020-12-24 16:29:57.615: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-7d7e3f3325", "properties": {}}'
+
+2020-12-24 16:29:57.629: Sending: 'PUT /city/cityName<test!>-a747d24ab1 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 114\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":{ "fuzz" : false },"subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.648: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a747d24ab1", "properties": {}}'
+
+2020-12-24 16:29:57.664: Sending: 'PUT /city/cityName<test!>-9f83b72d3d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 114\r\n\r\n{"properties":{"population":0,"area":{ "fuzz" : false },"strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.681: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-9f83b72d3d", "properties": {}}'
+
+2020-12-24 16:29:57.703: Sending: 'PUT /city/cityName<test!>-1a44b7d8f2 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 125\r\n\r\n{"properties":{"population":{ "fuzz" : false },"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:57.724: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-1a44b7d8f2", "properties": {}}'
+
+2020-12-24 16:29:57.748: Sending: 'PUT /city/cityName<test!>-f3edc70378 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 121\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":{ "fuzz" : false }}}}'
+
+2020-12-24 16:29:57.762: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-f3edc70378", "properties": {}}'
+
+2020-12-24 16:29:57.787: Sending: 'PUT /city/cityName<test!>-9b3e53d035 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 63\r\n\r\n{"properties":{"subproperties":{"subtest":{ "fuzz" : false }}}}'
+
+2020-12-24 16:29:57.807: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-9b3e53d035", "properties": {}}'
+
+2020-12-24 16:29:57.833: Sending: 'PUT /city/cityName<test!>-818553e96f HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 38\r\n\r\n{"properties":{"subproperties":false}}'
+
+2020-12-24 16:29:57.851: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-818553e96f", "properties": {}}'
+
+2020-12-24 16:29:57.871: Sending: 'PUT /city/cityName<test!>-ba41bf9381 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 45\r\n\r\n{"properties":{"strtest":{ "fuzz" : false }}}'
+
+2020-12-24 16:29:57.892: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-ba41bf9381", "properties": {}}'
+
+2020-12-24 16:29:57.912: Sending: 'PUT /city/cityName<test!>-536bfaddac HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 26\r\n\r\n{"properties":{"area":[]}}'
+
+2020-12-24 16:29:57.931: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-536bfaddac", "properties": {}}'
+
+2020-12-24 16:29:57.949: Sending: 'PUT /city/cityName<test!>-10785f9e03 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 1\r\n\r\n0'
+
+2020-12-24 16:29:57.967: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-10785f9e03", "properties": {}}'
+
+2020-12-24 16:29:57.985: Sending: 'PUT /city/cityName<test!>-8a76ef2980 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 16\r\n\r\n{"properties":0}'
+
+2020-12-24 16:29:58.003: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8a76ef2980", "properties": {}}'
+
+2020-12-24 16:29:58.025: Sending: 'PUT /city/cityName<test!>-f2ed8a5dd3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 12\r\n\r\n"fuzzstring"'
+
+2020-12-24 16:29:58.042: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-f2ed8a5dd3", "properties": {}}'
+
+2020-12-24 16:29:58.064: Sending: 'PUT /city/cityName<test!>-1fe287b453 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 29\r\n\r\n{"properties":{"area":false}}'
+
+2020-12-24 16:29:58.084: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-1fe287b453", "properties": {}}'
+
+2020-12-24 16:29:58.106: Sending: 'PUT /city/cityName<test!>-7ce02462c7 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 25\r\n\r\n{"properties":{"area":0}}'
+
+2020-12-24 16:29:58.125: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-7ce02462c7", "properties": {}}'
+
+2020-12-24 16:29:58.147: Sending: 'PUT /city/cityName<test!>-9a6ec56bfc HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 17\r\n\r\n{"properties":[]}'
+
+2020-12-24 16:29:58.168: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-9a6ec56bfc", "properties": {}}'
+
+2020-12-24 16:29:58.190: Sending: 'PUT /city/cityName<test!>-f09dd55a9d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 33\r\n\r\n{"properties":{ "fuzz" : false }}'
+
+2020-12-24 16:29:58.208: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-f09dd55a9d", "properties": {}}'
+
+2020-12-24 16:29:58.229: Sending: 'PUT /city/cityName<test!>-f3949339c0 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 2\r\n\r\n[]'
+
+2020-12-24 16:29:58.250: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-f3949339c0", "properties": {}}'
+
+2020-12-24 16:29:58.271: Sending: 'PUT /city/cityName<test!>-7628941859 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 27\r\n\r\n{"properties":"fuzzstring"}'
+
+2020-12-24 16:29:58.291: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-7628941859", "properties": {}}'
+
+2020-12-24 16:29:58.312: Sending: 'PUT /city/cityName<test!>-dec803d7dc HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 18\r\n\r\n{ "fuzz" : false }'
+
+2020-12-24 16:29:58.335: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-dec803d7dc", "properties": {}}'
+
+2020-12-24 16:29:58.359: Sending: 'PUT /city/cityName<test!>-dfb34bd1fa HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 32\r\n\r\n{"properties":{"population":[]}}'
+
+2020-12-24 16:29:58.380: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-dfb34bd1fa", "properties": {}}'
+
+2020-12-24 16:29:58.402: Sending: 'PUT /city/cityName<test!>-6cd5ddb108 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 35\r\n\r\n{"properties":{"population":false}}'
+
+2020-12-24 16:29:58.422: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-6cd5ddb108", "properties": {}}'
+
+2020-12-24 16:29:58.442: Sending: 'PUT /city/cityName<test!>-aaa0d4194b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 42\r\n\r\n{"properties":{"population":"fuzzstring"}}'
+
+2020-12-24 16:29:58.462: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-aaa0d4194b", "properties": {}}'
+
+2020-12-24 16:29:58.488: Sending: 'PUT /city/cityName<test!>-e5ad22b01e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 101\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":false,"subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:58.503: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e5ad22b01e", "properties": {}}'
+
+2020-12-24 16:29:58.514: Sending: 'PUT /city/cityName<test!>-2bdfc187e4 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 93\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":[]}}'
+
+2020-12-24 16:29:58.523: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-2bdfc187e4", "properties": {}}'
+
+2020-12-24 16:29:58.534: Sending: 'PUT /city/cityName<test!>-adf7ea708f HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 92\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":0}}'
+
+2020-12-24 16:29:58.544: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-adf7ea708f", "properties": {}}'
+
+2020-12-24 16:29:58.554: Sending: 'PUT /city/cityName<test!>-850c3605a8 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 98\r\n\r\n{"properties":{"population":0,"area":[],"strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:58.563: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-850c3605a8", "properties": {}}'
+
+2020-12-24 16:29:58.574: Sending: 'PUT /city/cityName<test!>-7288f6d1bc HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 105\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":[]}}}'
+
+2020-12-24 16:29:58.583: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-7288f6d1bc", "properties": {}}'
+
+2020-12-24 16:29:58.593: Sending: 'PUT /city/cityName<test!>-a48ac3bb3a HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 97\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":0,"subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:58.603: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a48ac3bb3a", "properties": {}}'
+
+2020-12-24 16:29:58.613: Sending: 'PUT /city/cityName<test!>-9ea0a1efff HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 109\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{ "fuzz" : false }}}'
+
+2020-12-24 16:29:58.622: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-9ea0a1efff", "properties": {}}'
+
+2020-12-24 16:29:58.633: Sending: 'PUT /city/cityName<test!>-2e4de2a95d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 109\r\n\r\n{"properties":{"population":[],"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:58.642: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-2e4de2a95d", "properties": {}}'
+
+2020-12-24 16:29:58.653: Sending: 'PUT /city/cityName<test!>-8352384ff8 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 98\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":[],"subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:58.663: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8352384ff8", "properties": {}}'
+
+2020-12-24 16:29:58.673: Sending: 'PUT /city/cityName<test!>-6c88711c6a HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 103\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":"fuzzstring"}}'
+
+2020-12-24 16:29:58.683: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-6c88711c6a", "properties": {}}'
+
+2020-12-24 16:29:58.692: Sending: 'PUT /city/cityName<test!>-ec50d00b45 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 115\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":"fuzzstring"}}}'
+
+2020-12-24 16:29:58.702: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-ec50d00b45", "properties": {}}'
+
+2020-12-24 16:29:58.712: Sending: 'PUT /city/cityName<test!>-824c9722db HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 101\r\n\r\n{"properties":{"population":0,"area":false,"strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:58.721: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-824c9722db", "properties": {}}'
+
+2020-12-24 16:29:58.731: Sending: 'PUT /city/cityName<test!>-c536184fc8 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 104\r\n\r\n{"properties":{"population":0,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":0}}}'
+
+2020-12-24 16:29:58.742: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-c536184fc8", "properties": {}}'
+
+2020-12-24 16:29:58.752: Sending: 'PUT /city/cityName<test!>-0955b8f0c6 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 112\r\n\r\n{"properties":{"population":false,"area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:58.762: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0955b8f0c6", "properties": {}}'
+
+2020-12-24 16:29:58.771: Sending: 'PUT /city/cityName<test!>-1072b3e2b4 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 97\r\n\r\n{"properties":{"population":0,"area":0,"strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:58.781: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-1072b3e2b4", "properties": {}}'
+
+2020-12-24 16:29:58.790: Sending: 'PUT /city/cityName<test!>-7690eb1879 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 119\r\n\r\n{"properties":{"population":"fuzzstring","area":"fuzzstring","strtest":"fuzzstring","subproperties":{"subtest":false}}}'
+
+2020-12-24 16:29:58.799: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-7690eb1879", "properties": {}}'
+
+2020-12-24 16:29:58.810: Sending: 'PUT /city/cityName<test!>-d92a009249 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 57\r\n\r\n{"properties":{"subproperties":{"subtest":"fuzzstring"}}}'
+
+2020-12-24 16:29:58.820: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-d92a009249", "properties": {}}'
+
+2020-12-24 16:29:58.830: Sending: 'PUT /city/cityName<test!>-53d8a9cc5d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 46\r\n\r\n{"properties":{"subproperties":{"subtest":0}}}'
+
+2020-12-24 16:29:58.839: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-53d8a9cc5d", "properties": {}}'
+
+2020-12-24 16:29:58.850: Sending: 'PUT /city/cityName<test!>-0ea686d3a9 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 34\r\n\r\n{"properties":{"subproperties":0}}'
+
+2020-12-24 16:29:58.859: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0ea686d3a9", "properties": {}}'
+
+2020-12-24 16:29:58.869: Sending: 'PUT /city/cityName<test!>-09782cee70 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 45\r\n\r\n{"properties":{"subproperties":"fuzzstring"}}'
+
+2020-12-24 16:29:58.880: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-09782cee70", "properties": {}}'
+
+2020-12-24 16:29:58.889: Sending: 'PUT /city/cityName<test!>-5e417daeb2 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 35\r\n\r\n{"properties":{"subproperties":[]}}'
+
+2020-12-24 16:29:58.899: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-5e417daeb2", "properties": {}}'
+
+2020-12-24 16:29:58.909: Sending: 'PUT /city/cityName<test!>-0f7774f439 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 51\r\n\r\n{"properties":{"subproperties":{ "fuzz" : false }}}'
+
+2020-12-24 16:29:58.917: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0f7774f439", "properties": {}}'
+
+2020-12-24 16:29:58.928: Sending: 'PUT /city/cityName<test!>-0e4f53f637 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 47\r\n\r\n{"properties":{"subproperties":{"subtest":[]}}}'
+
+2020-12-24 16:29:58.937: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0e4f53f637", "properties": {}}'
+
+2020-12-24 16:29:58.948: Sending: 'PUT /city/cityName<test!>-363c840c3b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 29\r\n\r\n{"properties":{"strtest":[]}}'
+
+2020-12-24 16:29:58.958: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-363c840c3b", "properties": {}}'
+
+2020-12-24 16:29:58.967: Sending: 'PUT /city/cityName<test!>-8aa71f24e3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 32\r\n\r\n{"properties":{"strtest":false}}'
+
+2020-12-24 16:29:58.977: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8aa71f24e3", "properties": {}}'
+
+2020-12-24 16:29:58.986: Sending: 'PUT /city/cityName<test!>-6639914240 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 28\r\n\r\n{"properties":{"strtest":0}}'
+
+2020-12-24 16:29:58.997: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-6639914240", "properties": {}}'
+
+2020-12-24 16:29:59.008: PayloadBodyChecker Tracker begin (Type):
+2020-12-24 16:29:59.020: PayloadBodyChecker     Valid: 52
+2020-12-24 16:29:59.031: PayloadBodyChecker     Invalid: 0
+2020-12-24 16:29:59.044: PayloadBodyChecker Tracker end
+2020-12-24 16:29:59.060: PayloadBodyChecker Task end Type
+2020-12-24 16:29:59.070: Checker: PayloadBodyChecker kicks out
+
+2020-12-24 16:29:59.079: Checker: ExamplesChecker kicks in
+
+2020-12-24 16:29:59.088: Checker: ExamplesChecker kicks out
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 16)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		+ restler_custom_payload_uuid4_suffix: cityName<test!>-
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"properties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"population":'
+		+ restler_fuzzable_int: ['"0"', '"1"']
+		- restler_static_string: ', "area": "5000",'
+		+ restler_fuzzable_string: ['"fuzzstring"', '"enable"']
+		- restler_static_string: ':'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: ',"subproperties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"subtest":'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 6)
+		- restler_static_string: 'GET '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		- restler_static_string: '_READER_DELIM_city_put_name_READER_DELIM'
+		- restler_static_string: '?'
+		- restler_static_string: 'location='
+		+ restler_custom_payload: ['centralus', '10']
+		- restler_static_string: '&'
+		- restler_static_string: 'group='
+		+ restler_fuzzable_group: ['A', 'BB', 'CCC']
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2020-12-24 16:29:59.769: Sending: 'PUT /city/cityName<test!>-b42abe78a5 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:29:59.779: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-b42abe78a5", "properties": {}}'
+
+2020-12-24 16:29:59.790: Sending: 'GET /city/cityName<test!>-b42abe78a5?location=centralus&group=A HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2020-12-24 16:29:59.806: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-b42abe78a5", "properties": {}}'
+
+2020-12-24 16:29:59.820: Checker: PayloadBodyChecker kicks in
+
+2020-12-24 16:29:59.831: Checker: PayloadBodyChecker kicks out
+
+2020-12-24 16:29:59.841: Checker: ExamplesChecker kicks in
+
+2020-12-24 16:29:59.850: Checker: ExamplesChecker kicks out
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 16)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		+ restler_custom_payload_uuid4_suffix: cityName<test!>-
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"properties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"population":'
+		+ restler_fuzzable_int: ['"0"', '"1"']
+		- restler_static_string: ', "area": "5000",'
+		+ restler_fuzzable_string: ['"fuzzstring"', '"enable"']
+		- restler_static_string: ':'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: ',"subproperties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"subtest":'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+		- restler_static_string: 'DELETE '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		- restler_static_string: '_READER_DELIM_city_put_name_READER_DELIM'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2020-12-24 16:30:00.413: Sending: 'PUT /city/cityName<test!>-4b44288701 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:00.422: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-4b44288701", "properties": {}}'
+
+2020-12-24 16:30:00.433: Sending: 'DELETE /city/cityName<test!>-4b44288701 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2020-12-24 16:30:00.444: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"cityName<test!>-4b44288701"'
+
+2020-12-24 16:30:00.455: Checker: PayloadBodyChecker kicks in
+
+2020-12-24 16:30:00.466: Checker: PayloadBodyChecker kicks out
+
+2020-12-24 16:30:00.475: Checker: ExamplesChecker kicks in
+
+2020-12-24 16:30:00.484: Checker: ExamplesChecker kicks out
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 16)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		+ restler_custom_payload_uuid4_suffix: cityName<test!>-
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"properties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"population":'
+		+ restler_fuzzable_int: ['"0"', '"1"']
+		- restler_static_string: ', "area": "5000",'
+		+ restler_fuzzable_string: ['"fuzzstring"', '"enable"']
+		- restler_static_string: ':'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: ',"subproperties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"subtest":'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		- restler_static_string: '_READER_DELIM_city_put_name_READER_DELIM'
+		- restler_static_string: '/'
+		- restler_static_string: 'house'
+		- restler_static_string: '/'
+		+ restler_custom_payload_uuid4_suffix: houseName<test!>-
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '['
+		- restler_static_string: '{'
+		- restler_static_string: '"house":'
+		+ restler_custom_payload_uuid4_suffix: "houseName<test!>-"
+		- restler_static_string: ',"group":'
+		+ restler_fuzzable_group: ['A', 'BB', 'CCC']
+		- restler_static_string: '}'
+		- restler_static_string: ','
+		- restler_static_string: '{'
+		- restler_static_string: '"arraytest":'
+		+ restler_custom_payload: ['"centralus"', '10']
+		- restler_static_string: '}'
+		- restler_static_string: ']'
+		- restler_static_string: '\r\n'
+
+2020-12-24 16:30:01.260: Sending: 'PUT /city/cityName<test!>-e4eabca1f9 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:01.269: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e4eabca1f9", "properties": {}}'
+
+2020-12-24 16:30:01.279: Sending: 'PUT /city/cityName<test!>-e4eabca1f9/house/houseName<test!>-8d15f4c251 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-8d15f4c251","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:01.288: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-8d15f4c251"}'
+
+2020-12-24 16:30:01.300: Checker: PayloadBodyChecker kicks in
+
+2020-12-24 16:30:01.316: PayloadBodyChecker Start fuzzing request: PUT /city/{cityName}/house/{houseName}
+2020-12-24 16:30:01.328: PayloadBodyChecker #node: 6
+2020-12-24 16:30:01.340: PayloadBodyChecker Fuzz using dynamic feedback
+2020-12-24 16:30:01.350: PayloadBodyChecker #N: 6, #max: 200, #width: 20
+2020-12-24 16:30:01.362: PayloadBodyChecker Task begin Invalid-JSON
+2020-12-24 16:30:01.373: Sending: 'PUT /city/cityName<test!>-e4eabca1f9/house/houseName<test!>-4235f97ee1 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 62\r\n\r\n[{"house":"fuzzstring","group":"A"},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:01.382: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4235f97ee1"}'
+
+2020-12-24 16:30:01.392: Re-rendering and sending start of sequence
+2020-12-24 16:30:01.402: Sending: 'PUT /city/cityName<test!>-e7b0da678d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:01.411: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e7b0da678d", "properties": {}}'
+
+2020-12-24 16:30:01.421: Sending: 'PUT /city/cityName<test!>-e7b0da678d/house/houseName<test!>-2c0c46d748 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-2c0c46d748","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:01.431: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-2c0c46d748"}'
+
+2020-12-24 16:30:01.443: Done refreshing the sequence
+2020-12-24 16:30:01.454: Sending: 'PUT /city/cityName<test!>-e7b0da678d/house/houseName<test!>-9178e8004e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 117\r\n\r\n[{"house":"houseName<test!>-4235f97ee1","house":"houseName<test!>-4235f97ee1","group":"A"},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:01.464: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9178e8004e"}'
+
+2020-12-24 16:30:01.475: Re-rendering and sending start of sequence
+2020-12-24 16:30:01.483: Sending: 'PUT /city/cityName<test!>-8628b6648f HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:01.493: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8628b6648f", "properties": {}}'
+
+2020-12-24 16:30:01.511: Sending: 'PUT /city/cityName<test!>-8628b6648f/house/houseName<test!>-6bd98e7a32 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-6bd98e7a32","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:01.523: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-6bd98e7a32"}'
+
+2020-12-24 16:30:01.540: Done refreshing the sequence
+2020-12-24 16:30:01.553: Sending: 'PUT /city/cityName<test!>-8628b6648f/house/houseName<test!>-79cdef21f3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 103\r\n\r\n[{"house":"houseName<test!>-9178e8004e","group":"A"},{"arraytest":"centralus","arraytest":"centralus"}]'
+
+2020-12-24 16:30:01.563: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-79cdef21f3"}'
+
+2020-12-24 16:30:01.572: Re-rendering and sending start of sequence
+2020-12-24 16:30:01.582: Sending: 'PUT /city/cityName<test!>-963facc4f6 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:01.592: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-963facc4f6", "properties": {}}'
+
+2020-12-24 16:30:01.602: Sending: 'PUT /city/cityName<test!>-963facc4f6/house/houseName<test!>-4ce14c6042 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-4ce14c6042","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:01.613: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4ce14c6042"}'
+
+2020-12-24 16:30:01.622: Done refreshing the sequence
+2020-12-24 16:30:01.632: Sending: 'PUT /city/cityName<test!>-963facc4f6/house/houseName<test!>-ba969b0c4c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 91\r\n\r\n[{"group":"A","house":"houseName<test!>-79cdef21f3","group":"A"},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:01.641: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-ba969b0c4c"}'
+
+2020-12-24 16:30:01.653: PayloadBodyChecker Tracker begin (Invalid-JSON):
+2020-12-24 16:30:01.663: PayloadBodyChecker     Valid: 4
+2020-12-24 16:30:01.678: PayloadBodyChecker     Invalid: 0
+2020-12-24 16:30:01.689: PayloadBodyChecker Tracker end
+2020-12-24 16:30:01.703: PayloadBodyChecker Task end Invalid-JSON
+
+2020-12-24 16:30:01.725: PayloadBodyChecker Task begin Structure
+2020-12-24 16:30:01.739: Re-rendering and sending start of sequence
+2020-12-24 16:30:01.750: Sending: 'PUT /city/cityName<test!>-2f993c6dea HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:01.759: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-2f993c6dea", "properties": {}}'
+
+2020-12-24 16:30:01.770: Sending: 'PUT /city/cityName<test!>-2f993c6dea/house/houseName<test!>-ee1e4bd3fd HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-ee1e4bd3fd","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:01.787: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-ee1e4bd3fd"}'
+
+2020-12-24 16:30:01.799: Done refreshing the sequence
+2020-12-24 16:30:01.810: Sending: 'PUT /city/cityName<test!>-2f993c6dea/house/houseName<test!>-7af14bd832 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 41\r\n\r\n[{"house":"houseName<test!>-ba969b0c4c"}]'
+
+2020-12-24 16:30:01.819: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-7af14bd832"}'
+
+2020-12-24 16:30:01.830: Re-rendering and sending start of sequence
+2020-12-24 16:30:01.840: Sending: 'PUT /city/cityName<test!>-8077663c49 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:01.852: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8077663c49", "properties": {}}'
+
+2020-12-24 16:30:01.863: Sending: 'PUT /city/cityName<test!>-8077663c49/house/houseName<test!>-1f2165c668 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-1f2165c668","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:01.873: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-1f2165c668"}'
+
+2020-12-24 16:30:01.883: Done refreshing the sequence
+2020-12-24 16:30:01.894: Sending: 'PUT /city/cityName<test!>-8077663c49/house/houseName<test!>-a2a5d3d6ef HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 41\r\n\r\n[{"group":"A"},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:01.911: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-a2a5d3d6ef"}'
+
+2020-12-24 16:30:01.923: Re-rendering and sending start of sequence
+2020-12-24 16:30:01.933: Sending: 'PUT /city/cityName<test!>-99bfd283f1 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:01.944: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-99bfd283f1", "properties": {}}'
+
+2020-12-24 16:30:01.954: Sending: 'PUT /city/cityName<test!>-99bfd283f1/house/houseName<test!>-a02bb857f3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-a02bb857f3","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:01.964: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-a02bb857f3"}'
+
+2020-12-24 16:30:01.974: Done refreshing the sequence
+2020-12-24 16:30:01.985: Sending: 'PUT /city/cityName<test!>-99bfd283f1/house/houseName<test!>-c62bdd517c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 67\r\n\r\n[{"house":"houseName<test!>-a2a5d3d6ef"},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:01.995: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-c62bdd517c"}'
+
+2020-12-24 16:30:02.006: Re-rendering and sending start of sequence
+2020-12-24 16:30:02.017: Sending: 'PUT /city/cityName<test!>-e200f92026 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:02.031: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e200f92026", "properties": {}}'
+
+2020-12-24 16:30:02.045: Sending: 'PUT /city/cityName<test!>-e200f92026/house/houseName<test!>-b2597b780d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-b2597b780d","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:02.056: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-b2597b780d"}'
+
+2020-12-24 16:30:02.069: Done refreshing the sequence
+2020-12-24 16:30:02.081: Sending: 'PUT /city/cityName<test!>-e200f92026/house/houseName<test!>-576e990c8b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 79\r\n\r\n[{"house":"houseName<test!>-c62bdd517c","group":"A"},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:02.093: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-576e990c8b"}'
+
+2020-12-24 16:30:02.104: Re-rendering and sending start of sequence
+2020-12-24 16:30:02.118: Sending: 'PUT /city/cityName<test!>-bf3b53ee9c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:02.132: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-bf3b53ee9c", "properties": {}}'
+
+2020-12-24 16:30:02.148: Sending: 'PUT /city/cityName<test!>-bf3b53ee9c/house/houseName<test!>-41cf40dc8a HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-41cf40dc8a","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:02.162: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-41cf40dc8a"}'
+
+2020-12-24 16:30:02.175: Done refreshing the sequence
+2020-12-24 16:30:02.192: Sending: 'PUT /city/cityName<test!>-bf3b53ee9c/house/houseName<test!>-ae58b681d0 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n[{"group":"A"}]'
+
+2020-12-24 16:30:02.204: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-ae58b681d0"}'
+
+2020-12-24 16:30:02.221: Re-rendering and sending start of sequence
+2020-12-24 16:30:02.235: Sending: 'PUT /city/cityName<test!>-4e68572dd0 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:02.249: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-4e68572dd0", "properties": {}}'
+
+2020-12-24 16:30:02.262: Sending: 'PUT /city/cityName<test!>-4e68572dd0/house/houseName<test!>-f03e9dec02 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-f03e9dec02","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:02.272: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f03e9dec02"}'
+
+2020-12-24 16:30:02.282: Done refreshing the sequence
+2020-12-24 16:30:02.291: Sending: 'PUT /city/cityName<test!>-4e68572dd0/house/houseName<test!>-677fd9bae1 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 53\r\n\r\n[{"house":"houseName<test!>-ae58b681d0","group":"A"}]'
+
+2020-12-24 16:30:02.300: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-677fd9bae1"}'
+
+2020-12-24 16:30:02.311: Re-rendering and sending start of sequence
+2020-12-24 16:30:02.321: Sending: 'PUT /city/cityName<test!>-7cb3e86516 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:02.330: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-7cb3e86516", "properties": {}}'
+
+2020-12-24 16:30:02.339: Sending: 'PUT /city/cityName<test!>-7cb3e86516/house/houseName<test!>-7bde5046e9 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-7bde5046e9","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:02.350: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-7bde5046e9"}'
+
+2020-12-24 16:30:02.359: Done refreshing the sequence
+2020-12-24 16:30:02.369: Sending: 'PUT /city/cityName<test!>-7cb3e86516/house/houseName<test!>-3ba55aff0b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 27\r\n\r\n[{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:02.379: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-3ba55aff0b"}'
+
+2020-12-24 16:30:02.391: PayloadBodyChecker Tracker begin (Structure):
+2020-12-24 16:30:02.401: PayloadBodyChecker     Valid: 7
+2020-12-24 16:30:02.412: PayloadBodyChecker     Invalid: 0
+2020-12-24 16:30:02.423: PayloadBodyChecker Tracker end
+2020-12-24 16:30:02.434: PayloadBodyChecker Task end Structure
+
+2020-12-24 16:30:02.445: PayloadBodyChecker Task begin Type
+2020-12-24 16:30:02.459: Re-rendering and sending start of sequence
+2020-12-24 16:30:02.470: Sending: 'PUT /city/cityName<test!>-42fda8f5ce HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:02.481: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-42fda8f5ce", "properties": {}}'
+
+2020-12-24 16:30:02.490: Sending: 'PUT /city/cityName<test!>-42fda8f5ce/house/houseName<test!>-2ff63f1263 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-2ff63f1263","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:02.499: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-2ff63f1263"}'
+
+2020-12-24 16:30:02.510: Done refreshing the sequence
+2020-12-24 16:30:02.521: Sending: 'PUT /city/cityName<test!>-42fda8f5ce/house/houseName<test!>-fe05ab1ea5 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 30\r\n\r\n[{"house":{ "fuzz" : false }}]'
+
+2020-12-24 16:30:02.530: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-fe05ab1ea5"}'
+
+2020-12-24 16:30:02.540: Re-rendering and sending start of sequence
+2020-12-24 16:30:02.549: Sending: 'PUT /city/cityName<test!>-d3b62c604d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:02.561: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-d3b62c604d", "properties": {}}'
+
+2020-12-24 16:30:02.570: Sending: 'PUT /city/cityName<test!>-d3b62c604d/house/houseName<test!>-d59c4e0be3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-d59c4e0be3","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:02.580: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-d59c4e0be3"}'
+
+2020-12-24 16:30:02.588: Done refreshing the sequence
+2020-12-24 16:30:02.599: Sending: 'PUT /city/cityName<test!>-d3b62c604d/house/houseName<test!>-5d429cfe45 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 5\r\n\r\nfalse'
+
+2020-12-24 16:30:02.619: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-5d429cfe45"}'
+
+2020-12-24 16:30:02.637: Re-rendering and sending start of sequence
+2020-12-24 16:30:02.648: Sending: 'PUT /city/cityName<test!>-84e3e5d234 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:02.659: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-84e3e5d234", "properties": {}}'
+
+2020-12-24 16:30:02.677: Sending: 'PUT /city/cityName<test!>-84e3e5d234/house/houseName<test!>-30dd3057cc HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-30dd3057cc","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:02.690: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-30dd3057cc"}'
+
+2020-12-24 16:30:02.709: Done refreshing the sequence
+2020-12-24 16:30:02.721: Sending: 'PUT /city/cityName<test!>-84e3e5d234/house/houseName<test!>-6d99efa298 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 7\r\n\r\n[false]'
+
+2020-12-24 16:30:02.731: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-6d99efa298"}'
+
+2020-12-24 16:30:02.743: Re-rendering and sending start of sequence
+2020-12-24 16:30:02.752: Sending: 'PUT /city/cityName<test!>-ca99aa1584 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:02.762: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-ca99aa1584", "properties": {}}'
+
+2020-12-24 16:30:02.771: Sending: 'PUT /city/cityName<test!>-ca99aa1584/house/houseName<test!>-ebd75bb9a1 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-ebd75bb9a1","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:02.781: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-ebd75bb9a1"}'
+
+2020-12-24 16:30:02.790: Done refreshing the sequence
+2020-12-24 16:30:02.799: Sending: 'PUT /city/cityName<test!>-ca99aa1584/house/houseName<test!>-2d6844b5d3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 21\r\n\r\n[{"group":"A"},false]'
+
+2020-12-24 16:30:02.809: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-2d6844b5d3"}'
+
+2020-12-24 16:30:02.818: Re-rendering and sending start of sequence
+2020-12-24 16:30:02.830: Sending: 'PUT /city/cityName<test!>-5244704347 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:02.847: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-5244704347", "properties": {}}'
+
+2020-12-24 16:30:02.858: Sending: 'PUT /city/cityName<test!>-5244704347/house/houseName<test!>-e0f4d53b5c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-e0f4d53b5c","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:02.869: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-e0f4d53b5c"}'
+
+2020-12-24 16:30:02.886: Done refreshing the sequence
+2020-12-24 16:30:02.898: Sending: 'PUT /city/cityName<test!>-5244704347/house/houseName<test!>-8176769514 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 33\r\n\r\n[false,{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:02.908: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-8176769514"}'
+
+2020-12-24 16:30:02.920: Re-rendering and sending start of sequence
+2020-12-24 16:30:02.940: Sending: 'PUT /city/cityName<test!>-7d7a64b9f2 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:02.952: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-7d7a64b9f2", "properties": {}}'
+
+2020-12-24 16:30:02.962: Sending: 'PUT /city/cityName<test!>-7d7a64b9f2/house/houseName<test!>-e3321bae5b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-e3321bae5b","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:02.971: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-e3321bae5b"}'
+
+2020-12-24 16:30:02.980: Done refreshing the sequence
+2020-12-24 16:30:02.989: Sending: 'PUT /city/cityName<test!>-7d7a64b9f2/house/houseName<test!>-ed57892e2c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 48\r\n\r\n[{"group":"A"},{"arraytest":{ "fuzz" : false }}]'
+
+2020-12-24 16:30:03.006: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-ed57892e2c"}'
+
+2020-12-24 16:30:03.018: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.029: Sending: 'PUT /city/cityName<test!>-806c93d040 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.038: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-806c93d040", "properties": {}}'
+
+2020-12-24 16:30:03.049: Sending: 'PUT /city/cityName<test!>-806c93d040/house/houseName<test!>-a6771cf315 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-a6771cf315","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.059: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-a6771cf315"}'
+
+2020-12-24 16:30:03.068: Done refreshing the sequence
+2020-12-24 16:30:03.079: Sending: 'PUT /city/cityName<test!>-806c93d040/house/houseName<test!>-f44d3e7d0c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 74\r\n\r\n[{"house":"houseName<test!>-ed57892e2c"},{"arraytest":{ "fuzz" : false }}]'
+
+2020-12-24 16:30:03.090: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f44d3e7d0c"}'
+
+2020-12-24 16:30:03.105: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.120: Sending: 'PUT /city/cityName<test!>-a44f8ec0af HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.135: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a44f8ec0af", "properties": {}}'
+
+2020-12-24 16:30:03.149: Sending: 'PUT /city/cityName<test!>-a44f8ec0af/house/houseName<test!>-98d996e975 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-98d996e975","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.160: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-98d996e975"}'
+
+2020-12-24 16:30:03.173: Done refreshing the sequence
+2020-12-24 16:30:03.186: Sending: 'PUT /city/cityName<test!>-a44f8ec0af/house/houseName<test!>-07d6891453 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 56\r\n\r\n[{"house":{ "fuzz" : false }},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:03.200: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-07d6891453"}'
+
+2020-12-24 16:30:03.211: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.224: Sending: 'PUT /city/cityName<test!>-e6607362a1 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.233: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e6607362a1", "properties": {}}'
+
+2020-12-24 16:30:03.251: Sending: 'PUT /city/cityName<test!>-e6607362a1/house/houseName<test!>-18b6fb1ba3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-18b6fb1ba3","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.263: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-18b6fb1ba3"}'
+
+2020-12-24 16:30:03.273: Done refreshing the sequence
+2020-12-24 16:30:03.282: Sending: 'PUT /city/cityName<test!>-e6607362a1/house/houseName<test!>-f99dba77b6 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 47\r\n\r\n[{"house":"houseName<test!>-07d6891453"},false]'
+
+2020-12-24 16:30:03.291: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f99dba77b6"}'
+
+2020-12-24 16:30:03.302: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.312: Sending: 'PUT /city/cityName<test!>-531c873180 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.321: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-531c873180", "properties": {}}'
+
+2020-12-24 16:30:03.330: Sending: 'PUT /city/cityName<test!>-531c873180/house/houseName<test!>-b2cc260119 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-b2cc260119","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.339: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-b2cc260119"}'
+
+2020-12-24 16:30:03.349: Done refreshing the sequence
+2020-12-24 16:30:03.358: Sending: 'PUT /city/cityName<test!>-531c873180/house/houseName<test!>-682a840d6e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 86\r\n\r\n[{"house":"houseName<test!>-f99dba77b6","group":"A"},{"arraytest":{ "fuzz" : false }}]'
+
+2020-12-24 16:30:03.368: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-682a840d6e"}'
+
+2020-12-24 16:30:03.377: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.387: Sending: 'PUT /city/cityName<test!>-86432e76a5 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.398: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-86432e76a5", "properties": {}}'
+
+2020-12-24 16:30:03.408: Sending: 'PUT /city/cityName<test!>-86432e76a5/house/houseName<test!>-58256b07b6 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-58256b07b6","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.418: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-58256b07b6"}'
+
+2020-12-24 16:30:03.427: Done refreshing the sequence
+2020-12-24 16:30:03.436: Sending: 'PUT /city/cityName<test!>-86432e76a5/house/houseName<test!>-774879ed25 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 68\r\n\r\n[{"house":{ "fuzz" : false },"group":"A"},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:03.446: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-774879ed25"}'
+
+2020-12-24 16:30:03.456: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.466: Sending: 'PUT /city/cityName<test!>-baa6fd2928 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.476: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-baa6fd2928", "properties": {}}'
+
+2020-12-24 16:30:03.486: Sending: 'PUT /city/cityName<test!>-baa6fd2928/house/houseName<test!>-e2ebc60192 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-e2ebc60192","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.496: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-e2ebc60192"}'
+
+2020-12-24 16:30:03.505: Done refreshing the sequence
+2020-12-24 16:30:03.515: Sending: 'PUT /city/cityName<test!>-baa6fd2928/house/houseName<test!>-4878aeaa34 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 59\r\n\r\n[{"house":"houseName<test!>-774879ed25","group":"A"},false]'
+
+2020-12-24 16:30:03.524: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4878aeaa34"}'
+
+2020-12-24 16:30:03.534: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.543: Sending: 'PUT /city/cityName<test!>-8e9954594d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.552: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8e9954594d", "properties": {}}'
+
+2020-12-24 16:30:03.561: Sending: 'PUT /city/cityName<test!>-8e9954594d/house/houseName<test!>-00783623da HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-00783623da","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.570: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-00783623da"}'
+
+2020-12-24 16:30:03.579: Done refreshing the sequence
+2020-12-24 16:30:03.588: Sending: 'PUT /city/cityName<test!>-8e9954594d/house/houseName<test!>-9338ab2a8c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 42\r\n\r\n[{"house":{ "fuzz" : false },"group":"A"}]'
+
+2020-12-24 16:30:03.597: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9338ab2a8c"}'
+
+2020-12-24 16:30:03.607: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.616: Sending: 'PUT /city/cityName<test!>-06ee7b86d1 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.625: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-06ee7b86d1", "properties": {}}'
+
+2020-12-24 16:30:03.634: Sending: 'PUT /city/cityName<test!>-06ee7b86d1/house/houseName<test!>-2b13ea18c8 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-2b13ea18c8","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.643: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-2b13ea18c8"}'
+
+2020-12-24 16:30:03.652: Done refreshing the sequence
+2020-12-24 16:30:03.661: Sending: 'PUT /city/cityName<test!>-06ee7b86d1/house/houseName<test!>-9990ed1bad HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 34\r\n\r\n[{"arraytest":{ "fuzz" : false }}]'
+
+2020-12-24 16:30:03.670: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9990ed1bad"}'
+
+2020-12-24 16:30:03.680: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.689: Sending: 'PUT /city/cityName<test!>-0b451f8dcb HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.698: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-0b451f8dcb", "properties": {}}'
+
+2020-12-24 16:30:03.707: Sending: 'PUT /city/cityName<test!>-0b451f8dcb/house/houseName<test!>-6931ec48d5 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-6931ec48d5","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.716: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-6931ec48d5"}'
+
+2020-12-24 16:30:03.725: Done refreshing the sequence
+2020-12-24 16:30:03.734: Sending: 'PUT /city/cityName<test!>-0b451f8dcb/house/houseName<test!>-5c66e89b10 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 14\r\n\r\n[{"house":[]}]'
+
+2020-12-24 16:30:03.744: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-5c66e89b10"}'
+
+2020-12-24 16:30:03.753: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.762: Sending: 'PUT /city/cityName<test!>-fdea27212b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.771: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-fdea27212b", "properties": {}}'
+
+2020-12-24 16:30:03.780: Sending: 'PUT /city/cityName<test!>-fdea27212b/house/houseName<test!>-2791797be9 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-2791797be9","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.789: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-2791797be9"}'
+
+2020-12-24 16:30:03.799: Done refreshing the sequence
+2020-12-24 16:30:03.809: Sending: 'PUT /city/cityName<test!>-fdea27212b/house/houseName<test!>-d2821462a4 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 1\r\n\r\n0'
+
+2020-12-24 16:30:03.818: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-d2821462a4"}'
+
+2020-12-24 16:30:03.839: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.851: Sending: 'PUT /city/cityName<test!>-f4b8e7a6dd HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.861: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-f4b8e7a6dd", "properties": {}}'
+
+2020-12-24 16:30:03.871: Sending: 'PUT /city/cityName<test!>-f4b8e7a6dd/house/houseName<test!>-7347c9711e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-7347c9711e","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.881: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-7347c9711e"}'
+
+2020-12-24 16:30:03.889: Done refreshing the sequence
+2020-12-24 16:30:03.899: Sending: 'PUT /city/cityName<test!>-f4b8e7a6dd/house/houseName<test!>-763c4891cb HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 3\r\n\r\n[0]'
+
+2020-12-24 16:30:03.919: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-763c4891cb"}'
+
+2020-12-24 16:30:03.932: Re-rendering and sending start of sequence
+2020-12-24 16:30:03.945: Sending: 'PUT /city/cityName<test!>-936e3a5055 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:03.955: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-936e3a5055", "properties": {}}'
+
+2020-12-24 16:30:03.967: Sending: 'PUT /city/cityName<test!>-936e3a5055/house/houseName<test!>-23d26d0739 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-23d26d0739","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:03.977: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-23d26d0739"}'
+
+2020-12-24 16:30:03.986: Done refreshing the sequence
+2020-12-24 16:30:03.996: Sending: 'PUT /city/cityName<test!>-936e3a5055/house/houseName<test!>-fcfc658793 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 12\r\n\r\n"fuzzstring"'
+
+2020-12-24 16:30:04.006: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-fcfc658793"}'
+
+2020-12-24 16:30:04.016: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.027: Sending: 'PUT /city/cityName<test!>-8a7bbcd482 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.036: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8a7bbcd482", "properties": {}}'
+
+2020-12-24 16:30:04.048: Sending: 'PUT /city/cityName<test!>-8a7bbcd482/house/houseName<test!>-60b81c02a5 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-60b81c02a5","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.057: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-60b81c02a5"}'
+
+2020-12-24 16:30:04.065: Done refreshing the sequence
+2020-12-24 16:30:04.075: Sending: 'PUT /city/cityName<test!>-8a7bbcd482/house/houseName<test!>-310da4c153 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 17\r\n\r\n[{"house":false}]'
+
+2020-12-24 16:30:04.084: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-310da4c153"}'
+
+2020-12-24 16:30:04.095: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.105: Sending: 'PUT /city/cityName<test!>-093c5d6548 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.116: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-093c5d6548", "properties": {}}'
+
+2020-12-24 16:30:04.125: Sending: 'PUT /city/cityName<test!>-093c5d6548/house/houseName<test!>-c77f7960f8 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-c77f7960f8","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.136: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-c77f7960f8"}'
+
+2020-12-24 16:30:04.147: Done refreshing the sequence
+2020-12-24 16:30:04.157: Sending: 'PUT /city/cityName<test!>-093c5d6548/house/houseName<test!>-65a3d08a1b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 13\r\n\r\n[{"house":0}]'
+
+2020-12-24 16:30:04.167: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-65a3d08a1b"}'
+
+2020-12-24 16:30:04.177: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.187: Sending: 'PUT /city/cityName<test!>-46b72a4e56 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.197: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-46b72a4e56", "properties": {}}'
+
+2020-12-24 16:30:04.207: Sending: 'PUT /city/cityName<test!>-46b72a4e56/house/houseName<test!>-6569af59cd HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-6569af59cd","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.217: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-6569af59cd"}'
+
+2020-12-24 16:30:04.226: Done refreshing the sequence
+2020-12-24 16:30:04.236: Sending: 'PUT /city/cityName<test!>-46b72a4e56/house/houseName<test!>-642d139544 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 4\r\n\r\n[[]]'
+
+2020-12-24 16:30:04.245: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-642d139544"}'
+
+2020-12-24 16:30:04.254: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.265: Sending: 'PUT /city/cityName<test!>-2b151d2185 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.274: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-2b151d2185", "properties": {}}'
+
+2020-12-24 16:30:04.285: Sending: 'PUT /city/cityName<test!>-2b151d2185/house/houseName<test!>-ce7e4ffd52 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-ce7e4ffd52","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.309: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-ce7e4ffd52"}'
+
+2020-12-24 16:30:04.323: Done refreshing the sequence
+2020-12-24 16:30:04.335: Sending: 'PUT /city/cityName<test!>-2b151d2185/house/houseName<test!>-e8bf869f3e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 20\r\n\r\n[{ "fuzz" : false }]'
+
+2020-12-24 16:30:04.346: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-e8bf869f3e"}'
+
+2020-12-24 16:30:04.356: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.366: Sending: 'PUT /city/cityName<test!>-6569af7c3d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.375: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-6569af7c3d", "properties": {}}'
+
+2020-12-24 16:30:04.384: Sending: 'PUT /city/cityName<test!>-6569af7c3d/house/houseName<test!>-d79cf73d77 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-d79cf73d77","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.393: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-d79cf73d77"}'
+
+2020-12-24 16:30:04.402: Done refreshing the sequence
+2020-12-24 16:30:04.413: Sending: 'PUT /city/cityName<test!>-6569af7c3d/house/houseName<test!>-4b12f17156 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 18\r\n\r\n{ "fuzz" : false }'
+
+2020-12-24 16:30:04.422: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4b12f17156"}'
+
+2020-12-24 16:30:04.432: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.442: Sending: 'PUT /city/cityName<test!>-ef347facd2 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.451: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-ef347facd2", "properties": {}}'
+
+2020-12-24 16:30:04.461: Sending: 'PUT /city/cityName<test!>-ef347facd2/house/houseName<test!>-71ac285832 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-71ac285832","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.470: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-71ac285832"}'
+
+2020-12-24 16:30:04.480: Done refreshing the sequence
+2020-12-24 16:30:04.489: Sending: 'PUT /city/cityName<test!>-ef347facd2/house/houseName<test!>-19817bd1d6 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 14\r\n\r\n["fuzzstring"]'
+
+2020-12-24 16:30:04.498: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-19817bd1d6"}'
+
+2020-12-24 16:30:04.508: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.518: Sending: 'PUT /city/cityName<test!>-ae964b9a8e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.527: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-ae964b9a8e", "properties": {}}'
+
+2020-12-24 16:30:04.536: Sending: 'PUT /city/cityName<test!>-ae964b9a8e/house/houseName<test!>-d6689fc651 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-d6689fc651","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.545: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-d6689fc651"}'
+
+2020-12-24 16:30:04.556: Done refreshing the sequence
+2020-12-24 16:30:04.567: Sending: 'PUT /city/cityName<test!>-ae964b9a8e/house/houseName<test!>-1e44dac32e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 28\r\n\r\n[{"group":"A"},"fuzzstring"]'
+
+2020-12-24 16:30:04.578: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-1e44dac32e"}'
+
+2020-12-24 16:30:04.587: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.597: Sending: 'PUT /city/cityName<test!>-a2635805a9 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.607: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a2635805a9", "properties": {}}'
+
+2020-12-24 16:30:04.617: Sending: 'PUT /city/cityName<test!>-a2635805a9/house/houseName<test!>-f4c6933adb HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-f4c6933adb","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.626: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f4c6933adb"}'
+
+2020-12-24 16:30:04.636: Done refreshing the sequence
+2020-12-24 16:30:04.645: Sending: 'PUT /city/cityName<test!>-a2635805a9/house/houseName<test!>-5aaa582f74 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 29\r\n\r\n[0,{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:04.653: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-5aaa582f74"}'
+
+2020-12-24 16:30:04.663: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.672: Sending: 'PUT /city/cityName<test!>-59809f6937 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.681: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-59809f6937", "properties": {}}'
+
+2020-12-24 16:30:04.690: Sending: 'PUT /city/cityName<test!>-59809f6937/house/houseName<test!>-3caf3d22fc HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-3caf3d22fc","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.698: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-3caf3d22fc"}'
+
+2020-12-24 16:30:04.708: Done refreshing the sequence
+2020-12-24 16:30:04.717: Sending: 'PUT /city/cityName<test!>-59809f6937/house/houseName<test!>-be3007b61c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 17\r\n\r\n[{"group":"A"},0]'
+
+2020-12-24 16:30:04.727: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-be3007b61c"}'
+
+2020-12-24 16:30:04.736: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.746: Sending: 'PUT /city/cityName<test!>-8aa9c404eb HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.756: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8aa9c404eb", "properties": {}}'
+
+2020-12-24 16:30:04.766: Sending: 'PUT /city/cityName<test!>-8aa9c404eb/house/houseName<test!>-d52c2a2d92 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-d52c2a2d92","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.776: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-d52c2a2d92"}'
+
+2020-12-24 16:30:04.785: Done refreshing the sequence
+2020-12-24 16:30:04.795: Sending: 'PUT /city/cityName<test!>-8aa9c404eb/house/houseName<test!>-20483ff3aa HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 32\r\n\r\n[{"group":"A"},{"arraytest":[]}]'
+
+2020-12-24 16:30:04.804: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-20483ff3aa"}'
+
+2020-12-24 16:30:04.814: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.824: Sending: 'PUT /city/cityName<test!>-4fb1024dbb HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.833: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-4fb1024dbb", "properties": {}}'
+
+2020-12-24 16:30:04.843: Sending: 'PUT /city/cityName<test!>-4fb1024dbb/house/houseName<test!>-428e248ad3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-428e248ad3","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.853: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-428e248ad3"}'
+
+2020-12-24 16:30:04.864: Done refreshing the sequence
+2020-12-24 16:30:04.874: Sending: 'PUT /city/cityName<test!>-4fb1024dbb/house/houseName<test!>-3e6259415c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 35\r\n\r\n[{"group":"A"},{"arraytest":false}]'
+
+2020-12-24 16:30:04.884: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-3e6259415c"}'
+
+2020-12-24 16:30:04.894: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.903: Sending: 'PUT /city/cityName<test!>-1435e64337 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:04.913: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-1435e64337", "properties": {}}'
+
+2020-12-24 16:30:04.923: Sending: 'PUT /city/cityName<test!>-1435e64337/house/houseName<test!>-486efb4e8b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-486efb4e8b","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:04.933: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-486efb4e8b"}'
+
+2020-12-24 16:30:04.945: Done refreshing the sequence
+2020-12-24 16:30:04.955: Sending: 'PUT /city/cityName<test!>-1435e64337/house/houseName<test!>-819a1ed804 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 30\r\n\r\n[[],{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:04.967: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-819a1ed804"}'
+
+2020-12-24 16:30:04.978: Re-rendering and sending start of sequence
+2020-12-24 16:30:04.988: Sending: 'PUT /city/cityName<test!>-d2bd18aad7 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.000: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-d2bd18aad7", "properties": {}}'
+
+2020-12-24 16:30:05.012: Sending: 'PUT /city/cityName<test!>-d2bd18aad7/house/houseName<test!>-4fd8c68d7f HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-4fd8c68d7f","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.024: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4fd8c68d7f"}'
+
+2020-12-24 16:30:05.035: Done refreshing the sequence
+2020-12-24 16:30:05.048: Sending: 'PUT /city/cityName<test!>-d2bd18aad7/house/houseName<test!>-7bf073eaf7 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 31\r\n\r\n[{"group":"A"},{"arraytest":0}]'
+
+2020-12-24 16:30:05.058: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-7bf073eaf7"}'
+
+2020-12-24 16:30:05.069: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.080: Sending: 'PUT /city/cityName<test!>-88fef2907a HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.089: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-88fef2907a", "properties": {}}'
+
+2020-12-24 16:30:05.099: Sending: 'PUT /city/cityName<test!>-88fef2907a/house/houseName<test!>-6c9d7b0fd9 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-6c9d7b0fd9","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.108: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-6c9d7b0fd9"}'
+
+2020-12-24 16:30:05.117: Done refreshing the sequence
+2020-12-24 16:30:05.127: Sending: 'PUT /city/cityName<test!>-88fef2907a/house/houseName<test!>-f4760808e2 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 46\r\n\r\n[{ "fuzz" : false },{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:05.137: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f4760808e2"}'
+
+2020-12-24 16:30:05.147: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.157: Sending: 'PUT /city/cityName<test!>-d36b8a7191 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.166: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-d36b8a7191", "properties": {}}'
+
+2020-12-24 16:30:05.175: Sending: 'PUT /city/cityName<test!>-d36b8a7191/house/houseName<test!>-e87b9c5348 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-e87b9c5348","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.184: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-e87b9c5348"}'
+
+2020-12-24 16:30:05.194: Done refreshing the sequence
+2020-12-24 16:30:05.203: Sending: 'PUT /city/cityName<test!>-d36b8a7191/house/houseName<test!>-4de41b53c9 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 40\r\n\r\n["fuzzstring",{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:05.212: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4de41b53c9"}'
+
+2020-12-24 16:30:05.222: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.231: Sending: 'PUT /city/cityName<test!>-b1369bc69c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.241: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-b1369bc69c", "properties": {}}'
+
+2020-12-24 16:30:05.250: Sending: 'PUT /city/cityName<test!>-b1369bc69c/house/houseName<test!>-272eb33e92 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-272eb33e92","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.260: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-272eb33e92"}'
+
+2020-12-24 16:30:05.269: Done refreshing the sequence
+2020-12-24 16:30:05.279: Sending: 'PUT /city/cityName<test!>-b1369bc69c/house/houseName<test!>-6deb02aff4 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 34\r\n\r\n[{"group":"A"},{ "fuzz" : false }]'
+
+2020-12-24 16:30:05.289: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-6deb02aff4"}'
+
+2020-12-24 16:30:05.299: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.308: Sending: 'PUT /city/cityName<test!>-1a0ef54b63 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.317: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-1a0ef54b63", "properties": {}}'
+
+2020-12-24 16:30:05.326: Sending: 'PUT /city/cityName<test!>-1a0ef54b63/house/houseName<test!>-6b2839f00e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-6b2839f00e","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.337: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-6b2839f00e"}'
+
+2020-12-24 16:30:05.347: Done refreshing the sequence
+2020-12-24 16:30:05.355: Sending: 'PUT /city/cityName<test!>-1a0ef54b63/house/houseName<test!>-b6e0086bef HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 18\r\n\r\n[{"group":"A"},[]]'
+
+2020-12-24 16:30:05.365: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-b6e0086bef"}'
+
+2020-12-24 16:30:05.376: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.386: Sending: 'PUT /city/cityName<test!>-e496f38a13 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.396: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-e496f38a13", "properties": {}}'
+
+2020-12-24 16:30:05.406: Sending: 'PUT /city/cityName<test!>-e496f38a13/house/houseName<test!>-a9fa1d5307 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-a9fa1d5307","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.416: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-a9fa1d5307"}'
+
+2020-12-24 16:30:05.425: Done refreshing the sequence
+2020-12-24 16:30:05.435: Sending: 'PUT /city/cityName<test!>-e496f38a13/house/houseName<test!>-6358554c34 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 39\r\n\r\n[{"house":0},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:05.444: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-6358554c34"}'
+
+2020-12-24 16:30:05.455: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.465: Sending: 'PUT /city/cityName<test!>-3f3b32aa9b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.475: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3f3b32aa9b", "properties": {}}'
+
+2020-12-24 16:30:05.485: Sending: 'PUT /city/cityName<test!>-3f3b32aa9b/house/houseName<test!>-c6e79bc87b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-c6e79bc87b","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.494: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-c6e79bc87b"}'
+
+2020-12-24 16:30:05.503: Done refreshing the sequence
+2020-12-24 16:30:05.512: Sending: 'PUT /city/cityName<test!>-3f3b32aa9b/house/houseName<test!>-3500a171c5 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 43\r\n\r\n[{"house":"houseName<test!>-6358554c34"},0]'
+
+2020-12-24 16:30:05.522: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-3500a171c5"}'
+
+2020-12-24 16:30:05.533: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.542: Sending: 'PUT /city/cityName<test!>-73d90f1f17 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.551: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-73d90f1f17", "properties": {}}'
+
+2020-12-24 16:30:05.560: Sending: 'PUT /city/cityName<test!>-73d90f1f17/house/houseName<test!>-8a6d7c5e4c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-8a6d7c5e4c","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.569: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-8a6d7c5e4c"}'
+
+2020-12-24 16:30:05.579: Done refreshing the sequence
+2020-12-24 16:30:05.589: Sending: 'PUT /city/cityName<test!>-73d90f1f17/house/houseName<test!>-1c37136320 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 40\r\n\r\n[{"house":[]},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:05.599: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-1c37136320"}'
+
+2020-12-24 16:30:05.609: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.619: Sending: 'PUT /city/cityName<test!>-fc137e1276 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.629: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-fc137e1276", "properties": {}}'
+
+2020-12-24 16:30:05.639: Sending: 'PUT /city/cityName<test!>-fc137e1276/house/houseName<test!>-da351a6a94 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-da351a6a94","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.649: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-da351a6a94"}'
+
+2020-12-24 16:30:05.658: Done refreshing the sequence
+2020-12-24 16:30:05.667: Sending: 'PUT /city/cityName<test!>-fc137e1276/house/houseName<test!>-57b383633c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 58\r\n\r\n[{"house":"houseName<test!>-1c37136320"},{"arraytest":[]}]'
+
+2020-12-24 16:30:05.678: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-57b383633c"}'
+
+2020-12-24 16:30:05.688: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.698: Sending: 'PUT /city/cityName<test!>-d1f8b724a2 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.708: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-d1f8b724a2", "properties": {}}'
+
+2020-12-24 16:30:05.718: Sending: 'PUT /city/cityName<test!>-d1f8b724a2/house/houseName<test!>-f04c68ed5d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-f04c68ed5d","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.728: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f04c68ed5d"}'
+
+2020-12-24 16:30:05.737: Done refreshing the sequence
+2020-12-24 16:30:05.748: Sending: 'PUT /city/cityName<test!>-d1f8b724a2/house/houseName<test!>-d1c4989182 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 61\r\n\r\n[{"house":"houseName<test!>-57b383633c"},{"arraytest":false}]'
+
+2020-12-24 16:30:05.757: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-d1c4989182"}'
+
+2020-12-24 16:30:05.768: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.778: Sending: 'PUT /city/cityName<test!>-3070d9b326 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.787: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-3070d9b326", "properties": {}}'
+
+2020-12-24 16:30:05.797: Sending: 'PUT /city/cityName<test!>-3070d9b326/house/houseName<test!>-2ed367c605 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-2ed367c605","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.806: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-2ed367c605"}'
+
+2020-12-24 16:30:05.816: Done refreshing the sequence
+2020-12-24 16:30:05.825: Sending: 'PUT /city/cityName<test!>-3070d9b326/house/houseName<test!>-904b32bc53 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 57\r\n\r\n[{"house":"houseName<test!>-d1c4989182"},{"arraytest":0}]'
+
+2020-12-24 16:30:05.834: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-904b32bc53"}'
+
+2020-12-24 16:30:05.845: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.854: Sending: 'PUT /city/cityName<test!>-66211745b8 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.864: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-66211745b8", "properties": {}}'
+
+2020-12-24 16:30:05.873: Sending: 'PUT /city/cityName<test!>-66211745b8/house/houseName<test!>-012c9d4499 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-012c9d4499","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.883: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-012c9d4499"}'
+
+2020-12-24 16:30:05.892: Done refreshing the sequence
+2020-12-24 16:30:05.901: Sending: 'PUT /city/cityName<test!>-66211745b8/house/houseName<test!>-11fadabaec HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 43\r\n\r\n[{"house":false},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:05.910: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-11fadabaec"}'
+
+2020-12-24 16:30:05.920: Re-rendering and sending start of sequence
+2020-12-24 16:30:05.932: Sending: 'PUT /city/cityName<test!>-da523e5da0 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:05.942: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-da523e5da0", "properties": {}}'
+
+2020-12-24 16:30:05.953: Sending: 'PUT /city/cityName<test!>-da523e5da0/house/houseName<test!>-839bedd151 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-839bedd151","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:05.963: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-839bedd151"}'
+
+2020-12-24 16:30:05.972: Done refreshing the sequence
+2020-12-24 16:30:05.982: Sending: 'PUT /city/cityName<test!>-da523e5da0/house/houseName<test!>-74341c2f6f HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 60\r\n\r\n[{"house":"houseName<test!>-11fadabaec"},{ "fuzz" : false }]'
+
+2020-12-24 16:30:05.991: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-74341c2f6f"}'
+
+2020-12-24 16:30:06.001: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.012: Sending: 'PUT /city/cityName<test!>-fed5cb9741 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.022: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-fed5cb9741", "properties": {}}'
+
+2020-12-24 16:30:06.032: Sending: 'PUT /city/cityName<test!>-fed5cb9741/house/houseName<test!>-f724df8b35 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-f724df8b35","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.042: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-f724df8b35"}'
+
+2020-12-24 16:30:06.052: Done refreshing the sequence
+2020-12-24 16:30:06.062: Sending: 'PUT /city/cityName<test!>-fed5cb9741/house/houseName<test!>-777ebb3955 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 44\r\n\r\n[{"house":"houseName<test!>-74341c2f6f"},[]]'
+
+2020-12-24 16:30:06.071: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-777ebb3955"}'
+
+2020-12-24 16:30:06.082: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.091: Sending: 'PUT /city/cityName<test!>-75b90fd77a HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.100: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-75b90fd77a", "properties": {}}'
+
+2020-12-24 16:30:06.111: Sending: 'PUT /city/cityName<test!>-75b90fd77a/house/houseName<test!>-28d6b92951 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-28d6b92951","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.121: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-28d6b92951"}'
+
+2020-12-24 16:30:06.131: Done refreshing the sequence
+2020-12-24 16:30:06.141: Sending: 'PUT /city/cityName<test!>-75b90fd77a/house/houseName<test!>-04261aa9ac HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 54\r\n\r\n[{"house":"houseName<test!>-777ebb3955"},"fuzzstring"]'
+
+2020-12-24 16:30:06.150: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-04261aa9ac"}'
+
+2020-12-24 16:30:06.161: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.170: Sending: 'PUT /city/cityName<test!>-8f8121fd7e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.180: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8f8121fd7e", "properties": {}}'
+
+2020-12-24 16:30:06.190: Sending: 'PUT /city/cityName<test!>-8f8121fd7e/house/houseName<test!>-52dc30c25d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-52dc30c25d","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.199: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-52dc30c25d"}'
+
+2020-12-24 16:30:06.208: Done refreshing the sequence
+2020-12-24 16:30:06.217: Sending: 'PUT /city/cityName<test!>-8f8121fd7e/house/houseName<test!>-4c89112278 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 51\r\n\r\n[{"house":0,"group":"A"},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:06.227: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4c89112278"}'
+
+2020-12-24 16:30:06.236: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.246: Sending: 'PUT /city/cityName<test!>-977a0b4936 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.256: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-977a0b4936", "properties": {}}'
+
+2020-12-24 16:30:06.266: Sending: 'PUT /city/cityName<test!>-977a0b4936/house/houseName<test!>-9b6150fb5c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-9b6150fb5c","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.275: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9b6150fb5c"}'
+
+2020-12-24 16:30:06.284: Done refreshing the sequence
+2020-12-24 16:30:06.294: Sending: 'PUT /city/cityName<test!>-977a0b4936/house/houseName<test!>-19cf9285d4 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 55\r\n\r\n[{"house":"houseName<test!>-4c89112278","group":"A"},0]'
+
+2020-12-24 16:30:06.303: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-19cf9285d4"}'
+
+2020-12-24 16:30:06.313: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.323: Sending: 'PUT /city/cityName<test!>-f362655179 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.332: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-f362655179", "properties": {}}'
+
+2020-12-24 16:30:06.342: Sending: 'PUT /city/cityName<test!>-f362655179/house/houseName<test!>-86602f6061 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-86602f6061","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.350: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-86602f6061"}'
+
+2020-12-24 16:30:06.360: Done refreshing the sequence
+2020-12-24 16:30:06.369: Sending: 'PUT /city/cityName<test!>-f362655179/house/houseName<test!>-8d028260af HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 52\r\n\r\n[{"house":[],"group":"A"},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:06.379: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-8d028260af"}'
+
+2020-12-24 16:30:06.398: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.409: Sending: 'PUT /city/cityName<test!>-83111af5a9 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.420: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-83111af5a9", "properties": {}}'
+
+2020-12-24 16:30:06.429: Sending: 'PUT /city/cityName<test!>-83111af5a9/house/houseName<test!>-7b06b46a10 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-7b06b46a10","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.439: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-7b06b46a10"}'
+
+2020-12-24 16:30:06.450: Done refreshing the sequence
+2020-12-24 16:30:06.459: Sending: 'PUT /city/cityName<test!>-83111af5a9/house/houseName<test!>-821f424ead HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 70\r\n\r\n[{"house":"houseName<test!>-8d028260af","group":"A"},{"arraytest":[]}]'
+
+2020-12-24 16:30:06.469: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-821f424ead"}'
+
+2020-12-24 16:30:06.487: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.499: Sending: 'PUT /city/cityName<test!>-4d0923ef5a HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.509: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-4d0923ef5a", "properties": {}}'
+
+2020-12-24 16:30:06.521: Sending: 'PUT /city/cityName<test!>-4d0923ef5a/house/houseName<test!>-c1cdfaef2e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-c1cdfaef2e","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.538: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-c1cdfaef2e"}'
+
+2020-12-24 16:30:06.549: Done refreshing the sequence
+2020-12-24 16:30:06.557: Sending: 'PUT /city/cityName<test!>-4d0923ef5a/house/houseName<test!>-19107582ae HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 73\r\n\r\n[{"house":"houseName<test!>-821f424ead","group":"A"},{"arraytest":false}]'
+
+2020-12-24 16:30:06.567: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-19107582ae"}'
+
+2020-12-24 16:30:06.578: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.588: Sending: 'PUT /city/cityName<test!>-92bfb22125 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.598: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-92bfb22125", "properties": {}}'
+
+2020-12-24 16:30:06.608: Sending: 'PUT /city/cityName<test!>-92bfb22125/house/houseName<test!>-70369ee8d8 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-70369ee8d8","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.617: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-70369ee8d8"}'
+
+2020-12-24 16:30:06.626: Done refreshing the sequence
+2020-12-24 16:30:06.636: Sending: 'PUT /city/cityName<test!>-92bfb22125/house/houseName<test!>-8e0cf801b8 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 69\r\n\r\n[{"house":"houseName<test!>-19107582ae","group":"A"},{"arraytest":0}]'
+
+2020-12-24 16:30:06.645: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-8e0cf801b8"}'
+
+2020-12-24 16:30:06.655: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.665: Sending: 'PUT /city/cityName<test!>-8e472d5175 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.673: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-8e472d5175", "properties": {}}'
+
+2020-12-24 16:30:06.683: Sending: 'PUT /city/cityName<test!>-8e472d5175/house/houseName<test!>-25c2cf5cc3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-25c2cf5cc3","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.692: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-25c2cf5cc3"}'
+
+2020-12-24 16:30:06.701: Done refreshing the sequence
+2020-12-24 16:30:06.710: Sending: 'PUT /city/cityName<test!>-8e472d5175/house/houseName<test!>-1f9abb6d32 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 55\r\n\r\n[{"house":false,"group":"A"},{"arraytest":"centralus"}]'
+
+2020-12-24 16:30:06.719: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-1f9abb6d32"}'
+
+2020-12-24 16:30:06.729: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.739: Sending: 'PUT /city/cityName<test!>-f67dd86b27 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.748: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-f67dd86b27", "properties": {}}'
+
+2020-12-24 16:30:06.757: Sending: 'PUT /city/cityName<test!>-f67dd86b27/house/houseName<test!>-22c809a47e HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-22c809a47e","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.767: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-22c809a47e"}'
+
+2020-12-24 16:30:06.776: Done refreshing the sequence
+2020-12-24 16:30:06.785: Sending: 'PUT /city/cityName<test!>-f67dd86b27/house/houseName<test!>-1b901c2c06 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 72\r\n\r\n[{"house":"houseName<test!>-1f9abb6d32","group":"A"},{ "fuzz" : false }]'
+
+2020-12-24 16:30:06.795: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-1b901c2c06"}'
+
+2020-12-24 16:30:06.805: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.816: Sending: 'PUT /city/cityName<test!>-a9a27819b2 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.825: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a9a27819b2", "properties": {}}'
+
+2020-12-24 16:30:06.834: Sending: 'PUT /city/cityName<test!>-a9a27819b2/house/houseName<test!>-9848c4a9c7 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-9848c4a9c7","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.845: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-9848c4a9c7"}'
+
+2020-12-24 16:30:06.854: Done refreshing the sequence
+2020-12-24 16:30:06.864: Sending: 'PUT /city/cityName<test!>-a9a27819b2/house/houseName<test!>-4b0500b984 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 56\r\n\r\n[{"house":"houseName<test!>-1b901c2c06","group":"A"},[]]'
+
+2020-12-24 16:30:06.873: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4b0500b984"}'
+
+2020-12-24 16:30:06.883: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.893: Sending: 'PUT /city/cityName<test!>-9e920e1db9 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.902: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-9e920e1db9", "properties": {}}'
+
+2020-12-24 16:30:06.912: Sending: 'PUT /city/cityName<test!>-9e920e1db9/house/houseName<test!>-8cacbefc45 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-8cacbefc45","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.921: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-8cacbefc45"}'
+
+2020-12-24 16:30:06.931: Done refreshing the sequence
+2020-12-24 16:30:06.940: Sending: 'PUT /city/cityName<test!>-9e920e1db9/house/houseName<test!>-5a565bc4ff HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 66\r\n\r\n[{"house":"houseName<test!>-4b0500b984","group":"A"},"fuzzstring"]'
+
+2020-12-24 16:30:06.951: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-5a565bc4ff"}'
+
+2020-12-24 16:30:06.961: Re-rendering and sending start of sequence
+2020-12-24 16:30:06.971: Sending: 'PUT /city/cityName<test!>-05fd0d2f21 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:06.981: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-05fd0d2f21", "properties": {}}'
+
+2020-12-24 16:30:06.990: Sending: 'PUT /city/cityName<test!>-05fd0d2f21/house/houseName<test!>-b38d3843e7 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-b38d3843e7","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:06.999: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-b38d3843e7"}'
+
+2020-12-24 16:30:07.008: Done refreshing the sequence
+2020-12-24 16:30:07.018: Sending: 'PUT /city/cityName<test!>-05fd0d2f21/house/houseName<test!>-70ecc3613d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 26\r\n\r\n[{"house":[],"group":"A"}]'
+
+2020-12-24 16:30:07.029: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-70ecc3613d"}'
+
+2020-12-24 16:30:07.038: Re-rendering and sending start of sequence
+2020-12-24 16:30:07.048: Sending: 'PUT /city/cityName<test!>-a4e1d1a526 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:07.057: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a4e1d1a526", "properties": {}}'
+
+2020-12-24 16:30:07.066: Sending: 'PUT /city/cityName<test!>-a4e1d1a526/house/houseName<test!>-086ee8365f HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-086ee8365f","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:07.076: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-086ee8365f"}'
+
+2020-12-24 16:30:07.086: Done refreshing the sequence
+2020-12-24 16:30:07.095: Sending: 'PUT /city/cityName<test!>-a4e1d1a526/house/houseName<test!>-4c1e1a6b5a HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 29\r\n\r\n[{"house":false,"group":"A"}]'
+
+2020-12-24 16:30:07.104: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-4c1e1a6b5a"}'
+
+2020-12-24 16:30:07.114: Re-rendering and sending start of sequence
+2020-12-24 16:30:07.124: Sending: 'PUT /city/cityName<test!>-9c3a5f2d0f HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:07.133: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-9c3a5f2d0f", "properties": {}}'
+
+2020-12-24 16:30:07.144: Sending: 'PUT /city/cityName<test!>-9c3a5f2d0f/house/houseName<test!>-a5482ea168 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-a5482ea168","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:07.153: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-a5482ea168"}'
+
+2020-12-24 16:30:07.163: Done refreshing the sequence
+2020-12-24 16:30:07.182: Sending: 'PUT /city/cityName<test!>-9c3a5f2d0f/house/houseName<test!>-6317c6031b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 25\r\n\r\n[{"house":0,"group":"A"}]'
+
+2020-12-24 16:30:07.193: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-6317c6031b"}'
+
+2020-12-24 16:30:07.204: Re-rendering and sending start of sequence
+2020-12-24 16:30:07.214: Sending: 'PUT /city/cityName<test!>-975f31d63b HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:07.223: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-975f31d63b", "properties": {}}'
+
+2020-12-24 16:30:07.242: Sending: 'PUT /city/cityName<test!>-975f31d63b/house/houseName<test!>-0271f1e007 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-0271f1e007","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:07.254: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-0271f1e007"}'
+
+2020-12-24 16:30:07.264: Done refreshing the sequence
+2020-12-24 16:30:07.274: Sending: 'PUT /city/cityName<test!>-975f31d63b/house/houseName<test!>-5747de442a HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 18\r\n\r\n[{"arraytest":[]}]'
+
+2020-12-24 16:30:07.292: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-5747de442a"}'
+
+2020-12-24 16:30:07.306: Re-rendering and sending start of sequence
+2020-12-24 16:30:07.325: Sending: 'PUT /city/cityName<test!>-7efde13e31 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:07.343: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-7efde13e31", "properties": {}}'
+
+2020-12-24 16:30:07.362: Sending: 'PUT /city/cityName<test!>-7efde13e31/house/houseName<test!>-30f3d7c277 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-30f3d7c277","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:07.374: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-30f3d7c277"}'
+
+2020-12-24 16:30:07.384: Done refreshing the sequence
+2020-12-24 16:30:07.394: Sending: 'PUT /city/cityName<test!>-7efde13e31/house/houseName<test!>-b8492c8b69 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 21\r\n\r\n[{"arraytest":false}]'
+
+2020-12-24 16:30:07.404: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-b8492c8b69"}'
+
+2020-12-24 16:30:07.427: Re-rendering and sending start of sequence
+2020-12-24 16:30:07.444: Sending: 'PUT /city/cityName<test!>-90ded10ae6 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:07.454: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-90ded10ae6", "properties": {}}'
+
+2020-12-24 16:30:07.465: Sending: 'PUT /city/cityName<test!>-90ded10ae6/house/houseName<test!>-02bc8dfd57 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-02bc8dfd57","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:07.474: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-02bc8dfd57"}'
+
+2020-12-24 16:30:07.483: Done refreshing the sequence
+2020-12-24 16:30:07.492: Sending: 'PUT /city/cityName<test!>-90ded10ae6/house/houseName<test!>-55d0cd66d3 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 17\r\n\r\n[{"arraytest":0}]'
+
+2020-12-24 16:30:07.501: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-55d0cd66d3"}'
+
+2020-12-24 16:30:07.516: PayloadBodyChecker Tracker begin (Type):
+2020-12-24 16:30:07.527: PayloadBodyChecker     Valid: 61
+2020-12-24 16:30:07.536: PayloadBodyChecker     Invalid: 0
+2020-12-24 16:30:07.547: PayloadBodyChecker Tracker end
+2020-12-24 16:30:07.560: PayloadBodyChecker Task end Type
+2020-12-24 16:30:07.569: Checker: PayloadBodyChecker kicks out
+
+2020-12-24 16:30:07.586: Checker: ExamplesChecker kicks in
+
+2020-12-24 16:30:07.598: Checker: ExamplesChecker kicks out
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 16)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		+ restler_custom_payload_uuid4_suffix: cityName<test!>-
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"properties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"population":'
+		+ restler_fuzzable_int: ['"0"', '"1"']
+		- restler_static_string: ', "area": "5000",'
+		+ restler_fuzzable_string: ['"fuzzstring"', '"enable"']
+		- restler_static_string: ':'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: ',"subproperties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"subtest":'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+		- restler_static_string: 'GET '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		- restler_static_string: '_READER_DELIM_city_put_name_READER_DELIM'
+		- restler_static_string: '/'
+		- restler_static_string: 'house'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2020-12-24 16:30:08.400: Sending: 'PUT /city/cityName<test!>-a41737ed1d HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:08.418: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-a41737ed1d", "properties": {}}'
+
+2020-12-24 16:30:08.437: Sending: 'GET /city/cityName<test!>-a41737ed1d/house HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2020-12-24 16:30:08.449: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"house": {}}'
+
+2020-12-24 16:30:08.468: Checker: PayloadBodyChecker kicks in
+
+2020-12-24 16:30:08.478: Checker: PayloadBodyChecker kicks out
+
+2020-12-24 16:30:08.487: Checker: ExamplesChecker kicks in
+
+2020-12-24 16:30:08.496: Checker: ExamplesChecker kicks out
+
+
+Generation-3: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 16)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		+ restler_custom_payload_uuid4_suffix: cityName<test!>-
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"properties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"population":'
+		+ restler_fuzzable_int: ['"0"', '"1"']
+		- restler_static_string: ', "area": "5000",'
+		+ restler_fuzzable_string: ['"fuzzstring"', '"enable"']
+		- restler_static_string: ':'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: ',"subproperties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"subtest":'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		- restler_static_string: '_READER_DELIM_city_put_name_READER_DELIM'
+		- restler_static_string: '/'
+		- restler_static_string: 'house'
+		- restler_static_string: '/'
+		+ restler_custom_payload_uuid4_suffix: houseName<test!>-
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '['
+		- restler_static_string: '{'
+		- restler_static_string: '"house":'
+		+ restler_custom_payload_uuid4_suffix: "houseName<test!>-"
+		- restler_static_string: ',"group":'
+		+ restler_fuzzable_group: ['A', 'BB', 'CCC']
+		- restler_static_string: '}'
+		- restler_static_string: ','
+		- restler_static_string: '{'
+		- restler_static_string: '"arraytest":'
+		+ restler_custom_payload: ['"centralus"', '10']
+		- restler_static_string: '}'
+		- restler_static_string: ']'
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Remaining candidate combinations: 1)
+		- restler_static_string: 'GET '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		- restler_static_string: '_READER_DELIM_city_put_name_READER_DELIM'
+		- restler_static_string: '/'
+		- restler_static_string: 'house'
+		- restler_static_string: '/'
+		- restler_static_string: '_READER_DELIM_city_house_put_name_READER_DELIM'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2020-12-24 16:30:09.432: Sending: 'PUT /city/cityName<test!>-301d69d3a4 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:09.440: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-301d69d3a4", "properties": {}}'
+
+2020-12-24 16:30:09.450: Sending: 'PUT /city/cityName<test!>-301d69d3a4/house/houseName<test!>-297171d1d0 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-297171d1d0","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:09.460: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-297171d1d0"}'
+
+2020-12-24 16:30:09.469: Sending: 'GET /city/cityName<test!>-301d69d3a4/house/houseName<test!>-297171d1d0 HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2020-12-24 16:30:09.478: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-297171d1d0"}'
+
+2020-12-24 16:30:09.490: Checker: PayloadBodyChecker kicks in
+
+2020-12-24 16:30:09.499: Checker: PayloadBodyChecker kicks out
+
+2020-12-24 16:30:09.509: Checker: ExamplesChecker kicks in
+
+2020-12-24 16:30:09.519: Checker: ExamplesChecker kicks out
+
+
+Generation-3: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 16)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		+ restler_custom_payload_uuid4_suffix: cityName<test!>-
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"properties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"population":'
+		+ restler_fuzzable_int: ['"0"', '"1"']
+		- restler_static_string: ', "area": "5000",'
+		+ restler_fuzzable_string: ['"fuzzstring"', '"enable"']
+		- restler_static_string: ':'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: ',"subproperties":'
+		- restler_static_string: '{'
+		- restler_static_string: '"subtest":'
+		+ restler_fuzzable_bool: ['true', 'false']
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		- restler_static_string: '_READER_DELIM_city_put_name_READER_DELIM'
+		- restler_static_string: '/'
+		- restler_static_string: 'house'
+		- restler_static_string: '/'
+		+ restler_custom_payload_uuid4_suffix: houseName<test!>-
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '['
+		- restler_static_string: '{'
+		- restler_static_string: '"house":'
+		+ restler_custom_payload_uuid4_suffix: "houseName<test!>-"
+		- restler_static_string: ',"group":'
+		+ restler_fuzzable_group: ['A', 'BB', 'CCC']
+		- restler_static_string: '}'
+		- restler_static_string: ','
+		- restler_static_string: '{'
+		- restler_static_string: '"arraytest":'
+		+ restler_custom_payload: ['"centralus"', '10']
+		- restler_static_string: '}'
+		- restler_static_string: ']'
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Remaining candidate combinations: 1)
+		- restler_static_string: 'DELETE '
+		- restler_static_string: '/'
+		- restler_static_string: 'city'
+		- restler_static_string: '/'
+		- restler_static_string: '_READER_DELIM_city_put_name_READER_DELIM'
+		- restler_static_string: '/'
+		- restler_static_string: 'house'
+		- restler_static_string: '/'
+		- restler_static_string: '_READER_DELIM_city_house_put_name_READER_DELIM'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: restler.unit.test.server.com\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2020-12-24 16:30:10.416: Sending: 'PUT /city/cityName<test!>-b5fe497baa HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 102\r\n\r\n{"properties":{"population":"0", "area": "5000","fuzzstring":true,"subproperties":{"subtest":true}}}\r\n'
+
+2020-12-24 16:30:10.425: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "cityName<test!>-b5fe497baa", "properties": {}}'
+
+2020-12-24 16:30:10.434: Sending: 'PUT /city/cityName<test!>-b5fe497baa/house/houseName<test!>-c808bdde9c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 81\r\n\r\n[{"house":"houseName<test!>-c808bdde9c","group":"A"},{"arraytest":"centralus"}]\r\n'
+
+2020-12-24 16:30:10.443: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "houseName<test!>-c808bdde9c"}'
+
+2020-12-24 16:30:10.452: Sending: 'DELETE /city/cityName<test!>-b5fe497baa/house/houseName<test!>-c808bdde9c HTTP/1.1\r\nAccept: application/json\r\nHost: restler.unit.test.server.com\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2020-12-24 16:30:10.461: Received: 'HTTP/1.1 202 Accepted\r\nRestler Test\r\n\r\n"houseName<test!>-c808bdde9c"'
+
+2020-12-24 16:30:10.473: Checker: PayloadBodyChecker kicks in
+
+2020-12-24 16:30:10.482: Checker: PayloadBodyChecker kicks out
+
+2020-12-24 16:30:10.501: Checker: ExamplesChecker kicks in
+
+2020-12-24 16:30:10.514: Checker: ExamplesChecker kicks out
+

--- a/restler/unit_tests/log_baseline_test_files/test_grammar_body.json
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar_body.json
@@ -1,0 +1,673 @@
+{
+    "Requests": [
+      {
+        "id": {
+          "endpoint": "/city",
+          "method": "Get"
+        },
+        "method": "Get",
+        "path": [
+          {
+            "Constant": [
+              "String",
+              "city"
+            ]
+          }
+        ],
+        "queryParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": [
+              ]
+            }
+          ]
+        ],
+        "bodyParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "headers": [
+          [
+            "Accept",
+            "application/json"
+          ],
+          [
+            "Host",
+            "restler.unit.test.server.com"
+          ]
+        ],
+        "httpVersion": "1.1",
+        "requestMetadata": {
+          "isLongRunningOperation": false
+        }
+      },
+      {
+        "id": {
+          "endpoint": "/city/{cityName}",
+          "method": "Put"
+        },
+        "method": "Put",
+        "path": [
+          {
+            "Constant": [
+              "String",
+              "city"
+            ]
+          },
+          {
+            "Custom": [
+                "UuidSuffix",
+                "cityName",
+                false
+            ]
+          }
+        ],
+        "queryParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "bodyParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": [
+                [
+                  "payload",
+                  {
+                    "InternalNode": [
+                      {
+                        "name": "",
+                        "propertyType": "Object",
+                        "isRequired": true,
+                        "isReadOnly": false
+                      },
+                      [
+                        {
+                          "InternalNode": [
+                            {
+                              "name": "properties",
+                              "propertyType": "Property",
+                              "isRequired": true,
+                              "isReadOnly": false
+                            },
+                            [
+                              {
+                                "InternalNode": [
+                                  {
+                                    "name": "",
+                                    "propertyType": "Object",
+                                    "isRequired": true,
+                                    "isReadOnly": false
+                                  },
+                                  [
+                                    {
+                                      "LeafNode": {
+                                        "name": "population",
+                                        "payload": {
+                                          "Fuzzable": [
+                                              "Int",
+                                              "1000"
+                                          ]
+                                        },
+                                        "isRequired": false,
+                                        "isReadOnly": false
+                                      }
+                                    },
+                                    {
+                                      "LeafNode": {
+                                        "name": "area",
+                                        "payload": {
+                                          "Constant": [
+                                            "String",
+                                            "5000"
+                                          ]
+                                        },
+                                        "isRequired": false,
+                                        "isReadOnly": false
+                                      }
+                                    },
+                                    {
+                                      "LeafNode": {
+                                        "name": "strtest",
+                                        "payload": {
+                                            "Fuzzable": [
+                                                "String",
+                                                "true"
+                                            ]
+                                        },
+                                        "isRequired": true,
+                                        "isReadOnly": false
+                                      }
+                                    },
+                                    {
+                                      "InternalNode": [
+                                        {
+                                          "name": "subproperties",
+                                          "propertyType": "Property",
+                                          "isRequired": true,
+                                          "isReadOnly": false
+                                        },
+                                        [
+                                          {
+                                            "InternalNode": [
+                                              {
+                                                "name": "",
+                                                "propertyType": "Object",
+                                                "isRequired": true,
+                                                "isReadOnly": false
+                                              },
+                                              [
+                                                {
+                                                  "LeafNode": {
+                                                    "name": "subtest",
+                                                    "payload": {
+                                                      "Fuzzable": [
+                                                        "Bool",
+                                                        "true"
+                                                      ]
+                                                    },
+                                                    "isRequired": false,
+                                                    "isReadOnly": false
+                                                  }
+                                                }
+                                              ]
+                                            ]
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  ]
+                                ]
+                              }
+                            ]
+                          ]
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        ],
+        "headers": [
+            [
+              "Accept",
+              "application/json"
+            ],
+            [
+              "Host",
+              "restler.unit.test.server.com"
+            ]
+          ],
+          "httpVersion": "1.1",
+          "requestMetadata": {
+            "isLongRunningOperation": false
+          }
+      },
+      {
+        "id": {
+          "endpoint": "/city/{cityName}",
+          "method": "Get"
+        },
+        "method": "Get",
+        "path": [
+          {
+            "Constant": [
+              "String",
+              "city"
+            ]
+          },
+          {
+            "DynamicObject": "_city_put_name"
+          }
+        ],
+        "queryParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": [
+                "location",
+                {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Custom": {
+                        "payloadType": "String",
+                        "primitiveType": "String",
+                        "payloadValue": "location",
+                        "isObject": false
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                },
+                "group",
+                {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": [
+                        {
+                          "Enum": [
+                            "String",
+                            [
+                              "A",
+                              "BB",
+                              "CCC"
+                            ],
+                            null
+                          ]
+                        },
+                        "A"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        ],
+        "bodyParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "headers": [
+            [
+              "Accept",
+              "application/json"
+            ],
+            [
+              "Host",
+              "restler.unit.test.server.com"
+            ]
+          ],
+          "httpVersion": "1.1",
+          "requestMetadata": {
+            "isLongRunningOperation": false
+          }
+      },
+      {
+        "id": {
+          "endpoint": "/city/{cityName}",
+          "method": "Delete"
+        },
+        "method": "Delete",
+        "path": [
+          {
+            "Constant": [
+              "String",
+              "city"
+            ]
+          },
+          {
+            "DynamicObject": "_city_put_name"
+          }
+        ],
+        "queryParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "bodyParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "headers": [
+            [
+              "Accept",
+              "application/json"
+            ],
+            [
+              "Host",
+              "restler.unit.test.server.com"
+            ]
+          ],
+          "httpVersion": "1.1",
+          "requestMetadata": {
+            "isLongRunningOperation": false
+          }
+      },
+      {
+        "id": {
+          "endpoint": "/city/{cityName}/house",
+          "method": "Get"
+        },
+        "method": "Get",
+        "path": [
+          {
+            "Constant": [
+              "String",
+              "city"
+            ]
+          },
+          {
+            "DynamicObject": "_city_put_name"
+          },
+          {
+              "Constant": [
+                  "String",
+                  "house"
+              ]
+          }
+        ],
+        "queryParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "bodyParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "headers": [
+            [
+              "Accept",
+              "application/json"
+            ],
+            [
+              "Host",
+              "restler.unit.test.server.com"
+            ]
+          ],
+          "httpVersion": "1.1",
+          "requestMetadata": {
+            "isLongRunningOperation": false
+          }
+      },
+      {
+        "id": {
+          "endpoint": "/city/{cityName}/house/{houseName}",
+          "method": "Put"
+        },
+        "method": "Put",
+        "path": [
+          {
+            "Constant": [
+              "String",
+              "city"
+            ]
+          },
+          {
+            "DynamicObject": "_city_put_name"
+          },
+          {
+              "Constant": [
+                  "String",
+                  "house"
+              ]
+          },
+          {
+            "Custom": [
+                "UuidSuffix",
+                "houseName",
+                false
+            ]
+          }
+        ],
+        "queryParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "bodyParameters": [
+            [
+              "Schema",
+              {
+                "ParameterList": [
+                  [
+                    "payload",
+                    {
+                      "InternalNode": [
+                        {
+                          "name": "",
+                          "propertyType": "Array",
+                          "isRequired": true,
+                          "isReadOnly": false
+                        },
+                        [
+                          {
+                            "InternalNode": [
+                              {
+                                "name": "",
+                                "propertyType": "Object",
+                                "isRequired": true,
+                                "isReadOnly": false
+                              },
+                              [
+                                {
+                                  "LeafNode": {
+                                    "name": "house",
+                                    "payload": {
+                                      "Custom": {
+                                        "payloadType": "UuidSuffix",
+                                        "primitiveType": "String",
+                                        "payloadValue": "houseName",
+                                        "isObject": false
+                                      }
+                                    },
+                                    "isRequired": false,
+                                    "isReadOnly": false
+                                  }
+                                },
+                                {
+                                  "LeafNode": {
+                                    "name": "group",
+                                    "payload": {
+                                      "Fuzzable": [
+                                        {
+                                          "Enum": [
+                                            "String",
+                                            [
+                                              "A",
+                                              "BB",
+                                              "CCC"
+                                            ],
+                                            null
+                                          ]
+                                        },
+                                        "A"
+                                      ]
+                                    }
+                                  }
+                                }
+                              ]
+                            ]
+                          },
+                          {
+                            "InternalNode": [
+                              {
+                                "name": "",
+                                "propertyType": "Object",
+                                "isRequired": true,
+                                "isReadOnly": false
+                              },
+                              [
+                                {
+                                  "LeafNode": {
+                                    "name": "arraytest",
+                                    "payload": {
+                                      "Custom": {
+                                        "payloadType": "String",
+                                        "primitiveType": "String",
+                                        "payloadValue": "location",
+                                        "isObject": false
+                                      }
+                                    },
+                                    "isRequired": false,
+                                    "isReadOnly": false
+                                  }
+                                }
+                              ]
+                            ]
+                          }
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ],
+        "headers": [
+            [
+              "Accept",
+              "application/json"
+            ],
+            [
+              "Host",
+              "restler.unit.test.server.com"
+            ]
+          ],
+          "httpVersion": "1.1",
+          "requestMetadata": {
+            "isLongRunningOperation": false
+          }
+      },
+      {
+        "id": {
+          "endpoint": "/city/{cityName}/house/{houseName}",
+          "method": "Get"
+        },
+        "method": "Get",
+        "path": [
+          {
+            "Constant": [
+              "String",
+              "city"
+            ]
+          },
+          {
+            "DynamicObject": "_city_put_name"
+          },
+          {
+              "Constant": [
+                  "String",
+                  "house"
+              ]
+          },
+          {
+              "DynamicObject": "_city_house_put_name"
+          }
+        ],
+        "queryParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "bodyParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "headers": [
+            [
+              "Accept",
+              "application/json"
+            ],
+            [
+              "Host",
+              "restler.unit.test.server.com"
+            ]
+          ],
+          "httpVersion": "1.1",
+          "requestMetadata": {
+            "isLongRunningOperation": false
+          }
+      },
+      {
+        "id": {
+          "endpoint": "/city/{cityName}/house/{houseName}",
+          "method": "Delete"
+        },
+        "method": "Delete",
+        "path": [
+          {
+            "Constant": [
+              "String",
+              "city"
+            ]
+          },
+          {
+            "DynamicObject": "_city_put_name"
+          },
+          {
+              "Constant": [
+                  "String",
+                  "house"
+              ]
+          },
+          {
+              "DynamicObject": "_city_house_put_name"
+          }
+        ],
+        "queryParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "bodyParameters": [
+          [
+            "Schema",
+            {
+              "ParameterList": []
+            }
+          ]
+        ],
+        "headers": [
+            [
+              "Accept",
+              "application/json"
+            ],
+            [
+              "Host",
+              "restler.unit.test.server.com"
+            ]
+          ],
+          "httpVersion": "1.1",
+          "requestMetadata": {
+            "isLongRunningOperation": false
+          }
+      }
+    ]
+  }

--- a/restler/unit_tests/log_baseline_test_files/test_grammar_body.py
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar_body.py
@@ -1,0 +1,263 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import print_function
+import json
+
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_city_put_name = dependencies.DynamicVariable(
+    "_city_put_name"
+)
+
+_city_house_put_name = dependencies.DynamicVariable(
+    "_city_house_put_name"
+)
+
+def parse_cityNamePut(data):
+    temp_123 = None
+
+    try:
+
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_city_put_name", temp_123)
+
+def parse_cityHouseNamePut(data):
+    temp_123 = None
+
+    try:
+
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_city_house_put_name", temp_123)
+
+req_collection = requests.RequestCollection([])
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("city"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n")
+],
+requestId="/city"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("city"),
+    primitives.restler_static_string("/"),
+    primitives.restler_custom_payload_uuid4_suffix("cityName"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"properties":'),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"population":'),
+    primitives.restler_fuzzable_int('10000', quoted=True),
+    primitives.restler_static_string(', "area": "5000",'),
+    primitives.restler_fuzzable_string('strtest', quoted=True),
+    primitives.restler_static_string(':'),
+    primitives.restler_fuzzable_bool('true', quoted=True),
+    primitives.restler_static_string(',"subproperties":'),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"subtest":'),
+    primitives.restler_fuzzable_bool("true", quoted=False),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_cityNamePut,
+            'dependencies':
+            [
+                _city_put_name.writer()
+            ]
+        }
+    },
+
+],
+requestId="/city/{cityName}"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("city"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_city_put_name.reader()),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("location="),
+    primitives.restler_custom_payload("location"),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("group="),
+    primitives.restler_fuzzable_group("fuzzable_group_tag", ['A','BB','CCC']),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n")
+],
+requestId="/city/{cityName}"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("DELETE "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("city"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_city_put_name.reader()),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n")
+],
+requestId="/city/{cityName}"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("city"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_city_put_name.reader()),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("house"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n")
+],
+requestId="/city/{cityName}/house"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("city"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_city_put_name.reader()),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("house"),
+    primitives.restler_static_string("/"),
+    primitives.restler_custom_payload_uuid4_suffix("houseName"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("["),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"house":'),
+    primitives.restler_custom_payload_uuid4_suffix("houseName", quoted=True),
+    primitives.restler_static_string(',"group":'),
+    primitives.restler_fuzzable_group("fuzzable_group_tag", ['A','BB','CCC'], quoted=True),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string(","),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"arraytest":'),
+    primitives.restler_custom_payload("location", quoted=True),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("]"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_cityHouseNamePut,
+            'dependencies':
+            [
+                _city_house_put_name.writer()
+            ]
+        }
+    },
+
+],
+requestId="/city/{cityName}/house/{houseName}"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("city"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_city_put_name.reader()),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("house"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_city_house_put_name.reader()),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n")
+],
+requestId="/city/{cityName}/house/{houseName}"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("DELETE "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("city"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_city_put_name.reader()),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("house"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_city_house_put_name.reader()),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n")
+],
+requestId="/city/{cityName}/house/{houseName}"
+)
+req_collection.add_request(request)
+
+

--- a/restler/unit_tests/test_basic_functionality_end_to_end.py
+++ b/restler/unit_tests/test_basic_functionality_end_to_end.py
@@ -253,7 +253,14 @@ class FunctionalityTests(unittest.TestCase):
 
     def test_payload_body_checker(self):
         """ This checks that the payload body checker sends all of the correct
-        requests in the correct order and an expected 500 bug is logged.
+        requests in the correct order and an expected 500 bug is logged. The test
+        sends requests in a predictable order and will test invalid json, type changes,
+        and structure changes using DROP and SELECT algorithms.
+
+        If this test fails it is important to verify (by diffing the current baseline files)
+        that the differences that caused the failure are expected by a recent change and no other
+        unexpected changes exist.
+
         """
         args = Common_Settings + [
             '--fuzzing_mode', 'directed-smoke-test',
@@ -293,7 +300,15 @@ class FunctionalityTests(unittest.TestCase):
 
     def test_payload_body_checker_advanced(self):
         """ This checks that the payload body checker sends all of the correct
-        requests in the correct order for more complicated bodies (including an array body)
+        requests in the correct order for more complicated bodies.
+        The bodies in this test include arrays and nested dict objects. The test
+        sends requests in a predictable order and will test invalid json, type changes,
+        and structure changes using DROP and SELECT algorithms.
+
+        If this test fails it is important to verify (by diffing the current baseline file)
+        that the differences that caused the failure are expected by a recent change and no other
+        unexpected changes exist.
+
         """
         args = Common_Settings + [
             '--fuzzing_mode', 'directed-smoke-test',

--- a/restler/unit_tests/test_basic_functionality_end_to_end.py
+++ b/restler/unit_tests/test_basic_functionality_end_to_end.py
@@ -291,6 +291,32 @@ class FunctionalityTests(unittest.TestCase):
         except TestFailedException:
             self.fail("Payload body failed: Garbage Collector")
 
+    def test_payload_body_checker_advanced(self):
+        """ This checks that the payload body checker sends all of the correct
+        requests in the correct order for more complicated bodies (including an array body)
+        """
+        args = Common_Settings + [
+            '--fuzzing_mode', 'directed-smoke-test',
+            '--restler_grammar', f'{os.path.join(Test_File_Directory, "test_grammar_body.py")}',
+            '--enable_checkers', 'payloadbody'
+        ]
+
+        result = subprocess.run(args, capture_output=True)
+        if result.stderr:
+            self.fail(result.stderr)
+        try:
+            result.check_returncode()
+        except subprocess.CalledProcessError:
+            self.fail(f"Restler returned non-zero exit code: {result.returncode}")
+
+        experiments_dir = self.get_experiments_dir()
+
+        try:
+            default_parser = FuzzingLogParser(os.path.join(Test_File_Directory, "payloadbody_advanced_testing_log.txt"))
+            test_parser = FuzzingLogParser(self.get_network_log_path(experiments_dir, logger.LOG_TYPE_TESTING))
+        except TestFailedException:
+            self.fail("Payload body arrays failed: Fuzzing")
+
     def test_examples_checker(self):
         """ This checks that the examples checker sends the correct requests
         in the correct order when query or body examples are present


### PR DESCRIPTION
## Summary of the Pull Request
Updated to allow handling of request and response bodies that start as arrays.

## PR Checklist
* [x] Applies to work item: Closes #67
* [x] CLA signed.
* [x] Tests added/passed.  
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach.

## Info on Pull Request

* Request and response parsers now recognize square brackets as valid body wrappers.
* Request schema parsing now treats arrays that are not key/value members correctly, which handles the cases where the body is an array instead of a dict. 
* Added new payload body checker test that handles an array body and a more complicated body (to be built upon and used more thoroughly later - specifically for improving bug bucketing)

## Validation Steps Performed

cd restler-fuzzer/restler
python -m pytest ./unit_tests