### PR TITLE
Improved payloadbody struct missing bug bucketing

### DIFF
--- a/restler/engine/fuzzing_parameters/body_schema.py
+++ b/restler/engine/fuzzing_parameters/body_schema.py
@@ -20,6 +20,8 @@ class BodySchemaVisitor():
         # Can be used as an accumulator string while
         # traversing the body schema's params.
         self.val_str = ''
+        # Can be used to track the current node depth while traversing
+        self.depth = 0
 
 class BodySchema():
     """ Body Schema Class. """

--- a/restler/engine/fuzzing_parameters/request_params.py
+++ b/restler/engine/fuzzing_parameters/request_params.py
@@ -411,7 +411,9 @@ class ParamObject(ParamBase):
 
         """
         for member in self._members:
+            visitor.depth += 1
             member.check_struct_missing(check_value, visitor)
+            visitor.depth -= 1
 
     def _traverse(self, config: FuzzingConfig, func: str, accum_value):
         """ Helper function that traverses the object's members
@@ -1238,7 +1240,12 @@ class ParamMember(ParamBase):
         elif self.name in check_value:
             new_check = check_value[self.name]
         else:
-            visitor.val_str += f'{TAG_SEPARATOR}{self.name}'
-            new_check = None
+            depth_str = (visitor.depth - 1) * '+'
+            visitor.val_str += f'{TAG_SEPARATOR}{depth_str}{self.name}'
+            if isinstance(self.value, ParamObject):
+                visitor.val_str += '{...}'
+            elif isinstance(self.value, ParamArray):
+                visitor.val_str += '[...]'
+            return
 
         self.value.check_struct_missing(new_check, visitor)


### PR DESCRIPTION
The struct missing bucketization now adds {...} or [...] when an object or array branch is missing, so the user can more easily tell when a large branch is missing.

Also, a depth counter was added to the struct missing bucketization and a '+' for each layer of depth is prepended to any missing struct tag. 

**Examples:**
Default Schema:  {"level1": {"level21": {"level3": "val"}, "level22": "val"}}

* "level1" missing: StructMissing_/level1{...}
* "level21" missing: StructMissing_/+level21{...}
* "level3" missing: StructMissing_/++level3
* "level21" and "level22" missing: StructMissing_/+level21{..}/+level22

