### PR TITLE
Memory and perf improvements

### DIFF
--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -33,9 +33,12 @@ module CodeGenerator =
                                 (Path.Combine(grammarOutputDirectory1, Restler.Workflow.Constants.DefaultJsonGrammarFileName))
             let pythonGrammar1 = File.ReadAllText (Path.Combine(grammarOutputDirectory1, Restler.Workflow.Constants.DefaultRestlerGrammarFileName))
 
-            let pythonGrammar2 = Restler.CodeGenerator.Python.generateCode
-                                    grammar1 configs.["demo_server"].IncludeOptionalParameters
-            Assert.True((pythonGrammar1 = pythonGrammar2), "grammars are not equal")
+            use sw = new System.IO.StringWriter()
+
+            Restler.CodeGenerator.Python.generateCode
+                grammar1 configs.["demo_server"].IncludeOptionalParameters sw.Write
+            
+            Assert.True((pythonGrammar1 = sw.GetStringBuilder().ToString()), "grammars are not equal")
 
 
         [<Fact>]
@@ -76,7 +79,7 @@ module CodeGenerator =
                     responseParser = None
                     requestMetadata = { isLongRunningOperation = false }
                 }
-            let elements = Restler.CodeGenerator.Python.getRequests (stn request) true
+            let elements = Restler.CodeGenerator.Python.getRequests [request] true
 
             Assert.True(elements |> Seq.length > 0)
 

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -814,7 +814,7 @@ let extractDependencies (requestData:(RequestId*RequestData)[])
             |> Seq.concat
         | _ -> Seq.empty
 
-    logTimingInfo "Get consumers."
+    logTimingInfo "Getting consumers..."
 
     let pathConsumers =
         requestData
@@ -889,7 +889,7 @@ let extractDependencies (requestData:(RequestId*RequestData)[])
                                 )
                 r, distinctConsumers)
 
-    logTimingInfo "Get producers."
+    logTimingInfo "Getting producers..."
 
     requestData
     // Only include POST, PUT, PATCH, and GET requests.  Others are never producers.
@@ -1245,6 +1245,7 @@ module DependencyLookup =
         let (parameterName, properties) = requestParameter
         let defaultPayload = (Fuzzable (PrimitiveType.String, ""))
         let dependencyPayload = getConsumerPayload dependencies pathPayload requestId parameterName EmptyAccessPath defaultPayload
+
         let payloadWithDependencies =
             if dependencyPayload <> defaultPayload then
                 Tree.LeafNode

--- a/src/compiler/Restler.Compiler/Restler.Compiler.fsproj
+++ b/src/compiler/Restler.Compiler/Restler.Compiler.fsproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OtherFlags></OtherFlags>
+    <Tailcalls>true</Tailcalls>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Config.fs" />

--- a/src/compiler/Restler.CompilerExe/Restler.CompilerExe.fsproj
+++ b/src/compiler/Restler.CompilerExe/Restler.CompilerExe.fsproj
@@ -9,6 +9,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OtherFlags></OtherFlags>
     <Deterministic>false</Deterministic>
+    <Tailcalls>true</Tailcalls>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <Tailcalls>true</Tailcalls>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />


### PR DESCRIPTION
## Summary of the Pull Request
- Use streams when serializing JSON rather than loading it up into a string
- Write generated grammar to a stream rather than building up a string and then wrting the string out
- Tune up performance by using datastructures that have better performance when appending to the end than existing implementation

## PR Checklist
* [X] Applies to work item: #135967 (Azure Devops internal bug)
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign.
* [X] Tests added/passed.  
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach. Issue number where discussion took place: #xxx

## Validation Steps Performed

- All unit tests are passing
- Compared grammars produced by RESTler from main branch and RESTler with changes in the PR and they are identical.
 Used following swagger specs: grade track, raft, petstore 