### PR TITLE
Allow specifying version of Python to use to run RESTler python components

### DIFF
--- a/src/driver/Telemetry.fs
+++ b/src/driver/Telemetry.fs
@@ -25,12 +25,11 @@ module Telemetry =
     let getMachineIdFilePath() =
         let machineTelemetryIdFileName = "restler.telemetry.uuid"
         let restlerSettingsCacheDir =
-            if RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
+            match Types.Platform.getOSPlatform() with
+            | Types.Platform.Platform.Linux ->
                 "~/.config/microsoft/restler"
-            else if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+            | Types.Platform.Platform.Windows ->
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\Restler";
-            else
-                raise (Exception("Platform not supported."))
         if not (Directory.Exists(restlerSettingsCacheDir)) then
             // Re-tries are needed in case several RESTler instances are started on a new machine
             let retryCount = 3

--- a/src/driver/Types.fs
+++ b/src/driver/Types.fs
@@ -128,6 +128,10 @@ type DriverArgs =
         /// The root directory to which logs should be uploaded
         /// If 'None', telemetry is not written
         logsUploadRootDirectoryPath : string option
+
+        /// The full path to the python executable that should be used
+        /// to launch the RESTler engine
+        pythonFilePath : string option
     }
 
 
@@ -184,3 +188,18 @@ module Logging =
     let logError (message:string) =
         printfn "\nERROR: %s\n" message
         Trace.error "%s" message
+
+module Platform =
+    type Platform =
+        | Linux
+        | Windows
+
+    open System
+    open System.Runtime.InteropServices
+    let getOSPlatform() =
+        if RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
+            Platform.Linux
+        else if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+            Platform.Windows
+        else
+            raise (Exception("Platform not supported."))


### PR DESCRIPTION
- Added a new option, --python_path, that allows specifying the python version to use
- Added 'python3' to the list of default options, if 'python' is not on the path (to avoid having to use the explicit option in the RESTler container)
- Added error handling so the driver does not crash if python is missing

Miscellaneous: avoid verbose logging about the log upload directory on the path when nothing is uploaded.

Closes #147