### PR TITLE
Fix RESTler build, test, and driver to work with spaces in paths.

### DIFF
--- a/build-restler.py
+++ b/build-restler.py
@@ -160,12 +160,12 @@ def publish_dotnet_apps(dirs, configuration):
         proj_file_path = dotnetcore_projects[target_dir_name]
         print(f"Publishing project {proj_file_path} to output dir {proj_output_dir}")
 
-        output = subprocess.run(f"dotnet restore {proj_file_path} --use-lock-file --locked-mode --force", shell=True, stderr=subprocess.PIPE)
+        output = subprocess.run(f"dotnet restore \"{proj_file_path}\" --use-lock-file --locked-mode --force", shell=True, stderr=subprocess.PIPE)
         if output.stderr:
             print("Build failed!")
             print(str(output.stderr))
             sys.exit(-1)
-        output = subprocess.run(f"dotnet publish {proj_file_path} --no-restore -o {proj_output_dir} -c {configuration} -f netcoreapp5.0", shell=True, stderr=subprocess.PIPE)
+        output = subprocess.run(f"dotnet publish \"{proj_file_path}\" --no-restore -o \"{proj_output_dir}\" -c {configuration} -f netcoreapp5.0", shell=True, stderr=subprocess.PIPE)
         if output.stderr:
             print("Build failed!")
             print(str(output.stderr))

--- a/restler-quick-start.py
+++ b/restler-quick-start.py
@@ -38,7 +38,7 @@ def compile_spec(api_spec_path, restler_dll_path):
         os.makedirs(RESTLER_TEMP_DIR)
 
     with usedir(RESTLER_TEMP_DIR):
-        subprocess.run(f'dotnet {restler_dll_path} compile --api_spec {api_spec_path}', shell=True)
+        subprocess.run(f'dotnet \"{restler_dll_path}\" compile --api_spec \"{api_spec_path}\"', shell=True)
 
 def test_spec(ip, port, host, use_ssl, restler_dll_path):
     """ Runs RESTler's test mode on a specified Compile directory
@@ -60,10 +60,12 @@ def test_spec(ip, port, host, use_ssl, restler_dll_path):
     """
     with usedir(RESTLER_TEMP_DIR):
         compile_dir = Path(f'Compile')
-
+        grammar_file_path = compile_dir.joinpath('grammar.py')
+        dictionary_file_path = compile_dir.joinpath('dict.json')
+        settings_file_path = compile_dir.joinpath('engine_settings.json')
         command = (
-            f"dotnet {restler_dll_path} test --grammar_file {compile_dir.joinpath('grammar.py')} --dictionary_file {compile_dir.joinpath('dict.json')}"
-            f" --settings {compile_dir.joinpath('engine_settings.json')}"
+            f"dotnet \"{restler_dll_path}\" test --grammar_file \"{grammar_file_path}\" --dictionary_file \"{dictionary_file_path}\""
+            f" --settings \"{settings_file_path}\""
         )
         if not use_ssl:
             command = f"{command} --no_ssl"

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -232,7 +232,7 @@ module Fuzz =
              | Some r -> sprintf "--path_regex %s" r
              | None -> "")
             (if String.IsNullOrWhiteSpace parameters.settingsFilePath then ""
-             else sprintf "--settings %s" parameters.settingsFilePath)
+             else sprintf "--settings \"%s\"" parameters.settingsFilePath)
 
             // Checkers
             (if parameters.checkerOptions.Length > 0 then
@@ -294,7 +294,7 @@ module Fuzz =
                     usage()
                 | Some (pythonFilePath, versionString) ->
                     printfn "Using python: '%s' (%s)" pythonFilePath (versionString.Trim())
-                    pythonFilePath, (sprintf "-B %s %s" Paths.RestlerPyPath restlerParameterCmdLine)
+                    pythonFilePath, (sprintf "-B \"%s\" %s" Paths.RestlerPyPath restlerParameterCmdLine)
 
         let! result =
             startProcessAsync


### PR DESCRIPTION
The following commands now work:

>python .\build-restler.py --dest_dir "D:\restlerdrop\path with spaces"
>python .\restler-quick-start.py --restler_drop_dir "d:\restlerdrop\path with spaces" --api_spec_path D:\git\restler-fuzzer\demo_server\swagger.json

Closes #157