### PR TITLE
Extend spec coverage file with concrete requests and responses.

### DIFF
--- a/docs/user-guide/Testing.md
+++ b/docs/user-guide/Testing.md
@@ -71,6 +71,24 @@ Each request is represented by a hash of its definition.
         "status_code": "400",
         "status_text": "BAD REQUEST",
         "error_message": "{\n    \"errors\": {\n        \"id\": \"'5882' is not of type 'integer'\"\n    },\n    \"message\": \"Input payload validation failed\"\n}\n",
+        "sample_request": {
+            "request_sent_timestamp": null,
+            "response_received_timestamp": "2021-03-31 18:20:14",
+            "request_uri": "/api/blog/posts/5882",
+            "request_headers": [
+                "Accept: application/json",
+                "Host: localhost:8888",
+                "Content-Type: application/json"
+            ],
+            "request_body": "{\n    \"id\":\"5882\",\n    \"checksum\":\"fuzzstring\",\n    \"body\":\"fuzzstring\"}\r\n",
+            "response_headers": [
+                "Content-Type: application/json",
+                "Content-Length: 124",
+                "Server: Werkzeug/0.16.0 Python/3.7.8",
+                "Date: Wed, 31 Mar 2021 18:20:14 GMT"
+            ],
+            "response_body": "{\n    \"errors\": {\n        \"id\": \"'5882' is not of type 'integer'\"\n    },\n    \"message\": \"Input payload validation failed\"\n}\n"
+        },
         "request_order": 4
     },
 ```
@@ -92,6 +110,8 @@ the appropriate __"invalid_due_to_..."__ value will be set to 1.
   but there was a failure while parsing the response data.
   * "500" will be set if a 5xx bug was detected.
 * The __"status_code"__ and __"status_text"__ values are the response values received from the server.
+* The __"sample_request"__ contains the concrete values of the sent request and received response for which
+the coverage data is being reported.
 * The __"error_message"__ value will be set to the response body if the request was not "valid".
 * The __"request_order"__ value is the 0 indexed order that the request was sent.
   * Requests sent during "preprocessing" or "postprocessing" will explicitely say so.

--- a/restler/engine/core/driver.py
+++ b/restler/engine/core/driver.py
@@ -365,7 +365,8 @@ def generate_sequences_directed_smoketest(fuzzing_requests, checkers):
 
         Side effects: request.stats.status_code updated
                       request.stats.status_text updated
-
+                      request.stats updated with concrete response and request text
+                      (valid request or last combination)
         @return: Tuple containing rendered sequence object, response body, and
                  failure information enum.
         @rtype : Tuple(RenderedSequence, str, FailureInformation)
@@ -387,8 +388,15 @@ def generate_sequences_directed_smoketest(fuzzing_requests, checkers):
             # will be returned from seq.render if all request combinations are
             # exhausted prior to getting a valid status code.
             if renderings.final_request_response:
+
                 request.stats.status_code = renderings.final_request_response.status_code
                 request.stats.status_text = renderings.final_request_response.status_text
+                # Get the last rendered request.  The corresponding response should be
+                # the last received response.
+                request.stats.sample_request.set_request_stats(
+                    renderings.sequence.sent_request_data_list[-1].rendered_data)
+                request.stats.sample_request.set_response_stats(renderings.final_request_response,
+                                                                renderings.final_response_datetime)
                 response_body = renderings.final_request_response.body
 
             apply_checkers(checkers, renderings, global_lock)

--- a/restler/engine/core/fuzzer.py
+++ b/restler/engine/core/fuzzer.py
@@ -5,6 +5,7 @@ import threading
 
 import engine.core.driver as driver
 import utils.logger as logger
+import traceback
 
 from engine.core.fuzzing_monitor import Monitor
 from engine.core.requests import GrammarRequestCollection
@@ -52,7 +53,7 @@ class FuzzingThread(threading.Thread):
         except InvalidDictionaryException:
             pass
         except Exception as err:
-            self._exception = str(err)
+            self._exception = traceback.format_exc()
 
     def join(self, *args):
         """ Overrides thread join function

--- a/restler/engine/core/postprocessing.py
+++ b/restler/engine/core/postprocessing.py
@@ -54,6 +54,12 @@ def delete_create_once_resources(destructors, fuzzing_requests):
                 destructor.stats.valid = 1
                 destructor.stats.status_code = renderings.final_request_response.status_code
                 destructor.stats.status_text = renderings.final_request_response.status_text
+
+                destructor.stats.sample_request.set_request_stats(
+                    renderings.sequence.sent_request_data_list[-1].rendered_data)
+                destructor.stats.sample_request.set_response_stats(renderings.final_request_response,
+                                                                   renderings.final_response_datetime)
+
         except Exception as error:
             msg = f"Failed to delete create_once resource: {error!s}"
             logger.raw_network_logging(msg)
@@ -65,6 +71,10 @@ def delete_create_once_resources(destructors, fuzzing_requests):
                     destructor.stats.status_code = renderings.final_request_response.status_code
                     destructor.stats.status_text = renderings.final_request_response.status_text
                     destructor.stats.error_msg = renderings.final_request_response.body
+                    destructor.stats.sample_request.set_request_stats(
+                        renderings.sequence.sent_request_data_list[-1].rendered_data)
+                    destructor.stats.sample_request.set_response_stats(renderings.final_request_response, renderings.final_response_datetime)
+
             pass
 
     Monitor().current_fuzzing_generation += 1

--- a/restler/engine/core/preprocessing.py
+++ b/restler/engine/core/preprocessing.py
@@ -211,6 +211,11 @@ def apply_create_once_resources(fuzzing_requests):
                         resource_gen_req.stats.valid = 1
                         resource_gen_req.stats.status_code = renderings.final_request_response.status_code
                         resource_gen_req.stats.status_text = renderings.final_request_response.status_text
+                        resource_gen_req.stats.sample_request.set_request_stats(
+                            renderings.sequence.sent_request_data_list[-1].rendered_data)
+                        resource_gen_req.stats.sample_request.set_response_stats(renderings.final_request_response,
+                                                                                 renderings.final_response_datetime)
+
                 if req.is_destructor():
                     # Add destructors to the destructor list that will be returned
                     destructors.add(req)

--- a/restler/engine/transport_layer/response.py
+++ b/restler/engine/transport_layer/response.py
@@ -67,6 +67,21 @@ class HttpResponse(object):
             return None
 
     @property
+    def headers(self):
+        """ The headers of the response
+
+        @return: The headers
+        @rtype : List[Str]
+
+        """
+        try:
+            response_without_body = self._str.split(DELIM)[0]
+            # assumed format: HTTP/1.1 STATUS_CODE STATUS TEXT\r\nresponse...
+            return response_without_body.split(" ", 2)[2].split('\r\n')[1:]
+        except:
+            return None
+
+    @property
     def json_body(self):
         """ The json portion of the body if exists.
 

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -890,6 +890,7 @@ def print_spec_coverage(fuzzing_requests):
             req_spec['invalid_due_to_500'] = 1
         req_spec['status_code'] = req.stats.status_code
         req_spec['status_text'] = req.stats.status_text
+        req_spec['sample_request'] = vars(req.stats.sample_request)
         req_spec['error_message'] = req.stats.error_msg
         req_spec['request_order'] = req.stats.request_order
 

--- a/utilities/speccovparsing/diff_speccov.py
+++ b/utilities/speccovparsing/diff_speccov.py
@@ -28,6 +28,9 @@ def diff_reqs(left_req, right_req):
     # NOTE: Any differences in keys here will either cause a failure or be
     # ignored. The files are expected to have matching formats.
     for key in left_req.keys():
+        # Skip the sample request, which contains concrete values in paths, timestamps, etc.
+        if key == "sample_request":
+            continue
         try:
             if (type(left_req[key]) != type(right_req[key]))\
             or left_req[key] != right_req[key]:


### PR DESCRIPTION
This change adds an example of a concrete request for which the
data in the spec coverage file is reported.

The goal of this change is that information in the spec coverage file
can be used to troubleshoot failing requests using only:

- the spec coverage file
- backend logs for the service

The diff speccov script has been modified to avoid diffing the
concrete data that is now in the coverage file.