### PR TITLE
Fix demo_server break on Linux.

### DIFF
--- a/demo_server/requirements.txt
+++ b/demo_server/requirements.txt
@@ -1,4 +1,4 @@
 flask==1.1.2
 flask-restplus==0.13.0
-Flask-SQLAlchemy==2.4.4
+Flask-SQLAlchemy==2.5.1
 Werkzeug==0.16.0


### PR DESCRIPTION
Upgrading SQLAlchemy resolved the library exception.
Closes #165.