### PR TITLE
Fix results analyzer argument bug.

### DIFF
--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -513,7 +513,7 @@ let rec parseEngineArgs task (args:EngineParameters) = function
                             Logging.logWarning <| sprintf "Unknown checker %s specified. If this is a custom checker, ignore this message." x
                       )
         parseEngineArgs task { args with checkerOptions = args.checkerOptions @ [(checkerAction, specifiedCheckers |> String.concat " ")] } rest
-    | "no_results_analyzer"::rest ->
+    | "--no_results_analyzer"::rest ->
         parseEngineArgs task { args with runResultsAnalyzer = false } rest
     | invalidArgument::rest ->
         Logging.logError <| sprintf "Invalid argument: %s" invalidArgument


### PR DESCRIPTION
Fix bug due to a typo - dashes were missing from the argument check.