### PR TITLE
Refactor the Parameter type in the RESTler grammar.

### DIFF
--- a/restler/engine/fuzzing_parameters/request_schema_parser.py
+++ b/restler/engine/fuzzing_parameters/request_schema_parser.py
@@ -55,9 +55,10 @@ def des_request_param_payload(request_param_payload_json):
         param_list_seq = request_param_payload_json['ParameterList']
 
         for param_payload_pair in param_list_seq:
+
             if not ('name' in param_payload_pair and 'payload' in param_payload_pair):
                 logger.write_to_main('string - param payload does not contain expected elements')
-                return [KeyPayload(None, None)]
+                raise Exception("Error parsing param payload json.  See the main log for more details.")
 
             key = param_payload_pair['name']
             payload = param_payload_pair['payload']

--- a/restler/engine/fuzzing_parameters/request_schema_parser.py
+++ b/restler/engine/fuzzing_parameters/request_schema_parser.py
@@ -55,13 +55,12 @@ def des_request_param_payload(request_param_payload_json):
         param_list_seq = request_param_payload_json['ParameterList']
 
         for param_payload_pair in param_list_seq:
-            # pair must have size 2
-            if len(param_payload_pair) != 2:
-                logger.write_to_main('string - param payload pair size mismatch')
+            if not ('name' in param_payload_pair and 'payload' in param_payload_pair):
+                logger.write_to_main('string - param payload does not contain expected elements')
                 return [KeyPayload(None, None)]
 
-            key = param_payload_pair[0]
-            payload = param_payload_pair[1]
+            key = param_payload_pair['name']
+            payload = param_payload_pair['payload']
 
             payloads.append(KeyPayload(key, payload))
 

--- a/restler/test_servers/log_parser.py
+++ b/restler/test_servers/log_parser.py
@@ -115,6 +115,7 @@ class FuzzingLogParser(LogParser):
         """
         if self._seq_list != other._seq_list:
             print("Fuzzing sequence lists do not match.")
+            print(f"First Sequence:{self._seq_list}\n\n, Second sequence:{other._seq_list}\n\n")
             return False
         return True
 

--- a/restler/unit_tests/log_baseline_test_files/test_grammar.json
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar.json
@@ -119,60 +119,61 @@
             "Schema",
             {
               "ParameterList": [
-                [
-                  "payload",
+
                   {
-                    "InternalNode": [
-                      {
-                        "name": "",
-                        "propertyType": "Object",
-                        "isRequired": true,
-                        "isReadOnly": false
-                      },
-                      [
+                    "name": "subnetParameters",
+                    "payload": {
+                      "InternalNode": [
                         {
-                          "LeafNode": {
-                            "name": "population",
-                            "payload": {
-                              "Fuzzable": [
+                          "name": "",
+                          "propertyType": "Object",
+                          "isRequired": true,
+                          "isReadOnly": false
+                        },
+                        [
+                          {
+                            "LeafNode": {
+                              "name": "population",
+                              "payload": {
+                                "Fuzzable": [
                                   "Int",
                                   "1000"
-                              ]
-                            },
-                            "isRequired": false,
-                            "isReadOnly": false
-                          }
-                        },
-                        {
-                          "LeafNode": {
-                            "name": "area",
-                            "payload": {
-                              "Constant": [
-                                "String",
-                                "5000"
-                              ]
-                            },
-                            "isRequired": false,
-                            "isReadOnly": false
-                          }
-                        },
-                        {
-                          "LeafNode": {
-                            "name": "strtest",
-                            "payload": {
-                                "Fuzzable": [
-                                    "String",
-                                    "true"
                                 ]
-                            },
-                            "isRequired": true,
-                            "isReadOnly": false
+                              },
+                              "isRequired": false,
+                              "isReadOnly": false
+                            }
+                          },
+                          {
+                            "LeafNode": {
+                              "name": "area",
+                              "payload": {
+                                "Constant": [
+                                  "String",
+                                  "5000"
+                                ]
+                              },
+                              "isRequired": false,
+                              "isReadOnly": false
+                            }
+                          },
+                          {
+                            "LeafNode": {
+                              "name": "strtest",
+                              "payload": {
+                                "Fuzzable": [
+                                  "String",
+                                  "true"
+                                ]
+                              },
+                              "isRequired": true,
+                              "isReadOnly": false
+                            }
                           }
-                        }
+                        ]
                       ]
-                    ]
+                    }
                   }
-                ]
               ]
             }
           ]
@@ -214,41 +215,46 @@
             "Schema",
             {
               "ParameterList": [
-                "location",
                 {
-                  "LeafNode": {
-                    "name": "",
-                    "payload": {
-                      "Custom": {
-                        "payloadType": "String",
-                        "primitiveType": "String",
-                        "payloadValue": "location",
-                        "isObject": false
-                      }
-                    },
-                    "isRequired": true,
-                    "isReadOnly": false
+                  "name": "location",
+                  "payload": {
+                    "LeafNode": {
+                      "name": "",
+                      "payload": {
+                        "Custom": {
+                          "payloadType": "String",
+                          "primitiveType": "String",
+                          "payloadValue": "location",
+                          "isObject": false
+                        }
+                      },
+                      "isRequired": true,
+                      "isReadOnly": false
+                    }
                   }
                 },
-                "group",
                 {
-                  "LeafNode": {
-                    "name": "",
-                    "payload": {
-                      "Fuzzable": [
-                        {
-                          "Enum": [
-                            "String",
-                            [
-                              "A",
-                              "BB",
-                              "CCC"
-                            ],
-                            null
-                          ]
-                        },
-                        "A"
-                      ]
+                  "name": "group",
+                  "payload":
+                  {
+                    "LeafNode": {
+                      "name": "",
+                      "payload": {
+                        "Fuzzable": [
+                          {
+                            "Enum": [
+                              "String",
+                              [
+                                "A",
+                                "BB",
+                                "CCC"
+                              ],
+                              null
+                            ]
+                          },
+                          "A"
+                        ]
+                      }
                     }
                   }
                 }
@@ -424,9 +430,10 @@
               "Schema",
               {
                 "ParameterList": [
-                  [
-                    "payload",
-                    {
+
+                  {
+                    "name": "payload",
+                    "payload": {
                       "InternalNode": [
                         {
                           "name": "",
@@ -474,7 +481,7 @@
                         ]
                       ]
                     }
-                  ]
+                  }
                 ]
               }
             ]
@@ -970,9 +977,9 @@
             "Examples",
             {
               "ParameterList": [
-                [
-                  "payload",
-                  {
+                {
+                  "name": "payload",
+                  "payload": {
                     "InternalNode": [
                       {
                         "name": "",
@@ -999,7 +1006,7 @@
                       ]
                     ]
                   }
-                ]
+                }
               ]
             }
           ],
@@ -1007,9 +1014,9 @@
             "Schema",
             {
               "ParameterList": [
-                [
-                  "payload",
-                  {
+                {
+                  "name": "payload",
+                  "payload": {
                     "InternalNode": [
                       {
                         "name": "",
@@ -1034,7 +1041,7 @@
                       ]
                     ]
                   }
-                ]
+                }
               ]
             }
           ]
@@ -1240,9 +1247,10 @@
             "Examples",
             {
               "ParameterList": [
-                [
-                  "examplequery",
-                  {
+
+                {
+                  "name": "examplequery",
+                  "payload": {
                     "LeafNode": {
                       "name": "",
                       "payload": {
@@ -1255,10 +1263,11 @@
                       "isReadOnly": false
                     }
                   }
-                ],
-                [
-                  "location",
-                  {
+                },
+
+                {
+                  "name": "location",
+                  "payload": {
                     "LeafNode": {
                       "name": "",
                       "payload": {
@@ -1273,7 +1282,7 @@
                       "isReadOnly": false
                     }
                   }
-                ]
+                }
               ]
             }
           ],
@@ -1281,9 +1290,10 @@
             "Examples",
             {
               "ParameterList": [
-                [
-                  "payload",
-                  {
+
+                {
+                  "name": "payload",
+                  "payload": {
                     "InternalNode": [
                       {
                         "name": "",
@@ -1310,7 +1320,7 @@
                       ]
                     ]
                   }
-                ]
+                }
               ]
             }
           ],
@@ -1318,9 +1328,9 @@
             "Examples",
             {
               "ParameterList": [
-                [
-                  "arrayQueryParameter",
-                  {
+                {
+                  "name": "arrayQueryParameter",
+                  "payload": {
                     "InternalNode": [
                       {
                         "name": "",
@@ -1358,7 +1368,7 @@
                       ]
                     ]
                   }
-                ]
+                }
               ]
             }
           ],
@@ -1366,20 +1376,22 @@
             "Schema",
             {
               "ParameterList": [
-                "location",
                 {
-                  "LeafNode": {
-                    "name": "",
-                    "payload": {
-                      "Custom": {
-                        "payloadType": "String",
-                        "primitiveType": "String",
-                        "payloadValue": "location",
-                        "isObject": false
-                      }
-                    },
-                    "isRequired": true,
-                    "isReadOnly": false
+                  "name": "location",
+                  "payload": {
+                    "LeafNode": {
+                      "name": "",
+                      "payload": {
+                        "Custom": {
+                          "payloadType": "String",
+                          "primitiveType": "String",
+                          "payloadValue": "location",
+                          "isObject": false
+                        }
+                      },
+                      "isRequired": true,
+                      "isReadOnly": false
+                    }
                   }
                 }
               ]
@@ -1391,9 +1403,10 @@
               "Schema",
               {
                 "ParameterList": [
-                  [
-                    "payload",
-                    {
+
+                  {
+                    "name": "payload",
+                    "payload": {
                       "InternalNode": [
                         {
                           "name": "",
@@ -1434,7 +1447,7 @@
                         ]
                       ]
                     }
-                  ]
+                  }
                 ]
               }
             ]
@@ -1646,22 +1659,23 @@
             [
               "Schema",
               {
-                "ParameterList": [
+                "ParameterList":
                   [
-                    "payload",
                     {
-                      "InternalNode": [
-                        {
-                          "name": "",
-                          "propertyType": "Object",
-                          "isRequired": true,
-                          "isReadOnly": false
-                        },
-                        [
+                      "name": "payload",
+                      "payload": {
+                        "InternalNode": [
+                          {
+                            "name": "",
+                            "propertyType": "Object",
+                            "isRequired": true,
+                            "isReadOnly": false
+                          },
+                          [
+                          ]
                         ]
-                      ]
+                      }
                     }
-                  ]
                 ]
               }
             ]
@@ -1952,9 +1966,9 @@
           },
           {
             "Custom": [
-                "UuidSuffix",
-                "itemName",
-                false
+              "UuidSuffix",
+              "itemName",
+              false
             ]
           }
         ],
@@ -1963,34 +1977,39 @@
             "Schema",
             {
               "ParameterList": [
-                "location",
                 {
-                  "LeafNode": {
-                    "name": "",
-                    "payload": {
-                      "Custom": {
-                        "payloadType": "String",
-                        "primitiveType": "String",
-                        "payloadValue": "location",
-                        "isObject": false
-                      }
-                    },
-                    "isRequired": true,
-                    "isReadOnly": false
+                  "name": "location",
+                  "payload": {
+                    "LeafNode": {
+                      "name": "",
+                      "payload": {
+                        "Custom": {
+                          "payloadType": "String",
+                          "primitiveType": "String",
+                          "payloadValue": "location",
+                          "isObject": false
+                        }
+                      },
+                      "isRequired": true,
+                      "isReadOnly": false
+                    }
                   }
                 },
-                "date",
+
                 {
-                  "LeafNode": {
-                    "name": "",
-                    "payload": {
-                      "Fuzzable": [
-                        "DateTime",
-                        "2020-1-1"
-                      ]
-                    },
-                    "isRequired": true,
-                    "isReadOnly": false
+                  "name": "date",
+                  "payload": {
+                    "LeafNode": {
+                      "name": "",
+                      "payload": {
+                        "Fuzzable": [
+                          "DateTime",
+                          "2020-1-1"
+                        ]
+                      },
+                      "isRequired": true,
+                      "isReadOnly": false
+                    }
                   }
                 }
               ]
@@ -2002,9 +2021,10 @@
               "Schema",
               {
                 "ParameterList": [
-                  [
-                    "payload",
-                    {
+
+                  {
+                    "name": "payload",
+                    "payload": {
                       "InternalNode": [
                         {
                           "name": "",
@@ -2018,8 +2038,8 @@
                               "name": "datetest",
                               "payload": {
                                 "Fuzzable": [
-                                    "DateTime",
-                                    "2020-1-1"
+                                  "DateTime",
+                                  "2020-1-1"
                                 ]
                               },
                               "isRequired": false,
@@ -2066,7 +2086,7 @@
                         ]
                       ]
                     }
-                  ]
+                  }
                 ]
               }
             ]
@@ -2264,9 +2284,10 @@
             "Schema",
             {
               "ParameterList": [
-                [
-                  "payload",
-                  {
+
+                {
+                  "name": "payload",
+                  "payload": {
                     "InternalNode": [
                       {
                         "name": "",
@@ -2279,7 +2300,7 @@
                           "LeafNode": {
                             "name": "city",
                             "payload": {
-                                "DynamicObject": "_city_put_name"
+                              "DynamicObject": "_city_put_name"
                             },
                             "isRequired": false,
                             "isReadOnly": false
@@ -2289,7 +2310,7 @@
                           "LeafNode": {
                             "name": "item",
                             "payload": {
-                                "DynamicObject": "_item_put_name"
+                              "DynamicObject": "_item_put_name"
                             },
                             "isRequired": false,
                             "isReadOnly": false
@@ -2298,7 +2319,7 @@
                       ]
                     ]
                   }
-                ]
+                }
               ]
             }
           ]

--- a/restler/unit_tests/log_baseline_test_files/test_grammar_body.json
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar_body.json
@@ -80,9 +80,9 @@
             "Schema",
             {
               "ParameterList": [
-                [
-                  "payload",
-                  {
+                {
+                  "name": "payload",
+                  "payload": {
                     "InternalNode": [
                       {
                         "name": "",
@@ -114,8 +114,8 @@
                                         "name": "population",
                                         "payload": {
                                           "Fuzzable": [
-                                              "Int",
-                                              "1000"
+                                            "Int",
+                                            "1000"
                                           ]
                                         },
                                         "isRequired": false,
@@ -139,10 +139,10 @@
                                       "LeafNode": {
                                         "name": "strtest",
                                         "payload": {
-                                            "Fuzzable": [
-                                                "String",
-                                                "true"
-                                            ]
+                                          "Fuzzable": [
+                                            "String",
+                                            "true"
+                                          ]
                                         },
                                         "isRequired": true,
                                         "isReadOnly": false
@@ -194,7 +194,7 @@
                       ]
                     ]
                   }
-                ]
+                }
               ]
             }
           ]
@@ -236,41 +236,45 @@
             "Schema",
             {
               "ParameterList": [
-                "location",
                 {
-                  "LeafNode": {
-                    "name": "",
-                    "payload": {
-                      "Custom": {
-                        "payloadType": "String",
-                        "primitiveType": "String",
-                        "payloadValue": "location",
-                        "isObject": false
-                      }
-                    },
-                    "isRequired": true,
-                    "isReadOnly": false
+                  "name": "location",
+                  "payload": {
+                    "LeafNode": {
+                      "name": "",
+                      "payload": {
+                        "Custom": {
+                          "payloadType": "String",
+                          "primitiveType": "String",
+                          "payloadValue": "location",
+                          "isObject": false
+                        }
+                      },
+                      "isRequired": true,
+                      "isReadOnly": false
+                    }
                   }
                 },
-                "group",
                 {
-                  "LeafNode": {
-                    "name": "",
-                    "payload": {
-                      "Fuzzable": [
-                        {
-                          "Enum": [
-                            "String",
-                            [
-                              "A",
-                              "BB",
-                              "CCC"
-                            ],
-                            null
-                          ]
-                        },
-                        "A"
-                      ]
+                  "name": "group",
+                  "payload": {
+                    "LeafNode": {
+                      "name": "",
+                      "payload": {
+                        "Fuzzable": [
+                          {
+                            "Enum": [
+                              "String",
+                              [
+                                "A",
+                                "BB",
+                                "CCC"
+                              ],
+                              null
+                            ]
+                          },
+                          "A"
+                        ]
+                      }
                     }
                   }
                 }
@@ -446,9 +450,9 @@
               "Schema",
               {
                 "ParameterList": [
-                  [
-                    "payload",
-                    {
+                  {
+                    "name": "payload",
+                    "payload": {
                       "InternalNode": [
                         {
                           "name": "",
@@ -535,7 +539,7 @@
                         ]
                       ]
                     }
-                  ]
+                  }
                 ]
               }
             ]

--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -37,7 +37,7 @@ module CodeGenerator =
 
             Restler.CodeGenerator.Python.generateCode
                 grammar1 configs.["demo_server"].IncludeOptionalParameters sw.Write
-            
+
             Assert.True((pythonGrammar1 = sw.GetStringBuilder().ToString()), "grammars are not equal")
 
 
@@ -55,8 +55,9 @@ module CodeGenerator =
                 [
                     Method OperationMethod.Get
                     Path pathPayload
-                    QueryParameters (ParameterList ["page", q1 ; "payload", q2])
-                    Body (ParameterList  ["theBody",b1])
+                    QueryParameters (ParameterList [{ name = "page" ; payload = q1 ; serialization = None }
+                                                    { name = "payload"; payload = q2; serialization = None} ])
+                    Body (ParameterList  [{ name = "theBody" ; payload = b1 ; serialization = None}])
                     RequestElement.HttpVersion "1.1"
                     Headers [("Accept", "application/json")
                              ("Host", "fromSwagger")
@@ -69,8 +70,9 @@ module CodeGenerator =
 
                     method = OperationMethod.Get
                     path = pathPayload
-                    queryParameters = [(ParameterPayloadSource.Examples, ParameterList ["page", q1 ; "payload", q2])]
-                    bodyParameters =  [ParameterPayloadSource.Examples, (ParameterList ["thebody", b1]) ]
+                    queryParameters = [(ParameterPayloadSource.Examples, ParameterList [{ name = "page"; payload = q1; serialization = None}
+                                                                                        { name = "payload"; payload = q2; serialization = None}])]
+                    bodyParameters =  [ParameterPayloadSource.Examples, (ParameterList [{ name = "thebody"; payload = b1; serialization = None}]) ]
                     httpVersion = "1.1"
                     headers = [("Accept", "application/json")
                                ("Host", "fromSwagger")
@@ -97,7 +99,7 @@ module CodeGenerator =
             let l2 = LeafNode p2
             let par = InternalNode (r, [l1 ; l2])
 
-            let result = Restler.CodeGenerator.Python.generatePythonParameter true ParameterKind.Body ("theBody", par)
+            let result = Restler.CodeGenerator.Python.generatePythonParameter true ParameterKind.Body { name = "theBody"; payload = par; serialization = None }
 
             let hasRegion = result |> Seq.tryFind (fun s -> s = (Restler_static_string_constant "\"region\":"))
             Assert.True(hasRegion.IsSome, "region not found")

--- a/src/compiler/Restler.Compiler/CodeGenerator.fs
+++ b/src/compiler/Restler.Compiler/CodeGenerator.fs
@@ -106,7 +106,8 @@ let rec getRestlerPythonPayload (payload:FuzzingPayload) (isQuoted:bool) : Reque
     | p -> [ getPrimitivePayload p ]
 
 /// Generate the RESTler grammar for a request parameter
-let generatePythonParameter includeOptionalParameters parameterKind (parameterName, parameterPayload) =
+let generatePythonParameter includeOptionalParameters parameterKind (p:RequestParameter) =
+    let (parameterName, parameterPayload) = p.name, p.payload
     let formatParameterName name =
         match parameterKind with
         | ParameterKind.Query ->
@@ -284,7 +285,7 @@ let generatePythonParameter includeOptionalParameters parameterKind (parameterNa
             else
                 payloadPrimitives
 
-        (formatParameterName parameterName) :: payloadPrimitives 
+        (formatParameterName parameterName) :: payloadPrimitives
     | ParameterKind.Body
     | ParameterKind.Path ->
         payloadPrimitives
@@ -315,9 +316,9 @@ let generatePythonFromRequestElement includeOptionalParameters (e:RequestElement
                                     if i > 0 then
                                         [
                                             yield Restler_static_string_constant "&"
-                                            yield! primitive 
+                                            yield! primitive
                                         ]
-                                        
+
                                     else primitive
                                )
                    |> List.concat
@@ -326,7 +327,7 @@ let generatePythonFromRequestElement includeOptionalParameters (e:RequestElement
             else
                 [
                     yield Restler_static_string_constant "?"
-                    yield! parameters 
+                    yield! parameters
                 ]
         | _ ->
             raise (UnsupportedType (sprintf "This request parameters payload type is not supported: %A" qp))
@@ -514,7 +515,7 @@ let generatePythonFromRequest (request:Request) includeOptionalParameters mergeS
                         // Add back the first two elements
                         (filteredPrimitives |> List.take 2)
                         @ (newPrimitiveSeq |> List.ofSeq)
-                        @ mergedStaticStringSeq 
+                        @ mergedStaticStringSeq
 
                     | _ ->
                         primitives
@@ -550,7 +551,7 @@ let getResponseParsers (responseParsers:ResponseParser list) =
     let random = System.Random(0)
 
     // First, define the dynamic variables initialized by the response parser
-    let dynamicObjectDefinitions = 
+    let dynamicObjectDefinitions =
         [
             for r in responseParsers do
                 for writerVariable in r.writerVariables do
@@ -811,7 +812,7 @@ let generateCode (grammar:GrammarDefinition) includeOptionalParameters (write : 
     let grammar = generatePythonGrammar grammar includeOptionalParameters
 
     grammar
-    |> Seq.iteri (fun i x -> 
+    |> Seq.iteri (fun i x ->
         let element = codeGenElement x
         if i = (Seq.length grammar) - 1 then
             write(element)

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -227,9 +227,31 @@ type ParameterPayloadSource =
     /// Parameters were defined in a payload example
     | Examples
 
+/// The parameter serialization style
+type StyleKind =
+    | Form
+
+/// Information related to how to serialize the parameter
+type ParameterSerialization =
+    {
+        /// Defines how multiple values are delimited
+        style : StyleKind
+
+        /// Specifies whether arrays and objects should generate
+        /// separate parameters for each array item or object property
+        explode : bool
+    }
+
+type RequestParameter =
+    {
+        name: string
+        payload: ParameterPayload
+        serialization: ParameterSerialization option
+    }
+
 /// The payload for request parameters
 type RequestParametersPayload =
-    | ParameterList of seq<string * ParameterPayload>
+    | ParameterList of seq<RequestParameter>
     | Example of FuzzingPayload
 
 /// All request parameters


### PR DESCRIPTION
- make it a record instead of tuple and add serialization property.

This refactoring is done in preparation of allowing different style values.  See issue #175.