### PR TITLE
Fix query examples and support different serialization formats.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/DictionaryTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DictionaryTests.fs
@@ -37,7 +37,7 @@ module Dictionary =
         [<Fact>]
         /// Test for custom payload uuid suffix
         let ``path and body parameter set to the same uuid suffix payload`` () =
-            let grammarOutputDirPath = @"c:\temp\restlertest" //ctx.testRootDirPath
+            let grammarOutputDirPath = ctx.testRootDirPath
             let config = { Restler.Config.SampleConfig with
                              IncludeOptionalParameters = true
                              GrammarOutputDirectoryPath = Some grammarOutputDirPath

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -23,6 +23,9 @@
     <Content Include="baselines\dictionaryTests\quoted_primitives_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="baselines\exampleTests\array_example_grammar.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="baselines\dependencyTests\path_in_dictionary_payload_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/baselines/exampleTests/array_example_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/exampleTests/array_example_grammar.py
@@ -1,0 +1,152 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_stores__storeId__order_post_id = dependencies.DynamicVariable("_stores__storeId__order_post_id")
+
+def parse_storesstoreIdorderpost(data):
+    """ Automatically generated response parser """
+    # Declare response variables
+    temp_7262 = None
+    # Parse the response into json
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    # Try to extract each dynamic object
+
+
+    try:
+        temp_7262 = str(data["id"])
+    except Exception as error:
+        # This is not an error, since some properties are not always returned
+        pass
+
+
+    # If no dynamic objects were extracted, throw.
+    if not (temp_7262):
+        raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
+
+    # Set dynamic variables
+    if temp_7262:
+        dependencies.set_variable("_stores__storeId__order_post_id", temp_7262)
+
+req_collection = requests.RequestCollection([])
+# Endpoint: /stores, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}/order, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("order"),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("apiVersion="),
+    primitives.restler_static_string("2020-02-02"),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("expiration="),
+    primitives.restler_static_string("10"),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("arrayQueryParameter="),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("arrayQueryParameter2="),
+    primitives.restler_static_string("a"),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("arrayQueryParameter2="),
+    primitives.restler_static_string("b"),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("arrayQueryParameter2="),
+    primitives.restler_static_string("c"),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("arrayQueryParameter3="),
+    primitives.restler_static_string("ddd"),
+    primitives.restler_static_string(","),
+    primitives.restler_static_string("eee"),
+    primitives.restler_static_string(","),
+    primitives.restler_static_string("fff"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "storeId":"23456",
+    "rush":"True",
+    "bagType":"paperfestive",
+    "item_descriptions":
+    [
+    ],
+    "item_feedback":
+    [
+        "great",
+        "awesome"
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+        'post_send':
+        {
+            'parser': parse_storesstoreIdorderpost,
+            'dependencies':
+            [
+                _stores__storeId__order_post_id.writer()
+            ]
+        }
+    },
+
+],
+requestId="/stores/{storeId}/order"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}/order/{orderId}, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("order"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores__storeId__order_post_id.reader()),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}/order/{orderId}"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/swagger/array_example.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/array_example.json
@@ -33,38 +33,46 @@
             }
         },
         "GroceryList": {
-            "properties": {
-                "storeId": {
-                    "description": "The unique identifier of the store",
-                    "type": "integer"
-                },
-                "rush": {
-                    "description": "Is it a rush order",
-                    "type": "boolean"
-                },
-                "bagType": {
-                    "description": "The type of bags to use",
-                    "type": "string"
-                },
-              "item_descriptions": {
-                "description": "The type of bags to use",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-                "useDoubleBags": {
-                    "description": "Whether to use double bags",
-                    "type": "boolean"
-                },
-                "bannedBrands": {
-                    "description": "do not use these brands",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
+          "properties": {
+            "storeId": {
+              "description": "The unique identifier of the store",
+              "type": "integer"
+            },
+            "rush": {
+              "description": "Is it a rush order",
+              "type": "boolean"
+            },
+            "bagType": {
+              "description": "The type of bags to use",
+              "type": "string"
+            },
+            "item_descriptions": {
+              "description": "The type of bags to use",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "item_feedback": {
+              "description": "The type of bags to use",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+
+            "useDoubleBags": {
+              "description": "Whether to use double bags",
+              "type": "boolean"
+            },
+            "bannedBrands": {
+              "description": "do not use these brands",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
+          }
         },
         "GroceryListItem": {
             "properties": {
@@ -155,7 +163,7 @@
                   "in": "query",
                   "name": "expiration",
                   "required": true,
-                  "type": "inteter"
+                  "type": "integer"
                 },
                 {
                   "in": "query",
@@ -168,6 +176,26 @@
                   }
                 },
                 {
+                  "in": "query",
+                  "name": "arrayQueryParameter2",
+                  "required": true,
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "in": "query",
+                  "name": "arrayQueryParameter3",
+                  "required": true,
+                  "type": "array",
+                  "style": "form",
+                  "explode":  false,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
                   "name": "orderDetails",
                   "in": "body",
                   "required": true,
@@ -176,7 +204,7 @@
                   }
                 }
               ],
-                "x-ms-examples": {
+                "examples": {
                     "Make an order": {
                         "$ref": "./examples/make_order_descriptions.json"
                     }

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/examples/create_application_gateway.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/examples/create_application_gateway.json
@@ -25,6 +25,14 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet/subnets/appgwsubnet"
               }
             }
+          },
+          {
+            "name": "appgwipc2",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet/subnets/appgwsubnet2"
+              }
+            }
           }
         ],
         "sslCertificates": [

--- a/src/compiler/Restler.Compiler.Test/swagger/examples/make_order_descriptions.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/examples/make_order_descriptions.json
@@ -1,7 +1,9 @@
 {
   "parameters": {
     "storeId": "23456",
-    "arrayQueryParameter": [ 40.0, 50.1234 ],
+    "arrayQueryParameter": [],
+    "arrayQueryParameter2": [ "a", "b", "c" ],
+    "arrayQueryParameter3": [ "ddd", "eee", "fff" ],
     "apiVersion": "2020-02-02",
     "expiration": 10,
     "orderDetails": {
@@ -9,8 +11,10 @@
       "rush": "True",
       "bagType": "paperfestive",
       "item_descriptions": [
-        "a green apple",
-        "a yellow pear"
+      ],
+      "item_feedback": [
+        "great",
+        "awesome"
       ]
     }
   },

--- a/src/compiler/Restler.Compiler/Config.fs
+++ b/src/compiler/Restler.Compiler/Config.fs
@@ -191,7 +191,7 @@ let SampleConfig =
         UseRefreshableToken = Some true
         AllowGetProducers = false
         EngineSettingsFilePath = None
-        DataFuzzing = false
+        DataFuzzing = true
         ApiNamingConvention = None
     }
 


### PR DESCRIPTION
## Summary of the Pull Request

The primary purpose of this PR is to fix query parameter formatting and support two different serialization formats for queries: ```Form``` with ```explode: true``` or ```explode: False```.  This implements the format per the following spec: https://swagger.io/docs/specification/serialization/.

While implementing this, several issues with schema and example support for arrays were also fixed:

1) Multiple array values in examples are now supported (up to max 5).
2) Empty array examples in queries and bodies are supported.  These are represented with an array without a leaf element in grammar.json. 
 Previously, an empty array was represented as an object - this is now fixed, so it can be fuzzed correctly.

Closes issue #175. 

## PR Checklist
* [x ] Applies to work item: #175 
* [ x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign.
* [ x] Tests added/passed.  
* [ ] Requires documentation to be updated
* [ x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach. Issue number where discussion took place: #xxx

## Info on Pull Request

- Changes to SwaggerVisitors.json to support the new style values and array fixes
- Updated and simplified logic in the CodeGenerator.fs to support different parameter serialization options
- New tests
 
## Validation Steps Performed

*Added new compiler test
*Manually tested that the engine works correctly with the payload body checker.  This will not be checked in because there is no way to automatically update the large grammar baseline in the engine tests.  This will be investigated separately.