### PR TITLE
Support header parameters

### DIFF
--- a/docs/user-guide/FuzzingDictionary.md
+++ b/docs/user-guide/FuzzingDictionary.md
@@ -1,6 +1,6 @@
 # Fuzzing Dictionary
 
-The fuzzing dictionary allows users to configure sets of values for specific data types or individual parameters.  
+The fuzzing dictionary allows users to configure sets of values for specific data types or individual parameters.
 
 There are three categories of configurable values in the dictionary:
 
@@ -10,7 +10,7 @@ There are three categories of configurable values in the dictionary:
 
 
 
-RESTler *automatically* generates references to the dictionary when it compiles a Swagger specification.  The dictionary elements correspond to grammar elements in the RESTler grammar, and will determine part of a payload for one or more requests.  
+RESTler *automatically* generates references to the dictionary when it compiles a Swagger specification.  The dictionary elements correspond to grammar elements in the RESTler grammar, and will determine part of a payload for one or more requests.
 
 The following describes how each property in the dictionary is used in a RESTler grammar.  If needed, users may also customize the grammar further by referring directly to the dictionary.
 
@@ -20,16 +20,30 @@ The following describes how each property in the dictionary is used in a RESTler
 
 - *restler_custom_payload* - specifies constants corresponding to "magic values" or pre-provisioned resources that are not created by the API under test.  These are usually single constant values, such as IDs for pre-provisioned resources.  In some cases, a list of strings may need to be specified, for example if an enum specifies dozens of constants, but only a few of them should be used during fuzzing.  Below are a few example custom payloads:
 
-  ``` json 
+  ``` json
   {
      "restler_custom_payload": {
          "api-version": "2020-10-27",
-         "/feedback/[0]/tags": [ "happy", "sad"]    
-     }   
+         "/feedback/[0]/tags": [ "happy", "sad"]
+     }
   }
   ```
 
-- *restler_custom_payload_header* - specifies custom header names and sets of values to include as custom headers.
+- *restler_custom_payload_header* - specifies a list of specific values required for header parameters.
+
+  There are two use cases:
+
+  1) specifying values that should be plugged into header parameters which are declared in the spec.  This works in the same way as *restler_custom_payload*.
+  2) specifying custom header names that are not included in the specification.  This allows passing in extra custom headers.
+
+  ``` json
+  {
+     "restler_custom_payload_header": {
+         "firstHeader": ["v1"],
+         "secondHeader": [ "a", "b"]
+     }
+  }
+  ```
 
 - *restler_custom_payload_uuid4_suffix* specifies constant values to which random GUID values will be appended.
 
@@ -38,4 +52,4 @@ Note: to specify a double-quote " in a string in a fuzzing dictionary, use `\"`
 
 #### **Per resource dictionaries**
 
-Usually, it is sufficient to specify a dictionary for the entire API under test, or one dictionary per API specification when several API specifications are tested together.  However, there may be cases when a specific endpoint requires a different custom payload from the rest of the APIs.  An example of this is when a service uses different API versions for different endpoints in the same API: the ```api-version``` parameter needs to be one of several values, but for specific endpoints, so it cannot be specified in one *restler_custom_payload*.  Such cases are handled with a per-resource dictionary for individual endpoints, which takes precedence over the global dictionary.  See [SettingsFile](SettingsFile.md) for how to configure a per-resource dictionary.   
+Usually, it is sufficient to specify a dictionary for the entire API under test, or one dictionary per API specification when several API specifications are tested together.  However, there may be cases when a specific endpoint requires a different custom payload from the rest of the APIs.  An example of this is when a service uses different API versions for different endpoints in the same API: the ```api-version``` parameter needs to be one of several values, but for specific endpoints, so it cannot be specified in one *restler_custom_payload*.  Such cases are handled with a per-resource dictionary for individual endpoints, which takes precedence over the global dictionary.  See [SettingsFile](SettingsFile.md) for how to configure a per-resource dictionary.

--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -59,6 +59,7 @@ module CodeGenerator =
                                                     { name = "payload"; payload = q2; serialization = None} ])
                     Body (ParameterList  [{ name = "theBody" ; payload = b1 ; serialization = None}])
                     RequestElement.HttpVersion "1.1"
+                    HeaderParameters (ParameterList [])
                     Headers [("Accept", "application/json")
                              ("Host", "fromSwagger")
                              ("Content-Type", "application/json")]
@@ -73,6 +74,7 @@ module CodeGenerator =
                     queryParameters = [(ParameterPayloadSource.Examples, ParameterList [{ name = "page"; payload = q1; serialization = None}
                                                                                         { name = "payload"; payload = q2; serialization = None}])]
                     bodyParameters =  [ParameterPayloadSource.Examples, (ParameterList [{ name = "thebody"; payload = b1; serialization = None}]) ]
+                    headerParameters =  [ParameterPayloadSource.Schema, (ParameterList []) ]
                     httpVersion = "1.1"
                     headers = [("Accept", "application/json")
                                ("Host", "fromSwagger")

--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -99,6 +99,35 @@ module Examples =
                          }
             Restler.Workflow.generateRestlerGrammar None config
 
+
+        [<Fact>]
+        let ``header example with and without dependencies`` () =
+            let grammarOutputDirectoryPath = ctx.testRootDirPath
+            let config = { Restler.Config.SampleConfig with
+                             IncludeOptionalParameters = true
+                             GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
+                             UseHeaderExamples = Some true
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\headers.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\headers_dict.json"))
+                         }
+            Restler.Workflow.generateRestlerGrammar None config
+            let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, "grammar.py")
+            let grammar = File.ReadAllText(grammarFilePath)
+
+            // The grammar should only contain the computer dimensions, because
+            // computerName is missing from the example
+            Assert.False(grammar.Contains("primitives.restler_static_string(\"computerName: \")"))
+            Assert.True(grammar.Contains("primitives.restler_static_string(\"computerDimensions: \")"))
+
+            // The grammar should contain the array items from the example
+            Assert.True(grammar.Contains("1.11"))
+            Assert.True(grammar.Contains("2.22"))
+
+            // The grammar contains the custom payload element
+            Assert.True(grammar.Contains("primitives.restler_custom_payload_header(\"rating\"),"))
+            Assert.True(grammar.Contains("primitives.restler_custom_payload_header(\"extra1\"),"))
+            Assert.True(grammar.Contains("primitives.restler_custom_payload_header(\"extra2\"),"))
+
         [<Fact>]
         let ``example in grammar without dependencies`` () =
 

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -144,6 +144,12 @@
     <Content Include="swagger\empty_array_example.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\headers.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\headers_dict.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\example_demo_dictionary.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -154,6 +160,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\DependencyTests\examples\create_application_gateway.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\examples\headers_example.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\DependencyTests\examples\create_subnet.json">

--- a/src/compiler/Restler.Compiler.Test/swagger/examples/headers_example.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/examples/headers_example.json
@@ -1,0 +1,8 @@
+{
+  "parameters": {
+    "computerDimensions": [ "1.11", "2.22" ],
+    "rating":  ["111"]
+  },
+  "responses": {
+  }
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/headers.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/headers.json
@@ -1,0 +1,66 @@
+{
+    "basePath": "/api",
+    "consumes": [
+        "application/json"
+    ],
+    "host": "localhost:8888",
+    "info": {
+        "description": "A simple swagger spec that uses headers",
+        "title": "Header example spec",
+        "version": "1.0"
+    },
+    "paths": {
+        "/servers/{serverId}/restart": {
+            "post": {
+              "parameters": [
+                {
+                  "in": "path",
+                  "name": "serverId",
+                  "required": true,
+                  "type": "integer"
+                },
+                {
+                  "in": "header",
+                  "name": "computerName",
+                  "description": "The name of the server computer (targetMachine).",
+                  "type": "string",
+                  "fullTypeName": "System.String",
+                  "required": true
+                },
+                {
+                  "in": "header",
+                  "name": "rating",
+                  "description": "The name of the server computer (targetMachine).",
+                  "type": "Number",
+                  "required": true
+                },
+                {
+                  "in": "header",
+                  "name": "computerDimensions",
+                  "required": true,
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "explode": false,
+                  "style": "simple"
+                }
+              ],
+                "examples": {
+                    "Example with header": {
+                        "$ref": "./examples/headers_example.json"
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "404": {
+                        "description": "Server not found."
+                    }
+                }
+            }
+        }
+    },
+    "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/headers_dict.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/headers_dict.json
@@ -1,0 +1,7 @@
+{
+  "restler_custom_payload_header": {
+    "rating": [ "555", "999" ],
+    "extra1": [ "one" ],
+    "extra2":  ["two"]
+  }
+}

--- a/src/compiler/Restler.Compiler/Config.fs
+++ b/src/compiler/Restler.Compiler/Config.fs
@@ -58,6 +58,8 @@ type Config =
 
         IncludeOptionalParameters : bool
 
+        UseHeaderExamples : bool option
+
         UseQueryExamples : bool option
 
         UseBodyExamples : bool option
@@ -183,6 +185,7 @@ let SampleConfig =
         IncludeOptionalParameters = true
         UseQueryExamples = None
         UseBodyExamples = None
+        UseHeaderExamples = None
         DiscoverExamples = false
         ExamplesDirectory = ""
         ResolveQueryDependencies = true
@@ -208,6 +211,7 @@ let DefaultConfig =
         GrammarOutputDirectoryPath = None
         IncludeOptionalParameters = true
         UseQueryExamples = Some true
+        UseHeaderExamples = None
         UseBodyExamples = Some true
         DiscoverExamples = false
         ExamplesDirectory = ""

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -300,6 +300,8 @@ let findProducerWithResourceName
 
     let producerEndpoint, producerContainer =
         match consumer.parameterKind with
+        | ParameterKind.Header ->
+            raise (Exception("producer-consumer dependencies in headers are not supported."))
         | ParameterKind.Body
         | ParameterKind.Query -> None, None
         | ParameterKind.Path ->
@@ -702,6 +704,8 @@ let getParameterDependencies parameterKind globalAnnotations
         let resourceReference =
 
             match parameterKind with
+            | ParameterKind.Header ->
+                raise (Exception("producer-consumer dependencies in headers are not supported."))
             | ParameterKind.Path ->
 
                 let pathToParameter =
@@ -744,6 +748,8 @@ let getParameterDependencies parameterKind globalAnnotations
             consumerList.Add(c)
 
     match parameterKind with
+    | ParameterKind.Header ->
+        raise (Exception("producer-consumer dependencies in headers are not supported."))
     | ParameterKind.Path ->
         let c = getConsumer parameterName [] None
         consumerList.Add(c)

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -89,6 +89,7 @@ type ParameterKind =
     | Path
     | Body
     | Query
+    | Header
 
 /// The primitive types supported by RESTler
 type PrimitiveType =
@@ -226,10 +227,13 @@ type ParameterPayloadSource =
     | Schema
     /// Parameters were defined in a payload example
     | Examples
+    /// Parameters were defined as a custom payload
+    | DictionaryCustomPayload
 
 /// The parameter serialization style
 type StyleKind =
     | Form
+    | Simple
 
 /// Information related to how to serialize the parameter
 type ParameterSerialization =
@@ -258,6 +262,8 @@ type RequestParametersPayload =
 type RequestParameters =
     {
         path: RequestParametersPayload
+
+        header: (ParameterPayloadSource * RequestParametersPayload) list
 
         /// List of several possible parameter sets that may be used to invoke a request.
         /// The payload source is not expected to be unique. For example, there may be several schemas
@@ -294,6 +300,7 @@ type RequestElement =
     | Method of OperationMethod
     | Path of FuzzingPayload list
     | QueryParameters of RequestParametersPayload
+    | HeaderParameters of RequestParametersPayload
     | Body of RequestParametersPayload
     | Token of string
     | RefreshableToken
@@ -327,6 +334,8 @@ type Request =
         queryParameters : (ParameterPayloadSource * RequestParametersPayload) list
 
         bodyParameters : (ParameterPayloadSource * RequestParametersPayload) list
+
+        headerParameters : (ParameterPayloadSource * RequestParametersPayload) list
 
         /// The token required to access the API
         token : TokenKind


### PR DESCRIPTION
Changes include:
1. Fuzz header parameters of simple and array types.
2. Support restler_custom_payload_header in dictionary.  This works the
same way as the other types of custom payloads: if a parameter with the
same name is found in the spec, the custom payload from the dictionary
is used instead.
3. Fix bug in the earlier introduced feature that extra custom payload
headers (custom headers) can be added in the dictionary.  This allows the use
case of providing header parameters that are not included in the spec.

Testing:
- added compiler unit tests
- manual testing

Closes #156