### PR TITLE
Fix dependencies in arrays regression.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/DependencyTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DependencyTests.fs
@@ -277,6 +277,41 @@ module Dependencies =
             |> Seq.iter (fun x -> Assert.True(grammar.Contains(x),
                                               sprintf "Grammar does not contain %s" x))
 
+        [<Fact>]
+        let ``array dependencies with multiple array items`` () =
+            // A custom dictionary payload is considered a dependency payload.
+            let customDictionary = Some ("{ \"restler_custom_payload\":\
+                                            { \"item_descriptions\": [\"[zzz, yyy]\"], \
+                                              \"callback_parameters\": [\"{\\\"data1\\\": 5}\"] } }\
+                                         ")
+            let grammarOutputDirPath = ctx.testRootDirPath
+
+            let config = { Restler.Config.SampleConfig with
+                             SwaggerSpecConfig =
+                                Some
+                                  [{
+                                      SpecFilePath =
+                                         Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\array_dep_multiple_items.json")
+                                      Dictionary = customDictionary
+                                      DictionaryFilePath = None
+                                      AnnotationFilePath = None
+                                  }]
+                             IncludeOptionalParameters = true
+                             GrammarOutputDirectoryPath = Some grammarOutputDirPath
+                             ResolveBodyDependencies = true
+                             ResolveQueryDependencies = true
+                             UseBodyExamples = None
+                         }
+
+            Restler.Workflow.generateRestlerGrammar None config
+            // Make sure the grammar file exists and there is just one dynamic object for the array, regardless of how
+            // many elements it had before.
+            let grammarFilePath = Path.Combine(grammarOutputDirPath,
+                                               Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
+            let grammar = File.ReadAllLines(grammarFilePath)
+            let grammarDynamicObject = "primitives.restler_custom_payload(\"item_descriptions\", quoted=False),"
+            let numberOfDynamicObjects = grammar |> Seq.filter (fun x -> x.Contains(grammarDynamicObject)) |> Seq.length
+            Assert.Equal( 1, numberOfDynamicObjects)
 
         interface IClassFixture<Fixtures.TestSetupAndCleanup>
 

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -71,6 +71,9 @@
     <Content Include="swagger\dictionaryTests\multipleIdenticalUuidSuffix.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\dependencyTests\array_dep_multiple_items.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\dictionaryTests\multipleIdenticalUuidSuffixDict.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/array_dep_multiple_items.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/array_dep_multiple_items.json
@@ -1,0 +1,215 @@
+{
+    "basePath": "/api",
+    "consumes": [
+        "application/json"
+    ],
+    "definitions": {
+        "Store": {
+            "properties": {
+                "id": {
+                    "description": "The unique identifier of a store",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "The name of the store",
+                    "type": "integer"
+                }
+            }
+        },
+        "Order": {
+            "properties": {
+                "id": {
+                    "description": "The unique identifier of an order",
+                    "type": "integer"
+                },
+                "eta": {
+                    "description": "The date the order will be ready",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "The order status",
+                    "type": "string"
+                }
+            }
+        },
+        "GroceryList": {
+          "properties": {
+            "storeId": {
+              "description": "The unique identifier of the store",
+              "type": "integer"
+            },
+            "rush": {
+              "description": "Is it a rush order",
+              "type": "boolean"
+            },
+            "metadata_properties": {
+              "description": "Custom properties",
+              "type": "object"
+            },
+            "callback_parameters": {
+               "$ref":  "#/definitions/GetCallbackUrlParameters"
+            },
+              "bagType": {
+                "description": "The type of bags to use",
+                "type": "string"
+              },
+              "item_descriptions": {
+                "description": "The type of bags to use",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "useDoubleBags": {
+                "description": "Whether to use double bags",
+                "type": "boolean"
+              },
+              "bannedBrands": {
+                "description": "do not use these brands",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+        },
+        "GroceryListItem": {
+            "properties": {
+                "name": {
+                    "description": "The name of the item",
+                    "type": "string"
+                },
+                "code": {
+                    "description": "The code of the item",
+                    "type": "integer"
+                },
+                "storeId": {
+                    "description": "The unique identifier of the store",
+                    "type": "integer"
+                },
+                "expirationMaxDate": {
+                    "description": "The maximum date that this item should expire",
+                    "type": "string"
+                }
+            }
+        },
+        "KeyType": {
+            "type": "string",
+            "enum": [
+                "NotSpecified",
+                "Primary",
+                "Secondary"
+            ],
+            "x-ms-enum": {
+                "name": "KeyType",
+                "modelAsString": false
+            }
+        },
+        "GetCallbackUrlParameters": {
+            "type": "object",
+            "properties": {
+                "notAfter": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "The expiry time."
+                },
+                "keyType": {
+                    "$ref": "#/definitions/KeyType",
+                    "description": "The key type."
+                }
+            },
+            "description": "The callback url parameters."
+        }
+
+    },
+    "host": "localhost:8888",
+    "info": {
+        "description": "A simple swagger spec that uses examples",
+        "title": "My Grocery API",
+        "version": "1.0"
+    },
+    "paths": {
+        "/stores/": {
+            "get": {
+                "operationId": "get_stores",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/Store"
+                        }
+                    }
+                }
+            }
+        },
+        "/stores/{storeId}/order": {
+            "post": {
+                "operationId": "make_an_order",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "storeId",
+                        "required": true,
+                        "type": "integer"
+                    },
+                    {
+                        "name": "orderDetails",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GroceryList"
+                        }
+                    }
+                ],
+                "x-ms-examples": {
+                    "Make an order": {
+                        "$ref": "../examples/make_order_empty_descriptions.json"
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    },
+                    "404": {
+                        "description": "Store not found."
+                    }
+                }
+            }
+        },
+        "/stores/{storeId}/order/{orderId}": {
+            "get": {
+                "operationId": "get_order",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "orderId",
+                        "required": true,
+                        "type": "integer"
+                    },
+                    {
+                        "in": "path",
+                        "name": "storeId",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    },
+                    "404": {
+                        "description": "Order not found."
+                    }
+                }
+            }
+        }
+    },
+    "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -1231,26 +1231,7 @@ module DependencyLookup =
                         Some payload
                     else
                         None
-
-            // Handle the special case that this payload is an array.
-            match dependencyPayload, p.propertyType with
-            | Some dp, NestedType.Array ->
-                if innerProperties |> Seq.length <> 1 then
-                    raise (UnsupportedType (sprintf "Inner properties of an array should always be one item, found %d"
-                                                    (innerProperties |> Seq.length)))
-                let arrayItem = innerProperties |> Seq.head
-
-                let dependencyArrayItem =
-                    Tree.LeafNode
-                        {
-                            name = ""
-                            payload = dp
-                            isRequired = p.isRequired
-                            isReadOnly = p.isReadOnly
-                        }
-                Tree.InternalNode (p, stn dependencyArrayItem)
-            | _ ->
-                Tree.InternalNode ({ p with payload = dependencyPayload }, innerProperties)
+            Tree.InternalNode ({ p with payload = dependencyPayload }, innerProperties)
 
         // First, check if the parameter itself has a dependency
         let (parameterName, properties) = requestParameter.name, requestParameter.payload


### PR DESCRIPTION
The check for just one array item needed to be removed as part of PR #181.

Found by NRP regression testing.

Also fixed the extra pair of brackets generated for a custom payload due to an extra incorrect level of indirection.