### PR TITLE
Fix custom headers engine bug.

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -597,14 +597,6 @@ class Request(object):
                         values = current_fuzzable_values
                     else:
                         values = [current_fuzzable_values]
-                    if values:
-                        values = list(
-                            map(
-                                lambda x: "{}: {}\r\n".\
-                                format(default_val, x),
-                                values
-                            )
-                        )
                 except primitives.CandidateValueException:
                     _raise_dict_err(primitive_type, default_val)
                 except Exception as err:


### PR DESCRIPTION
restler_custom_payload_header should be treated like any other custom payload.
Remove the special case handling in the engine, which causes an extra header
name to be printed.

Closes #192.