### PR TITLE
Fix mis-named property in results analyzer run summary.

### DIFF
--- a/src/ResultsAnalyzer/Analyze/Main.fs
+++ b/src/ResultsAnalyzer/Analyze/Main.fs
@@ -123,8 +123,7 @@ let main (args:AnalyzeArgs) =
     let runDataMap = failedByResponseCode |> Map.ofSeq
     let runSummary =
         {
-            RunSummary.requestsCount = failedStatusRequestResponsePairs |> Seq.length
-            sequencesCount = 0
+            RunSummary.failedRequestsCount = failedStatusRequestResponsePairs |> Seq.length
             RunSummary.bugCount = match runDataMap |> Map.tryFind BugResponseCode with
                                   | Some x -> x |> Seq.length
                                   | None -> 0

--- a/src/ResultsAnalyzer/Analyze/Types.fs
+++ b/src/ResultsAnalyzer/Analyze/Types.fs
@@ -63,11 +63,8 @@ type RequestExecutionSummary =
 
 type RunSummary =
     {
-        /// Total number of executed requests
-        requestsCount : int
-
-        /// Total number of executed sequences
-        sequencesCount : int
+        /// Total number of requests that were classified as a failure (e.g. 40x or 50x)
+        failedRequestsCount : int
 
         /// The number of bugs found.  Note: for now, this will be
         /// the same as the number of 'BugResponseCode' errors above.


### PR DESCRIPTION
The request count only includes failed requests.