### PR TITLE
Fix result analyzer crash

### DIFF
--- a/src/ResultsAnalyzer/Analyze/Main.fs
+++ b/src/ResultsAnalyzer/Analyze/Main.fs
@@ -16,9 +16,6 @@ open Restler.ResultsAnalyzer.Common.Log
 open Restler.ResultsAnalyzer.Common.Http
 
 [<Literal>]
-let UnknownResponseCode = 0
-
-[<Literal>]
 let DefaultMaxInstancesPerBucket = Int32.MaxValue
 
 type AnalyzeArgs =

--- a/src/ResultsAnalyzer/Analyze/Types.fs
+++ b/src/ResultsAnalyzer/Analyze/Types.fs
@@ -7,9 +7,14 @@ open System
 open System.Text.RegularExpressions
 
 [<Literal>]
+let UnknownResponseCode = 0
+
+[<Literal>]
 let BugResponseCode = 500
 let isFailure x =
-    x >= 400
+    x >= 400 ||
+    // Consider these a failure as well, so they are analyzed.
+    x = UnknownResponseCode
 
 let isBug x =
     x = BugResponseCode

--- a/src/ResultsAnalyzer/Common/Http.fs
+++ b/src/ResultsAnalyzer/Common/Http.fs
@@ -57,6 +57,8 @@ module Types =
             uri: Uri
             headers: Headers
             body: 'T
+            /// The raw request string
+            str : string option
         }
 
         override this.ToString() =
@@ -75,6 +77,8 @@ module Types =
             statusDescription: string
             headers: Headers
             body: 'T
+            /// The raw response string
+            str : string option
         }
 
         override this.ToString() =
@@ -193,6 +197,7 @@ module Request =
             uri = uri
             headers = headers
             body = body
+            str = None
         }
     }
 
@@ -211,6 +216,7 @@ module Request =
             uri = req.uri
             headers = req.headers
             body = f req.body
+            str = req.str
         }
 
     /// Hash to identify a particular request without having to compare or print the full contents.
@@ -235,6 +241,7 @@ module Response =
             statusDescription = description
             headers = headers
             body = body
+            str = None
         }
     }
 
@@ -251,6 +258,7 @@ module Response =
             statusDescription = resp.statusDescription
             headers = resp.headers
             body = f resp.body
+            str = resp.str
         }
 
 // Utility functions to map over parts of (request, response) pairs.

--- a/src/ResultsAnalyzer/Common/Log.fs
+++ b/src/ResultsAnalyzer/Common/Log.fs
@@ -44,7 +44,18 @@ module Log =
                 |> String.ofPythonRepr
                 |> Request.parse
             match parsedRequest with
-            | None -> eprintfn "Error: Could not parse request in line %d: %s" lineNo request; None
+            | None ->
+                eprintfn "Warning: could not parse request in line %d: %s" lineNo request
+                let r =
+                    {
+                        Request.version = ""
+                        Request.uri = {path = [] ; queryString = Map.empty<string, string>}
+                        Request.method = ""
+                        Request.headers = Map.empty<string, string>
+                        Request.body = ""
+                        str = Some request
+                    }
+                Some (Sending (date, r))
             | Some request -> Some (Sending (date, request))
         | Regex "^([^']*): Received: '(.*)'" [ date; response ] ->
             let date = parseDateTime date
@@ -53,7 +64,18 @@ module Log =
                 |> String.ofPythonRepr
                 |> Response.parse
             match parsedResponse with
-            | None -> eprintfn "Error: Could not parse response in line %d: %s" lineNo response; None
+            | None ->
+                eprintfn "Warning: could not parse response in line %d: %s" lineNo response
+                let r =
+                    {
+                        version = ""
+                        statusCode = 0
+                        statusDescription = ""
+                        headers = Map.empty<string, string>
+                        body = ""
+                        str = Some response
+                    }
+                Some (Received (date, r))
             | Some response -> Some (Received (date, response))
         | _ignoreOtherLogLines -> None
 


### PR DESCRIPTION
Result analyzer was failing when an invalid payload was sent (e.g. payload body checker) or received (e.g. xml instead of json).
This change works around the issue.

Support for bucketizing the above malformed requests/responses is not included, and will be added in a future change.