### PR TITLE
Handle chucked-encoding corner case (transfer of single chunk will hang)

### DIFF
--- a/restler/engine/transport_layer/messaging.py
+++ b/restler/engine/transport_layer/messaging.py
@@ -231,6 +231,10 @@ class HttpSock(object):
         chuncked_encoding = False
         if 'Transfer-Encoding: chunked\r\n' in data or\
             'transfer-encoding: chunked\r\n' in data:
+            # Handle corner case of single-chunk data transfer. Without this
+            # check, the next recv call on _sock will hang until timeout.
+            if data.endswith(DELIM):
+                return data
             chuncked_encoding = True
         if chuncked_encoding:
             while True:


### PR DESCRIPTION
Hi guys -- I hope everyone is doing well!

I added a corner-case-handling to avoid hanging on chucked transfer-encoding where small payloads (i.e., one chuck) are send. I run into this problem in a couple of open-source services. Hopefully, my addition doesn't break anything ^.^

Thanks,
--
Vaggelis