### PR TITLE
Better handling of array error case.

### DIFF
--- a/src/compiler/Restler.Compiler/SwaggerVisitors.fs
+++ b/src/compiler/Restler.Compiler/SwaggerVisitors.fs
@@ -397,6 +397,11 @@ module SwaggerVisitors =
                                                               (schema::parents) id))
             let arrayProperties =
                 if schema.IsArray then
+                    // OpenAPI parsing succeeds when the array does not have an element type declared
+                    // Check this here, and fail with an error.
+                    if isNull schema.Item then
+                        raise (ArgumentException("Invalid array schema: found array property without a declared element"))
+
                     // An example of this is an array type query parameter.
                     let arrayPayloadExampleValue, includeProperty = GenerateGrammarElements.extractPropertyFromArray exampleValue
                     if not includeProperty then


### PR DESCRIPTION
When an array does not declare an array item, NSwag/NJsonSchema still successfully parses the spec.  So, it is possible for RESTler to see an array schema without an array element.  This was failing with a null deref - the fix is  to throw an exception with an informative error message.


Closes #215.