### PR TITLE
new options to NameSpaceRuleChecker + minor checker-code cleanups

### DIFF
--- a/docs/user-guide/Checkers.md
+++ b/docs/user-guide/Checkers.md
@@ -34,7 +34,23 @@ If so, RESTler reports a bug.
 Detects that an unauthorized user can access service resources.
 
 Triggers after a valid sequence where the last request contains a consumed resource.
-Will then attempt to use that resource as a different, unauthorized, user.
+Will then attempt to use that resource as a different, unauthorized (attacker) user.
+
+The two following options can (optionally) be specified in the settings file:
+```
+"checkers": {
+    "namespacerule": {
+        "trigger_on_dynamic_objects" : true,
+        "trigger_objects" : ["tenantID", "userID"]
+    }
+}
+```
+
+If *trigger_on_dynamic_objects* is true, then the namespacerule checker performs all its checks as usual. (Default: true)
+
+*trigger_objects* is a list of strings. If this list is non-empty, any request containing any of these strings will be replayed using the attacker credentials. This way, the user can direct this checker to try attacker credentials for any request containing specific trigger_object strings (and regardless of whether the request consumes a resource, etc.). In the example above, any request which includes either the string "tenantID" or "userID" anywhere in its rendering (e.g., in its path, or body, or header, etc.) will be replayed with the attacker credentials. 
+
+Both options are independent of each other and can be used simultaneously.
 
 ## ResourceHierarchyChecker
 Detects that a child resource can be accessed from a different parent resource.

--- a/restler/checkers/namespace_rule_checker.py
+++ b/restler/checkers/namespace_rule_checker.py
@@ -108,7 +108,9 @@ class NameSpaceRuleChecker(CheckerBase):
         for obj in self._trigger_objects:
             if last_rendering.find(obj) != -1:
                 last_request_contains_a_trigger_object = True
-                self._checker_log.checker_print(f"\nThe last request contains trigger_object: {obj}\nThe last request rendering is:\n{last_rendering}\n")
+                self._checker_log.checker_print(f"\n\
+                    The last request contains trigger_object: {obj}\n\
+                    The last request rendering is:\n{last_rendering}\n")
                 break
 
         # Exit the checker if there is nothing to do.

--- a/restler/checkers/resource_hierarchy_checker.py
+++ b/restler/checkers/resource_hierarchy_checker.py
@@ -41,6 +41,7 @@ class ResourceHierarchyChecker(CheckerBase):
         predecessors_types = consumes[:-1]
         # Last request is the victim -- our target!
         target_types = consumes[-1]
+
         # In the dictionary of "consumes" constraints, each request of the
         # sequence instance has its own dictionary of the dynamic variable
         # types produced by each request. We need to flatten this structure.
@@ -52,22 +53,21 @@ class ResourceHierarchyChecker(CheckerBase):
                 or not target_types - predecessors_types:
             return
 
-        # For the victim types (target dynamic objects), get the lattest
+        # For the target_types, get the latest
         # values which we know will exist due to the previous rendering.
-        # We will later on use these old values atop a new rendering.
+        # We will later on use these old values with a new parent rendering.
         old_values = {}
         for target_type in target_types - predecessors_types:
            old_values[target_type] = dependencies.get_variable(target_type)
 
-        # Reset tlb of all values and re-render all predecessor up to
+        # Reset tlb of all values and re-render all predecessors up to
         # the parent's parent. This will propagate new values for all
-        # dynamic objects except for those with target type. That's what we
-        # want and that's why we render up to the parent's parent (i.e.,
-        # up to length(seq) - 2.
+        # dynamic objects except for those with the target type. That's
+        # why we render up to the parent's parent (i.e., up to length(seq) - 2).
         dependencies.reset_tlb()
 
         # Render sequence up to before the first predecessor that produces
-        # the target type. that is, if any of the types produced by the
+        # the target type. That is, if any of the types produced by the
         # request is in the target types, then do not render this
         # predecessor and stop here.
         n_predecessors =  0
@@ -81,17 +81,17 @@ class ResourceHierarchyChecker(CheckerBase):
         self._checker_log.checker_print("\nTarget types: {}".\
                             format(target_types - predecessors_types))
         self._checker_log.checker_print(f"Predecesor types: {predecessors_types}")
-        self._checker_log.checker_print("Clean tlb: {}".\
+        self._checker_log.checker_print("Clean dependencies: {}".\
                             format(dependencies.tlb))
 
         # Before rendering the last request, substitute all target types
         # (target dynamic object) with a value that does NOT belong to
-        # the current rendering and should not (?) be accessible through
+        # the current rendering and should not be accessible through
         # the new predecessors' rendering.
         for target_type in old_values:
             dependencies.set_variable(target_type, old_values[target_type])
 
-        self._checker_log.checker_print("Poluted tlb: {}".\
+        self._checker_log.checker_print("Poluted dependencies: {}".\
                             format(dependencies.tlb))
         self._render_last_request(new_seq)
 

--- a/restler/checkers/use_after_free_checker.py
+++ b/restler/checkers/use_after_free_checker.py
@@ -55,7 +55,7 @@ class UseAfterFreeChecker(CheckerBase):
 
         # Log some helpful info
         self._checker_log.checker_print(f"\nTarget types: {destructed_types}")
-        self._checker_log.checker_print(f"Clean tlb: {dependencies.tlb}")
+        self._checker_log.checker_print(f"Clean dependencies: {dependencies.tlb}")
 
         # Try using the deleted objects.
         self._use_after_free(destructed_types)
@@ -153,13 +153,14 @@ class UseAfterFreeChecker(CheckerBase):
         @rtype : Bool
 
         """
-        try:
-            # Handle gitlab merged braches type that cause  false alarms
-            for p in list(seq)[-2].definition:
-                if p[1] == '/repository/merged_branches':
-                    return True
-        except Exception:
-            pass
+        # Here is an example of code filtering for false alarms.
+        # #try:
+        #    # Handle gitlab merged branches type that cause false alarms
+        #    for p in list(seq)[-2].definition:
+        #        if p[1] == '/repository/merged_branches':
+        #            return True
+        #except Exception:
+        #    pass
 
         # If we reach this point no violation has occured.
         return False


### PR DESCRIPTION
Close #221 

This PR implements two new options for the NameSpaceRuleChecker (and includes some minor checker-code cleanups).

If trigger_on_dynamic_objects (optional) is true, then the namespacerule checker performs all its checks as usual. (Default: true)

trigger_objects (optional) is a list of strings; if this list is non-empty, any request containing any of these strings will be replayed using the attacker credentials. This way, the user can direct this checker to try attacker credentials for any request containing specific trigger_object values, like "tenantID".

The documentation has been updated.

Tests: manual testing with a sample RESTler job.