### PR TITLE
Support macOS as a platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ RESTler was created at Microsoft Research and is still under active development.
 
 ## Setting up RESTler
 
-RESTler was designed to run on 64-bit machines with Windows or Linux.
+RESTler was designed to run on 64-bit machines with Windows or Linux.  Experimental support for macOS is also enabled.
 
 ### **Build instructions**
 

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -269,7 +269,7 @@ module Fuzz =
             match pythonFilePath with
             | None ->
                 match Platform.getOSPlatform() with
-                | Platform.Platform.Linux ->
+                | Platform.Platform.Linux | Platform.Platform.MacOS ->
                     ["python3" ; "python"]
                 | Platform.Platform.Windows ->
                     ["python.exe"]

--- a/src/driver/Telemetry.fs
+++ b/src/driver/Telemetry.fs
@@ -26,8 +26,8 @@ module Telemetry =
         let machineTelemetryIdFileName = "restler.telemetry.uuid"
         let restlerSettingsCacheDir =
             match Types.Platform.getOSPlatform() with
-            | Types.Platform.Platform.Linux ->
-                "~/.config/microsoft/restler"
+            | Types.Platform.Platform.Linux | Types.Platform.MacOS ->
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + @"/.config/microsoft/restler"
             | Types.Platform.Platform.Windows ->
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\Restler";
         if not (Directory.Exists(restlerSettingsCacheDir)) then

--- a/src/driver/Types.fs
+++ b/src/driver/Types.fs
@@ -196,6 +196,7 @@ module Platform =
     type Platform =
         | Linux
         | Windows
+        | MacOS
 
     open System
     open System.Runtime.InteropServices
@@ -204,5 +205,7 @@ module Platform =
             Platform.Linux
         else if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
             Platform.Windows
+        else if RuntimeInformation.IsOSPlatform(OSPlatform.OSX) then
+            Platform.MacOS
         else
             raise (Exception("Platform not supported."))


### PR DESCRIPTION
This adds support for macOS.  Based on #154, I'm uncertain if the authors would like to support macOS.  However, I needed these changes for myself, and they're fairly straightforward.

If these changes are accepted, the README should likely be updated to reflect macOS support.

I've tested these changes on macOS.

Below is version information.

```
restler-fuzzer on  macos-support [?] took 24s
➜ python3 --version
Python 3.9.4

restler-fuzzer on  macos-support [?]
➜ dotnet --version
5.0.101

restler-fuzzer on  macos-support [?]
➜ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.15.7
BuildVersion:	19H524
```

The `build-restler.py` script runs successfully.

```
python3 ./build-restler.py --dest_dir $(pwd)/restler_bin
```

And calls to `Restler.dll` run successfully.

```
restler-fuzzer on  main [!?] took 5s
➜ dotnet ./restler_bin/restler/Restler.dll fuzz \
➜ --grammar_file ./Compile/grammar.py \
➜ --dictionary_file ./Compile/dict.json
Starting task Fuzz...
Using python: 'python3' (Python 3.9.4)
Request coverage (successful / total): 5 / 5
No bugs were found.
Task Fuzz succeeded.
Collecting logs...
```