### PR TITLE
Fix python grammar break due to string quoting

### DIFF
--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -154,6 +154,7 @@ module Examples =
             // computerName is missing from the example
             Assert.False(grammar.Contains("primitives.restler_static_string(\"computerName: \")"))
             Assert.True(grammar.Contains("primitives.restler_static_string(\"computerDimensions: \")"))
+            Assert.True(grammar.Contains("primitives.restler_static_string(\"\\\"quotedString\\\"\")"))
 
             // The grammar should contain the array items from the example
             Assert.True(grammar.Contains("1.11"))

--- a/src/compiler/Restler.Compiler.Test/swagger/examples/headers_example.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/examples/headers_example.json
@@ -1,7 +1,8 @@
 {
   "parameters": {
     "computerDimensions": [ "1.11", "2.22" ],
-    "rating":  ["111"]
+    "rating": [ "111" ],
+    "description":  "\"quotedString\""
   },
   "responses": {
   }

--- a/src/compiler/Restler.Compiler.Test/swagger/headers.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/headers.json
@@ -36,6 +36,13 @@
                 },
                 {
                   "in": "header",
+                  "name": "description",
+                  "description": "The description of the server computer (targetMachine).",
+                  "type": "string",
+                  "required": true
+                },
+                {
+                  "in": "header",
                   "name": "computerDimensions",
                   "required": true,
                   "type": "array",

--- a/src/compiler/Restler.Compiler/CodeGenerator.fs
+++ b/src/compiler/Restler.Compiler/CodeGenerator.fs
@@ -804,7 +804,12 @@ let getRequests(requests:Request list) includeOptionalParameters =
                 if s.Length > 1 then
                     s.Replace("'", "\\'"), "'"
                 else s, "'"
-            else if s.Contains("\"") then s.Replace("\"", "\\\""), "\""
+            // Special case already escaped quoted strings (this will be the case for example values).
+            // Assume the entire string is quoted in this case.
+            else if s.StartsWith("\\\"") then
+                s, "\""
+            else if s.Contains("\"") then
+                s.Replace("\"", "\\\""), "\""
             else s, "\""
         s, delim
 


### PR DESCRIPTION
Example values that are already fully escaped should not be escaped again.