### PR TITLE
Added logging for execptions to fix #220

### DIFF
--- a/restler/engine/core/driver.py
+++ b/restler/engine/core/driver.py
@@ -144,6 +144,7 @@ def apply_checkers(checkers, renderings, global_lock):
                 RAW_LOGGING(f"Checker: {checker.__class__.__name__} kicks out\n")
         except Exception as error:
             print(f"Exception {error!s} applying checker {checker}")
+            logger.exception(f"Exception {error!s} applying checker {checker}")
             raise
 
 
@@ -664,6 +665,9 @@ def generate_sequences(fuzzing_requests, checkers, fuzzing_jobs=1):
                 logger.write_to_main("Exhausted collection...")
                 seq_collection = []
                 seq_collection_exhausted = True
+            
+            except Exception as ERR:
+                logger.exeception(f"Failed rendering in generate_sequences")
 
             logger.write_to_main(
                 f"{formatting.timestamp()}: Generation: {generation} / "

--- a/restler/engine/core/postprocessing.py
+++ b/restler/engine/core/postprocessing.py
@@ -64,6 +64,7 @@ def delete_create_once_resources(destructors, fuzzing_requests):
             msg = f"Failed to delete create_once resource: {error!s}"
             logger.raw_network_logging(msg)
             logger.write_to_main(msg, print_to_console=True)
+            logger.exception(msg)
             if Settings().in_smoke_test_mode():
                 destructor.stats.request_order = 'Postprocessing'
                 destructor.stats.valid = 0

--- a/restler/engine/core/preprocessing.py
+++ b/restler/engine/core/preprocessing.py
@@ -143,7 +143,7 @@ def parse_grammar_schema(schema_json):
     except ValueError as err:
         logger.write_to_main(f"Failed to parse grammar file for examples: {err!s}", print_to_console=True)
         return False
-    except Exception as ERR
+    except Exception as ERR:
         logger.exception()
         return False
 

--- a/restler/engine/core/preprocessing.py
+++ b/restler/engine/core/preprocessing.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 from __future__ import print_function
-from logging import exception
 import re
 import json
 

--- a/restler/engine/core/preprocessing.py
+++ b/restler/engine/core/preprocessing.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 from __future__ import print_function
+from logging import exception
 import re
 import json
 
@@ -141,6 +142,9 @@ def parse_grammar_schema(schema_json):
         return True
     except ValueError as err:
         logger.write_to_main(f"Failed to parse grammar file for examples: {err!s}", print_to_console=True)
+        return False
+    except Exception as ERR
+        logger.exception()
         return False
 
 def apply_create_once_resources(fuzzing_requests):

--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -74,6 +74,7 @@ class RenderedRequestStats(object):
                             f"Error setting request stats for text: {request_text}",
                             print_to_console=True
                         )
+            logger.exception(f"Error setting request stats for text: {request_text}")
             pass
 
     def set_response_stats(self, final_request_response, final_response_datetime):
@@ -444,7 +445,7 @@ class Request(object):
             try:
                 if isinstance(line[1], str) and line[1].startswith(request_utilities.HOST_PREFIX):
                     return i
-            except:
+            except Exception:
                 # ignore line parsing exceptions - error will be returned if host not found
                 pass
         return -1

--- a/restler/restler.py
+++ b/restler/restler.py
@@ -122,6 +122,7 @@ def get_checker_list(req_collection, fuzzing_requests, enable_list, disable_list
             spec.loader.exec_module(checker)
             logger.write_to_main(f"Loaded custom checker from {custom_checker_file_path}", print_to_console=True)
         except Exception as err:
+            logger.write_to_main(f"Failed to load custom checker {custom_checker_file_path}: {err!s}", print_to_console=True)
             logger.exception(f"Failed to load custom checker {custom_checker_file_path}: {err!s}")
             sys.exit(-1)
 


### PR DESCRIPTION
Added logger.exception() with message where it seemed fitting with issue #220.
It's worth noting when you use "except:" it catches all errors just not the once in [Exception](https://docs.python.org/3/library/exceptions.html). Most commonly you catch something like KeyboardInterupt.

## PR Checklist
* [x] Applies to work item: #220
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign.
* [x] Tests added/passed.  
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach. Issue number where discussion took place: #220