### PR TITLE
Add simple unit test with baseline for smoke test algorithm.

### DIFF
--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -261,7 +261,7 @@ def call_response_parser(parser, response, request=None):
             if request:
                 for producer in request.produces:
                     if dependencies.get_variable(producer) == 'None':
-                        err_str = f'Failed to parse {producer}; is now set to None.'
+                        err_str = f'Failed to parse {producer}; it is now set to None.'
                         write_to_main(err_str)
                         _RAW_LOGGING(err_str)
     except (ResponseParsingException, AttributeError) as error:

--- a/restler/test_servers/unit_test_server/unit_test_resources.py
+++ b/restler/test_servers/unit_test_server/unit_test_resources.py
@@ -100,6 +100,13 @@ class ResourceFactory(object):
         if type == "group":
             return Group(name, body)
 
+        if type == "A":
+            return A(name, body)
+        if type == "B":
+            return B(name, body)
+        if type == "D":
+            return D(name, body)
+
         # Checker tests
         if type == "leakageruletest":
             resource = LeakageRuleTester(name, body)
@@ -124,7 +131,12 @@ class ResourcePool(UnitTestResource):
             "city": None,
             "farm": None,
             "item": None,
-            "group": None
+            "group": None,
+            "A": None,
+            "B": None,
+            "C": None,
+            "D": None,
+            "E": None
         }
 
         for test in Root_Test_Resource_Types:
@@ -183,6 +195,18 @@ class Group(UnitTestResource):
                 self._data['properties']['item'] = body['item']
             if 'city' in body:
                 self._data['properties']['city'] = body['city']
+
+class A(UnitTestResource):
+    def __init__(self, name: str, body: dict):
+        super().__init__(name)
+
+class B(UnitTestResource):
+    def __init__(self, name: str, body: dict):
+        super().__init__(name)
+
+class D(UnitTestResource):
+    def __init__(self, name: str, body: dict):
+        super().__init__(name)
 
 class LeakageRuleTester(UnitTestResource):
     pass

--- a/restler/unit_tests/log_baseline_test_files/abc_smoke_test_testing_log.txt
+++ b/restler/unit_tests/log_baseline_test_files/abc_smoke_test_testing_log.txt
@@ -1,0 +1,329 @@
+2021-05-28 15:50:50.109: Will refresh token: python D:\demo\restler-fuzzer\restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
+2021-05-28 15:50:50.184: New value: {'user1':{}, 'user2':{}}
+Authorization: valid_unit_test_token
+Authorization: shadow_unit_test_token
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 1)
+	Request hash: 23db74a21a5b43c1601d160252a5cd1b7ae89805
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2021-05-28 15:50:50.379: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:50.388: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 1)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2021-05-28 15:50:50.647: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:50.658: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 1)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2021-05-28 15:50:50.899: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:50.909: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+	Request hash: 23db74a21a5b43c1601d160252a5cd1b7ae89805
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2021-05-28 15:50:51.142: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:51.151: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2021-05-28 15:50:51.162: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:51.171: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+
+Generation-3: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Remaining candidate combinations: 1)
+	Request hash: 2d217a8041860f0742efe1b22a09893cd0e89ca5
+
+		- restler_static_string: 'GET '
+		- restler_static_string: '/C'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2021-05-28 15:50:51.589: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:51.601: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2021-05-28 15:50:51.613: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:51.625: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+2021-05-28 15:50:51.636: Sending: 'GET /C HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 20\r\n\r\n{"A": "A", "B": "B"}'
+
+2021-05-28 15:50:51.647: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"C": {}}'
+
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 1)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2021-05-28 15:50:51.996: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:52.006: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+	Request hash: 23db74a21a5b43c1601d160252a5cd1b7ae89805
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+2021-05-28 15:50:52.255: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:52.270: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2021-05-28 15:50:52.284: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:52.297: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+
+Generation-3: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Remaining candidate combinations: 1)
+	Request hash: a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/D/D'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+2021-05-28 15:50:52.797: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:52.807: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2021-05-28 15:50:52.820: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:52.831: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+2021-05-28 15:50:52.842: Sending: 'PUT /D/D HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 22\r\n\r\n{"A": "A", "B": "B"}\r\n'
+
+2021-05-28 15:50:52.854: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "D"}'
+
+
+Generation-4: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/D/D'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 4 (Remaining candidate combinations: 1)
+	Request hash: fb149c026c182b9719b5b5b37ef0ef3f0950c55a
+
+		- restler_static_string: 'GET '
+		- restler_static_string: '/E'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"D": "'
+		- restler_static_string: '_READER_DELIM_post_d_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2021-05-28 15:50:54.010: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:54.025: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2021-05-28 15:50:54.040: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2021-05-28 15:50:54.055: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+2021-05-28 15:50:54.068: Sending: 'PUT /D/D HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 22\r\n\r\n{"A": "A", "B": "B"}\r\n'
+
+2021-05-28 15:50:54.083: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "D"}'
+
+2021-05-28 15:50:54.098: Sending: 'GET /E HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 10\r\n\r\n{"D": "D"}'
+
+2021-05-28 15:50:54.113: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"E": {}}'
+

--- a/restler/unit_tests/log_baseline_test_files/abc_test_grammar.py
+++ b/restler/unit_tests/log_baseline_test_files/abc_test_grammar.py
@@ -1,0 +1,204 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This grammar was created manually.
+# There is no corresponding OpenAPI spec.
+
+from __future__ import print_function
+import json
+
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_post_a = dependencies.DynamicVariable(
+    "_post_a"
+)
+
+_post_b = dependencies.DynamicVariable(
+    "_post_b"
+)
+
+_post_d = dependencies.DynamicVariable(
+    "_post_d"
+)
+
+def parse_A(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_a", temp_123)
+
+def parse_B(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_b", temp_123)
+
+
+def parse_D(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_d", temp_123)
+
+
+req_collection = requests.RequestCollection([])
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/A/A"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_A,
+            'dependencies':
+            [
+                _post_a.writer()
+            ]
+        }
+    },
+
+],
+requestId="/A/{A}"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/B/B"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_B,
+            'dependencies':
+            [
+                _post_b.writer()
+            ]
+        }
+    },
+],
+requestId="/B/{B}"
+)
+req_collection.add_request(request)
+
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/C"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"A": "'),
+    primitives.restler_static_string(_post_a.reader()),
+    primitives.restler_static_string('", "B": "'),
+    primitives.restler_static_string(_post_b.reader()),
+    primitives.restler_static_string('"'),
+    primitives.restler_static_string("}"),
+],
+requestId="/C"
+)
+req_collection.add_request(request)
+
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/D/D"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"A": "'),
+    primitives.restler_static_string(_post_a.reader()),
+    primitives.restler_static_string('", "B": "'),
+    primitives.restler_static_string(_post_b.reader()),
+    primitives.restler_static_string('"'),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_D,
+            'dependencies':
+            [
+                _post_d.writer()
+            ]
+        }
+    },
+
+],
+requestId="/D/{D}"
+)
+req_collection.add_request(request)
+
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/E"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"D": "'),
+    primitives.restler_static_string(_post_d.reader()),
+    primitives.restler_static_string('"'),
+    primitives.restler_static_string("}"),
+],
+requestId="/E"
+)
+req_collection.add_request(request)
+
+

--- a/restler/unit_tests/test_test_server.py
+++ b/restler/unit_tests/test_test_server.py
@@ -64,7 +64,8 @@ class TestServerTest(unittest.TestCase):
         test_dict = {'city' :
             {'city-123': {'name': 'city-123', 'properties': {'population': 5000}},
             'city-456': {'name': 'city-456', 'properties': {}}},
-            'farm': {}, 'item': {}, 'group': {}
+            'farm': {}, 'item': {}, 'group': {},
+            'A': {},'B': {},'C': {}, 'D': {}, 'E': {}
             }
         self.assertDictEqual(test_dict, data)
 
@@ -86,7 +87,8 @@ class TestServerTest(unittest.TestCase):
 
         test_dict = {'city' :
             {'city-456': {'name': 'city-456', 'properties': {}}},
-            'farm': {}, 'item': {}, 'group': {}
+            'farm': {}, 'item': {}, 'group': {},
+             'A': {},'B': {},'C': {}, 'D': {}, 'E': {}
             }
         self.assertDictEqual(test_dict, data)
 


### PR DESCRIPTION
In preparation for merging #233, we need to have a simple unit test with which we can review
the behavior change.  This commit adds such a unit test.

The unit test has 4 requests, A, B, C, D, and E.  A and B do not have any dependencies, while C and D
both depend on both A and B, and E depends on D.
The baseline 'abc_smoke_test_testing_log.txt' captures the current behavior with respect to this grammar.

In the current implementation, sequences for A, B, C, D will be
rendered "from scratch", but the sequence for E will reuse the 'D' prefix.