### PR TITLE
add new option save_results_in_fixed_dirname

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -111,6 +111,9 @@ Set to True to disable SSL for requests
 ### path_regex: str (default None=No regex filtering)
 Filters the grammar to only use endpoints whose paths contain the given regex string.
 
+### save_results_in_fixed_dirname: bool (default False)
+Save the results in a directory with a fixed name (skip the 'experiment\<pid\>' subdir).
+
 ### request_throttle_ms: float (default None)
 The time, in milliseconds, to throttle each request being sent.
 This is here for special cases where the server will block requests from connections that arrive too quickly.

--- a/restler/restler.py
+++ b/restler/restler.py
@@ -258,6 +258,9 @@ if __name__ == '__main__':
     parser.add_argument('--no_tokens_in_logs',
                         help='Do not print auth token data in logs (default: False)',
                         type=bool, default=False, required=False)
+    parser.add_argument('--save_results_in_fixed_dirname',
+                        help='Save results in a directory with a fixed name (default: False)',
+                        type=bool, default=False, required=False)
     parser.add_argument('--host',
                         help='Set to override Host in the grammar (default: do not override)',
                         type=str, default=None, required=False)
@@ -339,6 +342,9 @@ if __name__ == '__main__':
             except Exception as error:
                 print(f"Cannot import custom mutations: {error!s}")
                 sys.exit(-1)
+
+    if settings.save_results_in_fixed_dirname:
+        logger.save_results_in_fixed_dirname()
 
     # Create the directory where all the results will be saved
     try:

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -415,6 +415,8 @@ class RestlerSettings(object):
         self._no_ssl = SettingsArg('no_ssl', bool, False, user_args)
         ## Do not print auth token data in logs
         self._no_tokens_in_logs = SettingsArg('no_tokens_in_logs', bool, True, user_args)
+        ## Save the results in a dir with a fixed name (skip 'experiment<pid>' subdir)
+        self._save_results_in_fixed_dirname = SettingsArg('save_results_in_fixed_dirname', bool, False, user_args)
         ## Limit restler grammars only to endpoints whose paths contain a given substring
         self._path_regex = SettingsArg('path_regex', str, None, user_args)
         ## Minimum time, in milliseconds, to wait between sending requests
@@ -539,6 +541,10 @@ class RestlerSettings(object):
     @property
     def no_tokens_in_logs(self):
         return self._no_tokens_in_logs.val
+
+    @property
+    def save_results_in_fixed_dirname(self):
+        return self._save_results_in_fixed_dirname.val
 
     @property
     def path_regex(self):

--- a/restler/unit_tests/restler_user_settings.json
+++ b/restler/unit_tests/restler_user_settings.json
@@ -2,6 +2,7 @@
     "client_certificate_path": "\\path\\to\\file.pem",
     "max_combinations": 20,
     "max_request_execution_time": 90,
+    "save_results_in_fixed_dirname": false,
     "global_producer_timing_delay": 2,
     "dyn_objects_cache_size": 200,
     "fuzzing_jobs": 2,

--- a/restler/unit_tests/test_restler_settings.py
+++ b/restler/unit_tests/test_restler_settings.py
@@ -466,6 +466,8 @@ class RestlerSettingsTest(unittest.TestCase):
         self.assertEqual(20, settings.max_combinations)
         self.assertEqual(90, settings.max_request_execution_time)
 
+        self.assertEqual(False, settings.save_results_in_fixed_dirname)
+
         self.assertEqual(True, hex_def(request1) in settings.create_once_endpoints)
         self.assertNotEqual(True, hex_def(request2) in settings.create_once_endpoints)
 

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -23,6 +23,7 @@ PREPROCESSING_GENERATION = -1
 POSTPROCESSING_GENERATION = -2
 
 SETTINGS_NO_TOKENS_IN_LOGS = False
+SETTINGS_SAVE_RESULTS_IN_FIXED_DIRNAME = False
 
 # Experiment dir containing all logs
 EXPERIMENT_DIR = None
@@ -110,18 +111,31 @@ def no_tokens_in_logs():
     SETTINGS_NO_TOKENS_IN_LOGS = True
     return
 
+def save_results_in_fixed_dirname():
+    """ Save results in a directory with a fixed name
+    @ return: None
+    @rtype: None
+    """
+    global SETTINGS_SAVE_RESULTS_IN_FIXED_DIRNAME
+    SETTINGS_SAVE_RESULTS_IN_FIXED_DIRNAME = True
+    return
+
 def create_experiment_dir():
     """ creates the unique EXPERIMENT_DIR directory where results are saved
     @return: None
     @rtype: None
     """
     global EXPERIMENT_DIR
-    adder = 0
-    while True:
-        EXPERIMENT_DIR = os.path.join(os.getcwd(), 'RestlerResults', f'experiment{(os.getpid() + adder)!s}')
-        if not os.path.isdir(EXPERIMENT_DIR):
-            break
-        adder += 1
+    global SETTINGS_SAVE_RESULTS_IN_FIXED_DIRNAME
+    if SETTINGS_SAVE_RESULTS_IN_FIXED_DIRNAME:
+        EXPERIMENT_DIR = os.path.join(os.getcwd(), 'RestlerResults')
+    else:
+        adder = 0
+        while True:
+            EXPERIMENT_DIR = os.path.join(os.getcwd(), 'RestlerResults', f'experiment{(os.getpid() + adder)!s}')
+            if not os.path.isdir(EXPERIMENT_DIR):
+                break
+            adder += 1
 
     global CKPT_DIR
     CKPT_DIR = os.path.join(EXPERIMENT_DIR, 'checkpoints')


### PR DESCRIPTION
closes #240 

Removes/skips the "experiment<pid>" subdir under RestlerResults if the new option 'save_results_in_fixed_dirname' = true in the settings.json file.

Default value is False, so this feature is backward-compatible and off by default.

Tests: manually with a sample RESTler job in Test mode.

Note: this PR can wait to be merged after PR #206 (I can take care of the few potential merge conflicts with #206).