### PR TITLE
Fix initialization for "except" clause in annotations.

### DIFF
--- a/src/compiler/Restler.Compiler/Annotations.fs
+++ b/src/compiler/Restler.Compiler/Annotations.fs
@@ -63,10 +63,19 @@ let parseAnnotation (ann:JToken) =
                 (ResourceName producerId.resourceName),
                 producerId
 
+        let exceptConsumerId =
+            match annotation.except with
+            | None -> None
+            | Some exceptConsumer ->
+                Some {
+                        endpoint = exceptConsumer.consumer_endpoint
+                        method = getOperationMethodFromString exceptConsumer.consumer_method
+                     }
+
         Some {  ProducerConsumerAnnotation.producerId = producerId
                 consumerParameter = consumerParameter
                 producerParameter = producerParameter
-                exceptConsumerId = None
+                exceptConsumerId = exceptConsumerId
              }
 
 /// Gets annotation data from Json


### PR DESCRIPTION
The except was not initialized (this was a regression from a prior refactoring).

This was discovered by a user bug report.