### PR TITLE
Fix bug that caused invalid Python identifier to be generated.

### DIFF
--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -373,6 +373,10 @@ let generateDynamicObjectVariableName (requestId:RequestId) (accessPath:AccessPa
         match accessPath with
         | None -> Array.empty
         | Some ap -> ap.getPathPartsForName()
+    let objIdParts =
+        objIdParts
+        |> Seq.map (fun part -> part.Split(replaceTargets, System.StringSplitOptions.None))
+        |> Seq.concat
     let parts = endpointParts
                 @ [(requestId.method.ToString().ToLower())]
                 @ (objIdParts |> Seq.toList)


### PR DESCRIPTION
The logic to replace hyphens was included only for path strings, but was missing for identifier names.