### PR TITLE
Add the ability to track parameter values in the spec coverage file.

### DIFF
--- a/docs/user-guide/CompilerConfig.md
+++ b/docs/user-guide/CompilerConfig.md
@@ -97,3 +97,6 @@ catch consistency bugs in the specification because producer-consumer dependenci
     HyphenSeparator
     UnderscoreSeparator
     ```
+* *TrackFuzzedParameterNames* False by default.  When true, every fuzzable primitive will
+include an additional parameter `param_name` which is the name of the property or
+parameter being fuzzed.  These will be used to capture fuzzed parameters in ```tracked_parameters``` in the spec coverage file.

--- a/docs/user-guide/Testing.md
+++ b/docs/user-guide/Testing.md
@@ -105,7 +105,8 @@ During each Test run a `speccov.json` file will be created in the logs directory
             "response_body": "{\n    \"errors\": {\n        \"id\": \"'5882' is not of type 'integer'\"\n    },\n    \"message\": \"Input payload validation failed\"\n}\n"
         },
         "tracked_parameters": {
-            "per_page_9": "2"
+            "per_page": ["2"],
+            "page": ["1"]
         }
     },
 ```
@@ -135,7 +136,9 @@ the coverage data is being reported.
 * The __"tracked_parameters"__ property is optional and generated only when using
 `Test` mode with ```test-all-combinations```.
 This property contains key-value pairs of all of the parameters
-for which more than one value is being tested.
+for which more than one value is being tested.  By default, enums and custom payloads
+are always tracked.  In addition, when the specification was compiled with
+`TrackFuzzedParameterNames` set to `true`, all fuzzable parameters will be tracked.
 
 #### Postprocessing Scripts:
 The `utilities` directory contains a sub-directory called `speccovparsing` that contains scripts for postprocessing speccov files.

--- a/restler/engine/core/sequences.py
+++ b/restler/engine/core/sequences.py
@@ -350,7 +350,8 @@ class Sequence(object):
             dependencies.reset_tlb()
 
             sequence_failed = False
-            request._tracked_parameters = tracked_parameters
+            request._tracked_parameters = {}
+            request.update_tracked_parameters(tracked_parameters)
             # Step A: Static template rendering
             # Render last known valid combination of primitive type values
             # for every request until the last
@@ -360,7 +361,7 @@ class Sequence(object):
                     prev_request.render_current(candidate_values_pool,
                     preprocessing=preprocessing)
 
-                request._tracked_parameters.update(tracked_parameters)
+                request.update_tracked_parameters(tracked_parameters)
 
                 # substitute reference placeholders with resolved values
                 if not Settings().ignore_dependencies:

--- a/restler/engine/fuzzing_parameters/body_schema.py
+++ b/restler/engine/fuzzing_parameters/body_schema.py
@@ -201,10 +201,10 @@ class BodySchema():
                 examples = request_block[3]
                 value = None
             else:
-                field_name = None
                 value = request_block[1]
                 quoted = request_block[2]
                 examples = request_block[3]
+                field_name = request_block[4]
 
             # accumulate
             if primitive_type == primitives.STATIC_STRING:

--- a/restler/engine/primitives.py
+++ b/restler/engine/primitives.py
@@ -51,6 +51,11 @@ UNQUOTED_STR = '_unquoted'
 # Optional argument passed to fuzzable primitive definition function that can
 # provide an example value.  This value is used instead of the default value if present.
 EXAMPLES_ARG = 'examples'
+# Optional argument passed to fuzzable primitive definition function that can
+# provide the name of the parameter being fuzzed.
+# This value is used in test-all-combinations mode to allow the user to analyze spec coverage
+# for particular parameter values.
+PARAM_NAME_ARG = 'param_name'
 class CandidateValues(object):
     def __init__(self):
         self.unquoted_values = []
@@ -374,7 +379,8 @@ def restler_static_string(*args, **kwargs):
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
     examples = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 
 def restler_fuzzable_string(*args, **kwargs):
@@ -400,7 +406,10 @@ def restler_fuzzable_string(*args, **kwargs):
     examples=None
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    if PARAM_NAME_ARG in kwargs:
+        param_name = kwargs[PARAM_NAME_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 def restler_fuzzable_int(*args, **kwargs):
     """ Integer primitive.
@@ -425,7 +434,10 @@ def restler_fuzzable_int(*args, **kwargs):
     examples=None
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    if PARAM_NAME_ARG in kwargs:
+        param_name = kwargs[PARAM_NAME_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 
 def restler_fuzzable_bool(*args, **kwargs):
@@ -451,7 +463,10 @@ def restler_fuzzable_bool(*args, **kwargs):
     examples=None
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    if PARAM_NAME_ARG in kwargs:
+        param_name = kwargs[PARAM_NAME_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 
 def restler_fuzzable_number(*args, **kwargs):
@@ -477,7 +492,10 @@ def restler_fuzzable_number(*args, **kwargs):
     examples=None
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    if PARAM_NAME_ARG in kwargs:
+        param_name = kwargs[PARAM_NAME_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 
 def restler_fuzzable_delim(*args, **kwargs):
@@ -503,7 +521,10 @@ def restler_fuzzable_delim(*args, **kwargs):
     examples=None
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    if PARAM_NAME_ARG in kwargs:
+        param_name = kwargs[PARAM_NAME_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 
 def restler_fuzzable_group(*args, **kwargs):
@@ -536,7 +557,8 @@ def restler_fuzzable_group(*args, **kwargs):
     examples=None
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
-    return sys._getframe().f_code.co_name, field_name, enum_vals, quoted, examples
+    param_name = None
+    return sys._getframe().f_code.co_name, field_name, enum_vals, quoted, examples, param_name
 
 
 def restler_fuzzable_uuid4(*args, **kwargs):
@@ -562,7 +584,10 @@ def restler_fuzzable_uuid4(*args, **kwargs):
     examples=None
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    if PARAM_NAME_ARG in kwargs:
+        param_name = kwargs[PARAM_NAME_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 
 def restler_fuzzable_datetime(*args, **kwargs) :
@@ -589,7 +614,10 @@ def restler_fuzzable_datetime(*args, **kwargs) :
     examples=None
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    if PARAM_NAME_ARG in kwargs:
+        param_name = kwargs[PARAM_NAME_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 def restler_fuzzable_object(*args, **kwargs) :
     """ object primitive ({})
@@ -614,7 +642,9 @@ def restler_fuzzable_object(*args, **kwargs) :
     examples=None
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    if PARAM_NAME_ARG in kwargs:
+        param_name = kwargs[PARAM_NAME_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 def restler_multipart_formdata(*args, **kwargs):
     """ Multipart/formdata primitive
@@ -638,7 +668,8 @@ def restler_multipart_formdata(*args, **kwargs):
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
     examples = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 
 def restler_custom_payload(*args, **kwargs):
@@ -662,7 +693,8 @@ def restler_custom_payload(*args, **kwargs):
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
     examples = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 
 def restler_custom_payload_header(*args, **kwargs):
@@ -686,7 +718,8 @@ def restler_custom_payload_header(*args, **kwargs):
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
     examples = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 
 def restler_custom_payload_uuid4_suffix(*args, **kwargs):
@@ -710,7 +743,8 @@ def restler_custom_payload_uuid4_suffix(*args, **kwargs):
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
     examples = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 
 def restler_refreshable_authentication_token(*args, **kwargs):
@@ -734,4 +768,5 @@ def restler_refreshable_authentication_token(*args, **kwargs):
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
     examples = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples
+    param_name = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name

--- a/restler/unit_tests/log_baseline_test_files/test_grammar.json
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar.json
@@ -137,7 +137,9 @@
                               "payload": {
                                 "Fuzzable": [
                                   "Int",
-                                  "1000"
+                                  "1000",
+                                  null,
+                                  "population"
                                 ]
                               },
                               "isRequired": false,

--- a/restler/unit_tests/log_baseline_test_files/test_grammar.py
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar.py
@@ -223,8 +223,12 @@ request = requests.Request([
     primitives.restler_static_string("\r\n"),
     primitives.restler_static_string("{"),
     primitives.restler_static_string('"population":'),
-    primitives.restler_fuzzable_int('10000', quoted=True),
+    primitives.restler_fuzzable_int('10000', quoted=True, param_name="population"),
     primitives.restler_static_string(', "area": "5000",'),
+    # Note: There is a discrepancy here due to
+    # manual creation of this grammar - the fuzzable string
+    # does not match the grammar.json, which contains
+    # a constant string for this value.
     primitives.restler_fuzzable_string('strtest', quoted=True),
     primitives.restler_static_string(':'),
     primitives.restler_fuzzable_bool('true', quoted=True),
@@ -626,7 +630,7 @@ request = requests.Request([
     primitives.restler_static_string("{"),
     primitives.restler_static_string('testbool', quoted=True),
     primitives.restler_static_string(':'),
-    primitives.restler_fuzzable_bool("testval", quoted=True),
+    primitives.restler_fuzzable_bool("testval", quoted=True, param_name="testbool"),
     primitives.restler_static_string(',"location":'),
     primitives.restler_custom_payload("location", quoted=True),
     primitives.restler_static_string("}"),
@@ -849,7 +853,7 @@ request = requests.Request([
     primitives.restler_static_string("\r\n"),
     primitives.restler_static_string("{"),
     primitives.restler_static_string('"datetest":'),
-    primitives.restler_fuzzable_datetime("2020-1-1", quoted=True),
+    primitives.restler_fuzzable_datetime("2020-1-1", quoted=True, example=["2020-2-2"], param_name="datetest"),
     primitives.restler_static_string(',"id":'),
     primitives.restler_static_string('"/testparts/'),
     primitives.restler_custom_payload("testcustomparts", quoted=False),

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -480,10 +480,10 @@ def custom_network_logging(sequence, candidate_values_pool, **kwargs):
                 quoted = request_block[2]
                 examples = request_block[3]
             else:
-                field_name = None
                 default_val = request_block[1]
                 quoted = request_block[2]
                 examples = request_block[3]
+                field_name = request_block[4]
 
             # Handling dynamic primitives that need fresh rendering every time
             if primitive == "restler_fuzzable_uuid4":

--- a/src/compiler/Restler.Compiler/Config.fs
+++ b/src/compiler/Restler.Compiler/Config.fs
@@ -102,6 +102,11 @@ type Config =
         // When specified, use only this naming convention to infer
         // producer-consumer dependencies.
         ApiNamingConvention : NamingConvention option
+
+        // When this switch is on, the generated grammar will contain
+        // parameter names for all fuzzable values.  For example:
+        // restler_fuzzable_string("1", param_name="num_items")
+        TrackFuzzedParameterNames : bool
     }
 
 let convertToAbsPath (currentDirPath:string) (filePath:string) =
@@ -209,6 +214,7 @@ let SampleConfig =
         EngineSettingsFilePath = None
         DataFuzzing = true
         ApiNamingConvention = None
+        TrackFuzzedParameterNames = false
     }
 
 /// The default config used for unit tests.  Most of these should also be the defaults for
@@ -238,4 +244,5 @@ let DefaultConfig =
         EngineSettingsFilePath = None
         DataFuzzing = false
         ApiNamingConvention = None
+        TrackFuzzedParameterNames = false
     }

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -734,7 +734,7 @@ let getParameterDependencies parameterKind globalAnnotations
             let resourceAccessPath = PropertyAccessPaths.getLeafAccessPath parentAccessPath p
             let primitiveType =
                 match p.payload with
-                | FuzzingPayload.Fuzzable (pt, _, _) -> Some pt
+                | FuzzingPayload.Fuzzable (pt, _, _,_) -> Some pt
                 | FuzzingPayload.Constant (pt, _) -> Some pt
                 | FuzzingPayload.Custom c -> Some c.primitiveType
                 | _ -> None
@@ -1218,7 +1218,7 @@ module DependencyLookup =
                 else
                     let defaultPayload =
                         match p.payload with
-                        | None -> Fuzzable (PrimitiveType.String, "", None)
+                        | None -> Fuzzable (PrimitiveType.String, "", None, None)
                         | Some p -> p
                     let propertyAccessPath =
                         { path = PropertyAccessPaths.getInnerAccessPath resourceAccessPath p
@@ -1235,7 +1235,7 @@ module DependencyLookup =
 
         // First, check if the parameter itself has a dependency
         let (parameterName, properties) = requestParameter.name, requestParameter.payload
-        let defaultPayload = (Fuzzable (PrimitiveType.String, "", None))
+        let defaultPayload = (Fuzzable (PrimitiveType.String, "", None, None))
         let dependencyPayload = getConsumerPayload dependencies pathPayload requestId parameterName EmptyAccessPath defaultPayload
 
         let payloadWithDependencies =

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -135,9 +135,9 @@ type FuzzingPayload =
     /// Example: (Int "1")
     | Constant of PrimitiveType * string
 
-    /// (data type, default value, example value)
+    /// (data type, default value, example value, parameter name)
     /// Example: (Int "1", "2")
-    | Fuzzable of PrimitiveType * string * string option
+    | Fuzzable of PrimitiveType * string * string option * string option
 
     /// The custom payload, as specified in the fuzzing dictionary
     | Custom of CustomPayload


### PR DESCRIPTION
For large-scale testing, it is useful to have the specific values of
parameters fuzzed in the spec coverage file, in order to facilitate
root cause failure analysis.

This change adds an option to the compiler that produces a grammar which
contains the parameter names to track for every fuzzable value.

Testing:
- manual testing
- added/fixed engine tests to make sure new code path is exercised
- Note: the payload body checker code is not modified in this change because
it does not require this feature.