### PR TITLE
Enable analyzing flaky sequence failures without full network logs

### DIFF
--- a/docs/user-guide/Testing.md
+++ b/docs/user-guide/Testing.md
@@ -129,7 +129,8 @@ the appropriate __"invalid_due_to_..."__ value will be set to 1.
   * "500" will be set if a 5xx bug was detected.
 * The __"status_code"__ and __"status_text"__ values are the response values received from the server.
 * The __"sample_request"__ contains the concrete values of the sent request and received response for which
-the coverage data is being reported.
+the coverage data is being reported. This property is optional.
+* The __"sequence_failure_sample_request"__ contains the concrete values of the sent request that failed when a valid sequence was being re-rendered.  This property is optional.
 * The __"error_message"__ value will be set to the response body if the request was not "valid".
 * The __"request_order"__ value is the 0 indexed order that the request was sent.
   * Requests sent during "preprocessing" or "postprocessing" will explicitely say so.

--- a/docs/user-guide/Testing.md
+++ b/docs/user-guide/Testing.md
@@ -69,44 +69,52 @@ During each Test run a `speccov.json` file will be created in the logs directory
 
 #### Example of a single request from the json file:
 ```
-    "5915766984a7c5deaaae43cae4cfb810c138d0f2": {
+    "5915766984a7c5deaaae43cae4cfb810c138d0f2_1__1": {
         "verb": "PUT",
         "endpoint": "/blog/posts/{postId}",
         "verb_endpoint": "PUT /blog/posts/{postId}",
         "valid": 0,
-        "matching_prefix": {
-            "id": "1d7752f6d5ca3e03e423967a57335038a3d1bb70",
-            "valid": 1
-        },
+        "matching_prefix": [
+            {
+                "id": "1d7752f6d5ca3e03e423967a57335038a3d1bb70_1"
+            }
+        ],
         "invalid_due_to_sequence_failure": 0,
         "invalid_due_to_resource_failure": 0,
         "invalid_due_to_parser_failure": 0,
         "invalid_due_to_500": 0,
-        "status_code": "400",
-        "status_text": "BAD REQUEST",
-        "error_message": "{\n    \"errors\": {\n        \"id\": \"'5882' is not of type 'integer'\"\n    },\n    \"message\": \"Input payload validation failed\"\n}\n",
+        "status_code": null,
+        "status_text": null,
+        "error_message": "{\n    \"errors\": {\n        \"id\": \"'5872' is not of type 'integer'\"\n    },\n    \"message\": \"Input payload validation failed\"\n}\n",
         "request_order": 4,
         "sample_request": {
             "request_sent_timestamp": null,
-            "response_received_timestamp": "2021-03-31 18:20:14",
-            "request_uri": "/api/blog/posts/5882",
+            "response_received_timestamp": "2021-07-02 05:10:12",
+            "request_verb": "PUT",
+            "request_uri": "/api/blog/posts/5872",
             "request_headers": [
                 "Accept: application/json",
                 "Host: localhost:8888",
                 "Content-Type: application/json"
             ],
-            "request_body": "{\n    \"id\":\"5882\",\n    \"checksum\":\"fuzzstring\",\n    \"body\":\"fuzzstring\"}\r\n",
+            "request_body": "{\n    \"id\":\"5872\",\n    \"checksum\":\"fuzzstring\",\n    \"body\":\"first blog\"}\r\n",
+            "response_status_code": "400",
+            "response_status_text": "BAD REQUEST",
             "response_headers": [
                 "Content-Type: application/json",
                 "Content-Length: 124",
                 "Server: Werkzeug/0.16.0 Python/3.7.8",
-                "Date: Wed, 31 Mar 2021 18:20:14 GMT"
+                "Date: Fri, 02 Jul 2021 05:10:12 GMT"
             ],
-            "response_body": "{\n    \"errors\": {\n        \"id\": \"'5882' is not of type 'integer'\"\n    },\n    \"message\": \"Input payload validation failed\"\n}\n"
+            "response_body": "{\n    \"errors\": {\n        \"id\": \"'5872' is not of type 'integer'\"\n    },\n    \"message\": \"Input payload validation failed\"\n}\n"
         },
         "tracked_parameters": {
-            "per_page": ["2"],
-            "page": ["1"]
+            "id": [
+                "123"
+            ],
+            "body": [
+                "\"first blog\""
+            ]
         }
     },
 ```

--- a/restler/engine/core/driver.py
+++ b/restler/engine/core/driver.py
@@ -213,7 +213,8 @@ def render_one(seq_to_render, ith, checkers, generation, global_lock):
                 or renderings.valid or n_invalid_renderings < 1:
             apply_checkers(checkers, renderings, global_lock)
 
-        # If renderings.sequence is None it means there is nothing left to render.
+        # If renderings.sequence is None, it means there is nothing left to render or
+        # there was an error that prevents further testing, such as an error sending the request.
         if renderings.sequence is None:
             break
 
@@ -241,17 +242,21 @@ def render_one(seq_to_render, ith, checkers, generation, global_lock):
 
         # If in test mode, log the spec coverage.
         if Settings().fuzzing_mode == 'directed-smoke-test':
-            logged_renderings = renderings if renderings.sequence else prev_renderings
+            logged_renderings = renderings if renderings.sequence or renderings.failure_info else prev_renderings
             if logged_renderings:
-                logged_renderings.sequence.last_request.stats.set_all_stats(logged_renderings)
-                logger.print_request_coverage(rendered_sequence=logged_renderings, log_rendered_hash=True)
+                if logged_renderings.sequence:
+                    logged_renderings.sequence.last_request.stats.set_all_stats(logged_renderings)
+                    logger.print_request_coverage(rendered_sequence=logged_renderings, log_rendered_hash=True)
+                else:
+                    # The entire sequence was not rendered.  However, failure information may be available.
+                    current_seq.last_request.stats.set_all_stats(logged_renderings)
+                    logger.print_request_coverage(request=current_seq.last_request, log_rendered_hash=False)
             else:
-                # There was a failure rendering the sequence.  This needs to be logged to the spec coverage file.
+                # There was a failure rendering the sequence because no valid combinations were found.
+                # This needs to be logged to the spec coverage file.
                 current_seq.last_request.stats.valid = 0
-
                 if current_seq.length > 1:
                     current_seq.last_request.stats.set_matching_prefix(current_seq.prefix)
-
                 logger.print_request_coverage(request=current_seq.last_request, log_rendered_hash=False)
             # Else, there was a failure rendering the sequence.
             # Never rendered requests will be printed at the end of the fuzzing loop, so there is no need to
@@ -269,14 +274,10 @@ def render_one(seq_to_render, ith, checkers, generation, global_lock):
             apply_checkers(checkers, renderings, global_lock)
 
             # If in exhaustive test mode, log the spec coverage.
-            if renderings.sequence:
-                if Settings().fuzzing_mode == 'test-all-combinations':
+            if Settings().fuzzing_mode == 'test-all-combinations':
+                if renderings and renderings.sequence:
                     renderings.sequence.last_request.stats.set_all_stats(renderings)
                     logger.print_request_coverage(rendered_sequence=renderings, log_rendered_hash=True)
-
-                # Save the previous rendering in order to log statistics in cases when all renderings
-                # were invalid
-                prev_renderings = renderings
     else:
         print("Unsupported fuzzing_mode:", Settings().fuzzing_mode)
         assert False
@@ -403,6 +404,8 @@ def render_with_cache(seq_collection, fuzzing_pool, checkers, generation, global
                     # Print information about the attempt to render this request to main.txt
                     print_rendering_to_main_txt(current_seq)
                     logger.write_to_main(f"{formatting.timestamp()}: Rendering INVALID")
+
+
                     logger.format_rendering_stats_definition(
                         current_seq.last_request, GrammarRequestCollection().candidate_values_pool
                     )

--- a/restler/engine/core/driver.py
+++ b/restler/engine/core/driver.py
@@ -405,7 +405,6 @@ def render_with_cache(seq_collection, fuzzing_pool, checkers, generation, global
                     print_rendering_to_main_txt(current_seq)
                     logger.write_to_main(f"{formatting.timestamp()}: Rendering INVALID")
 
-
                     logger.format_rendering_stats_definition(
                         current_seq.last_request, GrammarRequestCollection().candidate_values_pool
                     )

--- a/restler/test_servers/parsed_requests.py
+++ b/restler/test_servers/parsed_requests.py
@@ -11,6 +11,8 @@ UNIT_TEST_RESOURCE_IDENTIFIER = '<test!>'
 class ParsedRequest:
     """ Created by parsing a request string """
     def __init__(self, request_str: str, ignore_dynamic_objects=False):
+        if not request_str or request_str.isspace():
+            raise Exception("Invalid request: empty payload")
         # Extract method from request string
         method_split = request_str.split(' ', 1)
         self.method = method_split[0]

--- a/restler/test_servers/resource_base.py
+++ b/restler/test_servers/resource_base.py
@@ -39,6 +39,14 @@ class InvalidBody(Exception):
     """
     pass
 
+class FlakyBehavior(Exception):
+    """ To be raised when flakiness is intentionally injected
+    via a 'flaky' property of the body.
+    Correct: 'flaky' property set to an odd number
+    FlakyBehavior: 'flaky' property set to an even number`
+    """
+    pass
+
 class ResourceBase:
     __metaclass__ = ABCMeta
 

--- a/restler/test_servers/unit_test_server/unit_test_resources.py
+++ b/restler/test_servers/unit_test_server/unit_test_resources.py
@@ -82,6 +82,9 @@ class UnitTestResource(ResourceBase):
             raise ResourceDoesNotExist()
 
 class ResourceFactory(object):
+    def __init__(self):
+        self._flaky_count = 0
+
     def get_resource_object(self, type: str, name: str, body: dict) -> UnitTestResource:
         if type == "city":
             return City(name, body)
@@ -101,6 +104,12 @@ class ResourceFactory(object):
             return Group(name, body)
 
         if type == "A":
+            # If the body contains a 'flaky' property, fail if it is
+            # set to an even number.
+            if 'flaky' in body:
+                self._flaky_count = self._flaky_count + 1
+                if (self._flaky_count - 1) % 2 == 1:
+                    raise FlakyBehavior()
             return A(name, body)
         if type == "B":
             return B(name, body)

--- a/restler/test_servers/unit_test_server/unit_test_server.py
+++ b/restler/test_servers/unit_test_server/unit_test_server.py
@@ -143,6 +143,8 @@ class UnitTestServer(TestServerBase):
             self._response = self._400(resource)
         except InvalidBody:
             self._response = self._400(request.body)
+        except FlakyBehavior:
+            self._response = self._400(request.body)
         except Exception as error:
             self._response = self._500(str(error))
 

--- a/restler/unit_tests/log_baseline_test_files/ab_flaky_b_all_combinations_speccov.json
+++ b/restler/unit_tests/log_baseline_test_files/ab_flaky_b_all_combinations_speccov.json
@@ -1,0 +1,172 @@
+{
+    "44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1": {
+        "verb": "PUT",
+        "endpoint": "/A/{A}",
+        "verb_endpoint": "PUT /A/{A}",
+        "valid": 1,
+        "matching_prefix": "None",
+        "invalid_due_to_sequence_failure": 0,
+        "invalid_due_to_resource_failure": 0,
+        "invalid_due_to_parser_failure": 0,
+        "invalid_due_to_500": 0,
+        "status_code": null,
+        "status_text": null,
+        "error_message": null,
+        "request_order": 0,
+        "sample_request": {
+            "request_sent_timestamp": null,
+            "response_received_timestamp": "2021-07-02 00:55:24",
+            "request_verb": "PUT",
+            "request_uri": "/A/A",
+            "request_headers": [
+                "Accept: application/json",
+                "Host: unittest",
+                "Content-Type: application/json",
+                "AUTHORIZATION TOKEN"
+            ],
+            "request_body": "{\"flaky\": 1}\r\n",
+            "response_status_code": "201",
+            "response_status_text": "Created",
+            "response_headers": [
+                "Restler Test"
+            ],
+            "response_body": "{\"name\": \"A\"}"
+        },
+        "tracked_parameters": {
+            "flaky": [
+                "1"
+            ]
+        }
+    },
+    "44414ad093616e18a9e2f845ae9d453eb6e4c8bc_2": {
+        "verb": "PUT",
+        "endpoint": "/A/{A}",
+        "verb_endpoint": "PUT /A/{A}",
+        "valid": 0,
+        "matching_prefix": "None",
+        "invalid_due_to_sequence_failure": 0,
+        "invalid_due_to_resource_failure": 0,
+        "invalid_due_to_parser_failure": 0,
+        "invalid_due_to_500": 0,
+        "status_code": null,
+        "status_text": null,
+        "error_message": "{\"error\": \"{\\\"flaky\\\": 2}\"}",
+        "request_order": 0,
+        "sample_request": {
+            "request_sent_timestamp": null,
+            "response_received_timestamp": "2021-07-02 00:55:24",
+            "request_verb": "PUT",
+            "request_uri": "/A/A",
+            "request_headers": [
+                "Accept: application/json",
+                "Host: unittest",
+                "Content-Type: application/json",
+                "AUTHORIZATION TOKEN"
+            ],
+            "request_body": "{\"flaky\": 2}\r\n",
+            "response_status_code": "400",
+            "response_status_text": "Bad Request",
+            "response_headers": [
+                "Restler Test"
+            ],
+            "response_body": "{\"error\": \"{\\\"flaky\\\": 2}\"}"
+        },
+        "tracked_parameters": {
+            "flaky": [
+                "2"
+            ]
+        }
+    },
+    "c4d9948bd2e270ee123e19bbb92f88b9b59f36c9_1__1": {
+        "verb": "GET",
+        "endpoint": "/A/{A}",
+        "verb_endpoint": "GET /A/{A}",
+        "valid": 1,
+        "matching_prefix": [
+            {
+                "id": "44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1",
+                "valid": 1
+            }
+        ],
+        "invalid_due_to_sequence_failure": 0,
+        "invalid_due_to_resource_failure": 0,
+        "invalid_due_to_parser_failure": 0,
+        "invalid_due_to_500": 0,
+        "status_code": null,
+        "status_text": null,
+        "error_message": null,
+        "request_order": 1,
+        "sample_request": {
+            "request_sent_timestamp": null,
+            "response_received_timestamp": "2021-07-02 00:55:25",
+            "request_verb": "GET",
+            "request_uri": "/A/A",
+            "request_headers": [
+                "Accept: application/json",
+                "Host: unittest",
+                "Content-Type: application/json",
+                "AUTHORIZATION TOKEN"
+            ],
+            "request_body": "{\"A\": \"A\",\"X\": 0.1}",
+            "response_status_code": "200",
+            "response_status_text": "OK",
+            "response_headers": [
+                "Restler Test"
+            ],
+            "response_body": "{\"name\": \"A\"}"
+        },
+        "tracked_parameters": {
+            "X": [
+                "0.1"
+            ],
+            "flaky": [
+                "1"
+            ]
+        }
+    },
+    "c4d9948bd2e270ee123e19bbb92f88b9b59f36c9_2__1": {
+        "verb": "GET",
+        "endpoint": "/A/{A}",
+        "verb_endpoint": "GET /A/{A}",
+        "valid": 0,
+        "matching_prefix": [
+            {
+                "id": "44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1"
+            }
+        ],
+        "invalid_due_to_sequence_failure": 1,
+        "invalid_due_to_resource_failure": 0,
+        "invalid_due_to_parser_failure": 0,
+        "invalid_due_to_500": 0,
+        "status_code": null,
+        "status_text": null,
+        "error_message": null,
+        "request_order": 1,
+        "sequence_failure_sample_request": {
+            "request_sent_timestamp": null,
+            "response_received_timestamp": "2021-07-02 00:55:25",
+            "request_verb": "PUT",
+            "request_uri": "/A/A",
+            "request_headers": [
+                "Accept: application/json",
+                "Host: unittest",
+                "Content-Type: application/json",
+                "AUTHORIZATION TOKEN"
+            ],
+            "request_body": "{\"flaky\": 1}\r\n",
+            "response_status_code": "400",
+            "response_status_text": "Bad Request",
+            "response_headers": [
+                "Restler Test"
+            ],
+            "response_body": "{\"error\": \"{\\\"flaky\\\": 1}\"}"
+        },
+        "tracked_parameters": {
+            "X": [
+                "0.2"
+            ],
+            "flaky": [
+                "1"
+            ]
+        }
+    }}

--- a/restler/unit_tests/log_baseline_test_files/ab_flaky_b_all_combinations_testing_log.txt
+++ b/restler/unit_tests/log_baseline_test_files/ab_flaky_b_all_combinations_testing_log.txt
@@ -1,0 +1,140 @@
+2021-07-01 17:55:24.466: Will refresh token: python D:\git\restler-fuzzer\restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
+2021-07-01 17:55:24.554: New value: {'user1':{}, 'user2':{}}
+Authorization: valid_unit_test_token
+Authorization: shadow_unit_test_token
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 2)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"flaky": '
+		+ restler_fuzzable_group: ['1', '2']
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+2021-07-01 17:55:24.741: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 14\r\n\r\n{"flaky": 1}\r\n'
+
+2021-07-01 17:55:24.748: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 1)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"flaky": '
+		+ restler_fuzzable_group: ['1', '2']
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+2021-07-01 17:55:24.910: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 14\r\n\r\n{"flaky": 2}\r\n'
+
+2021-07-01 17:55:24.919: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "{\\"flaky\\": 2}"}'
+
+2021-07-01 17:55:24.936: Failed to parse _post_a; it is now set to None.
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 2)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"flaky": '
+		+ restler_fuzzable_group: ['1', '2']
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 2)
+	Request hash: c4d9948bd2e270ee123e19bbb92f88b9b59f36c9
+
+		- restler_static_string: 'GET '
+		- restler_static_string: '/A/'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '","X": '
+		+ restler_fuzzable_group: ['0.1', '0.2']
+		- restler_static_string: '}'
+
+2021-07-01 17:55:25.383: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 14\r\n\r\n{"flaky": 1}\r\n'
+
+2021-07-01 17:55:25.392: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2021-07-01 17:55:25.407: Sending: 'GET /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 19\r\n\r\n{"A": "A","X": 0.1}'
+
+2021-07-01 17:55:25.416: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 2)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"flaky": '
+		+ restler_fuzzable_group: ['1', '2']
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+	Request hash: c4d9948bd2e270ee123e19bbb92f88b9b59f36c9
+
+		- restler_static_string: 'GET '
+		- restler_static_string: '/A/'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: ['token_refresh_cmd', 'token_refresh_interval']
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '","X": '
+		+ restler_fuzzable_group: ['0.1', '0.2']
+		- restler_static_string: '}'
+
+2021-07-01 17:55:25.734: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 14\r\n\r\n{"flaky": 1}\r\n'
+
+2021-07-01 17:55:25.743: Received: 'HTTP/1.1 400 Bad Request\r\nRestler Test\r\n\r\n{"error": "{\\"flaky\\": 1}"}'
+
+2021-07-01 17:55:25.760: Failed to parse _post_a; it is now set to None.

--- a/restler/unit_tests/log_baseline_test_files/ab_flaky_b_grammar.py
+++ b/restler/unit_tests/log_baseline_test_files/ab_flaky_b_grammar.py
@@ -1,0 +1,90 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This grammar was created manually.
+# There is no corresponding OpenAPI spec.
+
+from __future__ import print_function
+import json
+
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_post_a = dependencies.DynamicVariable(
+    "_post_a"
+)
+
+def parse_A(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_a", temp_123)
+
+
+req_collection = requests.RequestCollection([])
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/A/A"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"flaky": '),
+    # These must be an odd and even number
+    primitives.restler_fuzzable_group("flaky", ["1", "2"]),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_A,
+            'dependencies':
+            [
+                _post_a.writer()
+            ]
+        }
+    },
+
+],
+requestId="/A/{A}"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/A/"),
+    primitives.restler_static_string(_post_a.reader()),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"A": "'),
+    primitives.restler_static_string(_post_a.reader()),
+    primitives.restler_static_string('","X": '),
+    primitives.restler_fuzzable_group("X", ["0.1", "0.2"]),
+    primitives.restler_static_string("}"),
+],
+requestId="/A/{A}"
+)
+req_collection.add_request(request)
+
+

--- a/restler/unit_tests/test_logs/fuzzing_log_bad.txt
+++ b/restler/unit_tests/test_logs/fuzzing_log_bad.txt
@@ -265,4 +265,4 @@ Generation-2: Rendering Sequence-1
 
 2020-07-21 08:00:24.175: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "useafterfreeTest-87c1bb88f2"}'
 
-2020-07-21 08:00:24.186: Sending:
+2020-07-21 08:00:24.186: Sending:   

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -175,11 +175,16 @@ class SpecCoverageLog(object):
             req_spec['invalid_due_to_parser_failure'] = 1
         elif req.stats.failure == FailureInformation.BUG:
             req_spec['invalid_due_to_500'] = 1
+        elif req.stats.failure == FailureInformation.MISSING_STATUS_CODE:
+            req_spec['invalid_due_to_missing_response_code'] = 1
         req_spec['status_code'] = req.stats.status_code
         req_spec['status_text'] = req.stats.status_text
         req_spec['error_message'] = req.stats.error_msg
         req_spec['request_order'] = req.stats.request_order
-        req_spec['sample_request'] = vars(req.stats.sample_request)
+        if req.stats.sequence_failure_sample_request:
+            req_spec['sample_request'] = vars(req.stats.sample_request)
+        if req.stats.sequence_failure_sample_request:
+            req_spec['sequence_failure_sample_request'] = vars(req.stats.sequence_failure_sample_request)
 
         if log_tracked_parameters:
             req_spec['tracked_parameters'] = {}


### PR DESCRIPTION
This update logs a sample request for sequence failures in the spec coverage file.

The seq.render() code path has been updated to return a meaningful error in case of all failures, and
return the full sequence information in case of sequence failures.  This data can now be added to
the spec coverage log.