### PR TITLE
Support testing all examples as part of the main RESTler algorithm.

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -103,9 +103,13 @@ The maximum amount of time, in seconds, to wait for a resource to be created bef
 The maximum number of parameter value combinations for parameters within a given request payload.
 
 ### test_combinations_settings: dict (default empty)
-The settings for advanced testing of parameter combinations.  Currently, testing
+The settings for advanced testing of parameter combinations.
+
+__header_param_combinations__
+Currently, testing
 different combinations of headers is supported via the following property:
-```"test_combinations_settings": {
+```json
+"test_combinations_settings": {
       "header_param_combinations" : "optional"
 }
 ```
@@ -114,6 +118,18 @@ The supported values are 'optional', 'required', and 'all'.
 - optional: test all combinations of optional parameters, always sending the required parameters.
 - required: test combinations of required parameters, and omit all optional parameters.
 - all: test all combinations of headers, regardless of whether they are required or optional.
+
+__example_payloads__
+
+For request types where one or more examples are provided, this option enables testing all of
+the examples instead of just the first one.
+
+```json
+"test_combinations_settings": {
+      "example_payloadds" : "all"
+}
+```
+The supported value is 'all'.
 
 
 ### max_request_execution_time: float (default 120, max 600)

--- a/restler/engine/fuzzing_parameters/request_examples.py
+++ b/restler/engine/fuzzing_parameters/request_examples.py
@@ -25,8 +25,8 @@ class RequestExamples():
 
         """
         # initialization
-        self._query_examples: set = set()   # {QueryList}
-        self._body_examples: set = set()    # {BodySchema}
+        self._query_examples: list = []   # {QueryList}
+        self._body_examples: list = []    # {BodySchema}
 
         # process the request schema
         try:
@@ -83,7 +83,7 @@ class RequestExamples():
                 # Set each query parameter of the query
                 for query in des_query_param(query_parameter[1]):
                     query_list.append(query)
-                self._query_examples.add(query_list)
+                self._query_examples.append(query_list)
 
     def _set_body_params(self, body_parameters):
         """ Deserializes and populates the body parameters
@@ -102,4 +102,4 @@ class RequestExamples():
                 if payload:
                     body_example = des_param_payload(payload)
                     if body_example:
-                        self._body_examples.add(BodySchema(param=body_example))
+                        self._body_examples.append(BodySchema(param=body_example))

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -539,6 +539,12 @@ class RestlerSettings(object):
         return None
 
     @property
+    def example_payloads(self):
+        if 'example_payloads' in self._combinations_args.val:
+            return self._combinations_args.val['example_payloads']
+        return None
+
+    @property
     def max_request_execution_time(self):
         return self._max_request_execution_time.val
 

--- a/restler/unit_tests/restler_user_settings.json
+++ b/restler/unit_tests/restler_user_settings.json
@@ -2,8 +2,9 @@
     "client_certificate_path": "\\path\\to\\file.pem",
     "max_combinations": 20,
     "test_combinations_settings": {
-        "header_param_combinations" : "optional",
-        "query_param_combinations": "required"
+      "header_param_combinations" : "optional",
+      "query_param_combinations": "required",
+      "example_payloads":  "all"
     },
     "max_request_execution_time": 90,
     "save_results_in_fixed_dirname": false,

--- a/restler/unit_tests/test_restler_settings.py
+++ b/restler/unit_tests/test_restler_settings.py
@@ -464,6 +464,8 @@ class RestlerSettingsTest(unittest.TestCase):
         self.assertEqual("c:\\restler\\custom_dict2.json", custom_dicts[hex_def(request2)])
 
         self.assertEqual(20, settings.max_combinations)
+        self.assertEqual("optional", settings.header_param_combinations)
+        self.assertEqual("all", settings.example_payloads)
         self.assertEqual(90, settings.max_request_execution_time)
 
         self.assertEqual(False, settings.save_results_in_fixed_dirname)


### PR DESCRIPTION
To use it in 'Test' mode:

--test_all_combinations must be specified.

in the engine settings, also specify this property:

"test_combinations_settings": {

      "payload_examples":  "all"
    },