### PR TITLE
Add keyword for the body in the example config file.

### DIFF
--- a/docs/user-guide/Examples.md
+++ b/docs/user-guide/Examples.md
@@ -48,6 +48,12 @@ When specifying example payloads through an example file, set *DiscoverExamples*
 
 The format of the example file is as follows.  Note that either an external file or inline example can be specified.  Inline examples are useful for initial setup/debugging, but we recommend using external files to maintain examples separately for different requests.
 
+For specifying example body payloads, it is recommended to use the special keyword ```__body__```.
+This special property name will cause RESTler to assign this property value to the body,
+ignoring the name of the body parameter in the schema.  Because the body parameter name
+is not part of the actual body payload, this property name makes it more clear and less error prone
+to see where the body is specified in examples.
+
 ```json
 
 {
@@ -62,7 +68,12 @@ The format of the example file is as follows.  Note that either an external file
                         }
                     }
                 },
-                "2": "c:\\secondExample.json"
+                "2": "c:\\secondExample.json",
+                "3": {
+                    "parameters": {
+                        "__body__": {}
+                    }
+                }
             }
         }
     }

--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -75,16 +75,21 @@ module Examples =
 
         [<Fact>]
         let ``object example in grammar without dependencies`` () =
-
+            let grammarDirectoryPath = ctx.testRootDirPath
             let config = { Restler.Config.SampleConfig with
                              IncludeOptionalParameters = true
-                             GrammarOutputDirectoryPath = Some ctx.testRootDirPath
+                             GrammarOutputDirectoryPath = Some grammarDirectoryPath
                              ResolveBodyDependencies = false
                              UseBodyExamples = Some true
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\object_example.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo_dictionary.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
+            let grammarFilePath = Path.Combine(grammarDirectoryPath,
+                                               Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
+            let grammar = File.ReadAllText(grammarFilePath)
+            // Check that the grammar contains the object example
+            Assert.True(grammar.Contains("\"tag1\":\"value1\"") && grammar.Contains("\"tag2\":\"value2\""))
 
         [<Fact>]
         let ``allof property omitted in example`` () =

--- a/src/compiler/Restler.Compiler.Test/swagger/examples/make_order_tags.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/examples/make_order_tags.json
@@ -1,10 +1,10 @@
 {
   "parameters": {
     "storeId": "23456",
-    "orderDetails": {
+    "__body__": {
       "tags": {
         "tag1": "value1",
-       
+
         "tag2": "value2"
       }
     }

--- a/src/compiler/Restler.Compiler/SwaggerVisitors.fs
+++ b/src/compiler/Restler.Compiler/SwaggerVisitors.fs
@@ -375,7 +375,7 @@ module SwaggerVisitors =
                 let objTree =
                     // This object may or may not have nested properties.
                     // Similar to type 'None', just pass through the object and it will be taken care of downstream.
-                    generateGrammarElementForSchema property.ActualSchema (None, false) trackParameters
+                    generateGrammarElementForSchema property.ActualSchema (propertyPayloadExampleValue, generateFuzzablePayload) trackParameters
                                                     (property.IsRequired, (propertyIsReadOnly property))
                                                     parents (fun tree ->
                         // If the object has no properties, it should be set to its primitive type.


### PR DESCRIPTION
Today, the schema parameter name for the body must be specified in the example config file (because parameters are required to match the schema at this time).  In order to easily try out different bodies without having to refer to the spec, this change adds a special keyword __body__ for specifying the body. 

This change also fixes a bug (and test bug) in inferring examples that was found while testing this change.

Also added diagnostic output on parameters in the examples that were not found in the spec.