### PR TITLE
Fix bugs in example schema parsing.

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -1006,17 +1006,23 @@ class Request(object):
         num_payloads = len(self.examples.query_examples)
         for payload_idx in range(num_payloads):
             logger.write_to_main(f"Found example {payload_idx}.")
+            if len(self.examples.body_examples) <= payload_idx:
+                error_message=f"ERROR: ill-formed example {self.endpoint} {self.method}."
+                logger.write_to_main(error_message)
+                raise Exception(error_message)
             body_example = self.examples.body_examples[payload_idx]
             query_example = self.examples.query_examples[payload_idx]
             # TODO: header examples are not supported yet.
             #  header_example = examples.header_examples[payload_idx]
 
             # Copy the request definition and reset it here.
-            body_blocks = body_example.get_blocks()
+            body_blocks = None
+            if body_example:
+                body_blocks = body_example.get_blocks()
             query_blocks = []
             for idx, query in enumerate(query_example.param_list):
                 query_blocks += query.get_blocks()
-                if idx < len(query_example.queries) - 1:
+                if idx < len(query_example.param_list) - 1:
                     # Add the query separator
                     query_blocks.append(primitives.restler_static_string('&'))
 

--- a/restler/engine/fuzzing_parameters/request_examples.py
+++ b/restler/engine/fuzzing_parameters/request_examples.py
@@ -99,7 +99,12 @@ class RequestExamples():
         for body_parameter in body_parameters:
             if body_parameter[0] == 'Examples':
                 payload = des_body_param(body_parameter[1])
+                added_body = False
                 if payload:
                     body_example = des_param_payload(payload)
                     if body_example:
                         self._body_examples.append(BodySchema(param=body_example))
+                        added_body = True
+                if not added_body:
+                    # Add a None value in the array to track that this example has no body
+                    self._body_examples.append(None)


### PR DESCRIPTION
Bug 1: for requests without bodies, a placeholder needs to be added to correctly represent what is in the grammar, because
the examples are currently tied together via the index only.
Bug 2: incorrect property name

Note: this means there is no test coverage for having both query and no body examples in unit tests (e.g. examples for a GET request).
This needs to be addressed - a separate issue will be opened.