### PR TITLE
Enable producers from the input payload in the engine

### DIFF
--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -143,7 +143,7 @@ def resolve_dynamic_primitives(values, candidate_values_pool):
 
     """
     global last_refresh, latest_token_value, latest_shadow_token_value
-
+    from utils import logger
     # There should only be one uuid4_suffix in the request for a given name
     current_uuid_suffixes = {}
     for i in range(len(values)):
@@ -159,6 +159,7 @@ def resolve_dynamic_primitives(values, candidate_values_pool):
         elif isinstance(values[i], tuple)\
         and values[i][0] == primitives.CUSTOM_PAYLOAD_UUID4_SUFFIX:
             current_uuid_type_name = values[i][1]
+            writer_variable = values[i][5]
             quoted = False
             if len(current_uuid_type_name) >= 2 and current_uuid_type_name[0] == '"' and current_uuid_type_name[-1] == '"':
                 quoted = True
@@ -170,6 +171,11 @@ def resolve_dynamic_primitives(values, candidate_values_pool):
                 values[i] = f'"{current_uuid_suffixes[current_uuid_type_name]}"'
             else:
                 values[i] = current_uuid_suffixes[current_uuid_type_name]
+            # Check if a writer is present.  If so, assign the value generated above
+            # to the dynamic object variable.
+            if writer_variable is not None:
+                dependencies.set_variable(writer_variable, values[i])
+
         elif isinstance(values[i], types.FunctionType)\
         and values[i] == primitives.restler_refreshable_authentication_token:
             token_dict = candidate_values_pool.get_candidate_values(

--- a/restler/engine/primitives.py
+++ b/restler/engine/primitives.py
@@ -56,6 +56,11 @@ EXAMPLES_ARG = 'examples'
 # This value is used in test-all-combinations mode to allow the user to analyze spec coverage
 # for particular parameter values.
 PARAM_NAME_ARG = 'param_name'
+# Optional argument passed to fuzzable primitive definition function,
+# which indicates that the value assigned to the primitive should also be assigned to the
+# writer variable (dynamic object) specified.
+WRITER_VARIABLE_ARG = 'writer'
+
 class CandidateValues(object):
     def __init__(self):
         self.unquoted_values = []
@@ -745,8 +750,10 @@ def restler_custom_payload_uuid4_suffix(*args, **kwargs):
         quoted = kwargs[QUOTED_ARG]
     examples = None
     param_name = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
-
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 def restler_refreshable_authentication_token(*args, **kwargs):
     """ Custom refreshable authentication token.

--- a/restler/unit_tests/log_baseline_test_files/abc_dict.json
+++ b/restler/unit_tests/log_baseline_test_files/abc_dict.json
@@ -1,0 +1,5 @@
+{
+    "restler_custom_payload_uuid4_suffix": {
+        "postA": "A"
+    }
+}

--- a/restler/unit_tests/log_baseline_test_files/abc_test_grammar_without_responses.py
+++ b/restler/unit_tests/log_baseline_test_files/abc_test_grammar_without_responses.py
@@ -1,0 +1,146 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This grammar was created manually.
+# There is no corresponding OpenAPI spec.
+
+from __future__ import print_function
+import json
+
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_post_a = dependencies.DynamicVariable(
+    "_post_a"
+)
+
+_post_b = dependencies.DynamicVariable(
+    "_post_b"
+)
+
+def parse_A(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_a", temp_123)
+
+def parse_B(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_b", temp_123)
+
+
+def parse_D(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_d", temp_123)
+
+
+req_collection = requests.RequestCollection([])
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/A/"),
+    primitives.restler_custom_payload_uuid4_suffix("postA", writer=_post_a.writer()),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'dependencies':
+            [
+                _post_a.writer()
+            ]
+        }
+    },
+
+],
+requestId="/A/{A}"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/B/B"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_B,
+            'dependencies':
+            [
+                _post_b.writer()
+            ]
+        }
+    },
+],
+requestId="/B/{B}"
+)
+req_collection.add_request(request)
+
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/C"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"A": "'),
+    primitives.restler_static_string(_post_a.reader()),
+    primitives.restler_static_string('", "B": "'),
+    primitives.restler_static_string(_post_b.reader()),
+    primitives.restler_static_string('"'),
+    primitives.restler_static_string("}"),
+],
+requestId="/C"
+)
+req_collection.add_request(request)
+
+


### PR DESCRIPTION
Today, RESTler only supports producer-consumer dependencies by
parsing producers out of the response.

This enables a producer to be specified only as an input parameter.

In the grammar, a new named parameter called 'writer' is added to
the ```custom_payload_uuid4_suffix``` parameters.  The generated value
is then written similarly to how values would be parsed out of the response,
to be used in subsequent requests.

(Currently, only uuid4_suffix custom payloads are supported but we may
add support for custom payloads if that is a useful scenario.)

This partially implements #114