### PR TITLE
Implement injecting custom query parameters.

### DIFF
--- a/docs/user-guide/FuzzingDictionary.md
+++ b/docs/user-guide/FuzzingDictionary.md
@@ -45,6 +45,18 @@ The following describes how each property in the dictionary is used in a RESTler
   }
   ```
 
+- *restler_custom_payload_query* - specifies a list of specific values required for query parameters.  This property works the same as *restler_custom_payload_header*
+
+  ``` json
+  {
+     "restler_custom_payload_query": {
+         "query_param": ["qp1", "qp2"]
+     }
+  }
+  ```
+
+
+
 - *restler_custom_payload_uuid4_suffix* specifies constant values to which random GUID values will be appended.
 
 

--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -648,6 +648,7 @@ class Request(object):
                 examples = request_block[4]
             elif primitive_type in [ primitives.CUSTOM_PAYLOAD,
                                      primitives.CUSTOM_PAYLOAD_HEADER,
+                                     primitives.CUSTOM_PAYLOAD_QUERY,
                                      primitives.CUSTOM_PAYLOAD_UUID4_SUFFIX ]:
                 field_name = request_block[1]
                 quoted = request_block[2]
@@ -705,8 +706,9 @@ class Request(object):
                     _raise_dict_err(primitive_type, field_name)
                 except Exception as err:
                     _handle_exception(primitive_type, field_name, err)
-            # Handle custom (user defined) static payload on header (Adds \r\n)
-            elif primitive_type == primitives.CUSTOM_PAYLOAD_HEADER:
+            # Handle custom (user defined) static payload on header or query
+            elif (primitive_type == primitives.CUSTOM_PAYLOAD_HEADER or\
+                  primitive_type == primitives.CUSTOM_PAYLOAD_QUERY):
                 try:
                     current_fuzzable_values = candidate_values_pool.\
                         get_candidate_values(primitive_type, request_id=self._request_id, tag=field_name, quoted=quoted)

--- a/restler/engine/fuzzing_parameters/body_schema.py
+++ b/restler/engine/fuzzing_parameters/body_schema.py
@@ -195,6 +195,7 @@ class BodySchema():
                 examples = request_block[4]
             elif primitive_type in [ primitives.CUSTOM_PAYLOAD,
                                      primitives.CUSTOM_PAYLOAD_HEADER,
+                                     primitives.CUSTOM_PAYLOAD_QUERY,
                                      primitives.CUSTOM_PAYLOAD_UUID4_SUFFIX ]:
                 field_name = request_block[1]
                 quoted = request_block[2]

--- a/restler/engine/primitives.py
+++ b/restler/engine/primitives.py
@@ -40,6 +40,7 @@ FUZZABLE_OBJECT = "restler_fuzzable_object"
 FUZZABLE_MULTIPART_FORMDATA = "restler_multipart_formdata"
 CUSTOM_PAYLOAD = "restler_custom_payload"
 CUSTOM_PAYLOAD_HEADER = "restler_custom_payload_header"
+CUSTOM_PAYLOAD_QUERY = "restler_custom_payload_query"
 CUSTOM_PAYLOAD_UUID4_SUFFIX = "restler_custom_payload_uuid4_suffix"
 REFRESHABLE_AUTHENTICATION_TOKEN = "restler_refreshable_authentication_token"
 SHADOW_VALUES = "shadow_values"
@@ -120,6 +121,7 @@ class CandidateValuesPool(object):
             FUZZABLE_MULTIPART_FORMDATA,
             CUSTOM_PAYLOAD,
             CUSTOM_PAYLOAD_HEADER,
+            CUSTOM_PAYLOAD_QUERY,
             CUSTOM_PAYLOAD_UUID4_SUFFIX,
             REFRESHABLE_AUTHENTICATION_TOKEN,
             SHADOW_VALUES
@@ -127,6 +129,7 @@ class CandidateValuesPool(object):
         self.supported_primitive_dict_types = [
             CUSTOM_PAYLOAD,
             CUSTOM_PAYLOAD_HEADER,
+            CUSTOM_PAYLOAD_QUERY,
             CUSTOM_PAYLOAD_UUID4_SUFFIX,
             REFRESHABLE_AUTHENTICATION_TOKEN,
             SHADOW_VALUES
@@ -727,6 +730,30 @@ def restler_custom_payload_header(*args, **kwargs):
     param_name = None
     return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
+
+def restler_custom_payload_query(*args, **kwargs):
+    """ Custom payload primitive for query.
+
+    @param args: The argument with which the primitive is defined in the block
+                    of the request to which it belongs to. This is a custom
+                    payload which means that the user should have provided its
+                    exact value (to be rendered with).
+    @type  args: Tuple
+    @param kwargs: Optional keyword arguments.
+    @type  kwargs: Dict
+
+    @return: A tuple of the primitive's name and its default value or its tag
+                both passed as arguments via the restler grammar.
+    @rtype : Tuple
+
+    """
+    field_name = args[0]
+    quoted = False
+    if QUOTED_ARG in kwargs:
+        quoted = kwargs[QUOTED_ARG]
+    examples = None
+    param_name = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
 
 def restler_custom_payload_uuid4_suffix(*args, **kwargs):
     """ Custom payload primitive with uuid suffix.

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -826,6 +826,7 @@ def format_request_block(request_id, request_block, candidate_values_pool):
         examples = request_block[4]
     elif primitive in [ primitives.CUSTOM_PAYLOAD,
                         primitives.CUSTOM_PAYLOAD_HEADER,
+                        primitives.CUSTOM_PAYLOAD_QUERY,
                         primitives.CUSTOM_PAYLOAD_UUID4_SUFFIX ]:
         default_val = None
         field_name = request_block[1]
@@ -847,8 +848,9 @@ def format_request_block(request_id, request_block, candidate_values_pool):
     elif primitive == "restler_multipart_formdata":
         values = ['_OMITTED_BINARY_DATA_']
         default_val = '_OMITTED_BINARY_DATA_'
-    # Handle custom payload
-    elif primitive == "restler_custom_payload_header":
+    # Handle custom payload header and query
+    elif (primitive == "restler_custom_payload_header" or\
+          primitive == "restler_custom_payload_query"):
         current_fuzzable_tag = field_name
         values = candidate_values_pool.get_candidate_values(primitive, request_id=request.request_id, tag=current_fuzzable_tag, quoted=quoted)
         if not isinstance(values, list):

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -68,6 +68,12 @@
     <Content Include="swagger\dictionaryTests\pathDictionaryPayload.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\dictionaryTests\inject_custom_payloads_dict.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\dictionaryTests\no_params.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\dictionaryTests\multipleIdenticalUuidSuffix.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/inject_custom_payloads_dict.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/inject_custom_payloads_dict.json
@@ -1,0 +1,16 @@
+{
+  "restler_custom_payload_header": {
+    "extra_header1": [ "one" ],
+    "extra_header2":  ["two"],
+    "spec_header1":  ["qp"]
+  },
+  "restler_custom_payload_query": {
+    "extra_query1": [ "one" ],
+    "extra_query2":  ["two"],
+    "spec_query1":  ["qp"]
+  },
+  "restler_custom_payload": {
+    "spec_query2":  ["qp2"],
+    "spec_header2":  ["hp2"]
+  }
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/no_params.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/no_params.json
@@ -1,0 +1,55 @@
+{
+    "basePath": "/api",
+    "consumes": [
+        "application/json"
+    ],
+    "host": "localhost:8888",
+    "info": {
+        "description": "A simple swagger spec with one header and one query parameter.",
+        "title": "Simple spec",
+        "version": "1.0"
+    },
+    "paths": {
+        "/file": {
+            "post": {
+
+              "parameters": [
+                {
+                  "in": "header",
+                  "name": "spec_header1",
+                  "type": "string",
+                  "fullTypeName": "System.String",
+                  "required": true
+                },
+                {
+                  "in": "header",
+                  "name": "spec_header2",
+                  "type": "string",
+                  "fullTypeName": "System.String",
+                  "required": true
+                },
+                {
+                  "in": "query",
+                  "name": "spec_query1",
+                  "type": "string",
+                  "fullTypeName": "System.String",
+                  "required": true
+                },
+                {
+                  "in": "query",
+                  "name": "spec_query2",
+                  "type": "string",
+                  "fullTypeName": "System.String",
+                  "required": true
+                }
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Success"
+                  }
+              }
+            }
+        }
+    },
+    "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -397,9 +397,9 @@ let findProducerWithResourceName
             | None -> Seq.empty
             | Some d ->
                 // TODO: error handling.  only one should match.
-                d.getParameterForCustomPayload consumer.id.ResourceName consumer.id.AccessPathParts consumer.id.PrimitiveType
+                d.getParameterForCustomPayload consumer.id.ResourceName consumer.id.AccessPathParts consumer.id.PrimitiveType consumer.parameterKind
         let globalDictionaryMatches =
-            dictionary.getParameterForCustomPayload consumer.id.ResourceName consumer.id.AccessPathParts consumer.id.PrimitiveType
+            dictionary.getParameterForCustomPayload consumer.id.ResourceName consumer.id.AccessPathParts consumer.id.PrimitiveType consumer.parameterKind
         [
             perRequestDictionaryMatches
             globalDictionaryMatches
@@ -470,6 +470,7 @@ let findProducerWithResourceName
                 consumerResourceName
                 consumer.id.AccessPathParts
                 consumer.id.PrimitiveType
+                consumer.parameterKind
                 )
             |> Seq.isEmpty &&
            inferredExactMatches |> Seq.isEmpty then
@@ -495,7 +496,8 @@ let findProducerWithResourceName
              (dictionary.getParameterForCustomPayload
                 consumerResourceName
                 consumer.id.AccessPathParts
-                consumer.id.PrimitiveType)
+                consumer.id.PrimitiveType
+                consumer.parameterKind)
              |> Seq.isEmpty &&
              (not (inferredExactMatches
                    |> Seq.exists (fun x -> x.id.RequestId.method = OperationMethod.Put ||
@@ -1346,6 +1348,7 @@ let writeDependencies dependenciesFilePath dependencies (unresolvedOnly:bool) =
                                     | CustomPayloadType.String -> ""
                                     | CustomPayloadType.UuidSuffix -> "_uuid_suffix"
                                     | CustomPayloadType.Header -> "_header"
+                                    | CustomPayloadType.Query -> "_query"
                                 "",
                                 "",
                                 sprintf "restler_custom_payload%s__%s" customPayloadDesc payloadName

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -114,6 +114,8 @@ type CustomPayloadType =
     | String
     | UuidSuffix
     | Header
+    /// Used to inject query parameters that are not part of the specification.
+    | Query
 
 type CustomPayload =
     {


### PR DESCRIPTION
Use restler_custom_payload_query to inject query params not in the spec.

These parameters will be injected at the end of the query string for every request.

An example use case for restler_custom_payload_query is an application ID or authentication token that needs to be passed in the query.

Closes #287