### PR TITLE
Enable input parameters to be used in dependencies

### DIFF
--- a/docs/user-guide/Annotations.md
+++ b/docs/user-guide/Annotations.md
@@ -2,6 +2,23 @@
 
 RESTler allows the user to provide annotations with information about producer-consumer dependencies between requests.  This is helpful when RESTler cannot automatically infer such dependencies, which can happen for a variety of reasons (most often, because of very generic or inconsistent naming in the specification, or if the naming convention is not implemented in RESTler).
 
+## Supported types of dependencies
+RESTler currently supports the following types of producer-consumer dependencies:
+1. Between a response property and a request parameter.
+For example: request ```POST /A``` returns property "id", and request ```GET /A/{aId}``` specifies this ID in the path.
+
+2. Between two request parameters in different requests, where one of these is a ```custom_payload_uuid_suffix```.
+For example: ```POST /A/{aId}``` creates a resource with ID ```aId```, and ```GET /A/{AId}``` must use this ID, but the ID is not returned in the response.
+
+The annotation format for this annotation is the same as for annotations for producers that are response properties (as in (1)). RESTler will first look for the property name in the response, and if it does not find it will create this new kind of "input producer". The annotation does not explicitly allow to specify whether the ID should be extracted out of the response or not.
+
+3. Between two properties in the body.
+For example: "request ```PUT /A/{aId}``` has properties in the body that also need to refer to ```aId```, whose value is unique for each request invocation (via ```restler_custom_payload_uuid4_suffix```)
+
+Annotations are only supported for dependencies of type (1) and (2) above.
+
+## Annotation format
+
 Annotations are supported either globally (apply to all requests) or locally (apply only to a single request).  They may be specified inline in the Swagger specification (preferred if generated from the code, to evolve with the API) or outside in a separate file (preferred when modifications to the Swagger/OpenAPI spec are not acceptable, or maintaining a separate file is easier in your specific workflow).
 
 ## Global annotations
@@ -62,7 +79,7 @@ To provide local annotations inline in the Swagger/OpenAPI spec, specify the abo
 
 ## Annotation format
 
-Below is an example annotation that includes all supported properties:
+Below is an example annotation that includes all supported properties.  The ```except``` property may be either an object or an array with a list of except consumers.
 
 ```json
 {
@@ -90,4 +107,5 @@ In some cases, the resource names in the above may be ambiguous, e.g. because se
     "consumer_param": "/accounts/[0]/zones/[0]/name"
 }
 ```
+
 

--- a/restler/engine/fuzzing_parameters/request_schema_parser.py
+++ b/restler/engine/fuzzing_parameters/request_schema_parser.py
@@ -187,12 +187,22 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
             content_type = payload['Constant'][0]
             content_value = payload['Constant'][1]
         elif 'DynamicObject' in payload:
-            content_type = payload['DynamicObject'][0]
-            content_value = payload['DynamicObject'][1]
+            content_type = payload['DynamicObject']['primitiveType']
+            content_value = payload['DynamicObject']['variableName']
         elif 'Custom' in payload:
             custom = True
             content_type = payload['Custom']['payloadType']
             content_value = payload['Custom']['payloadValue']
+
+            # TODO: these dynamic objects are not yet supported in the schema.
+            # This dictionary is currently not used, and will be used once
+            # dynamic objects are added to the schema types below (ParamValue, etc.).
+            dynamic_object_input_variable=None
+            if 'dynamicObject' in payload['Custom']:
+                dynamic_object_input_variable={}
+                dynamic_object_input_variable['content_type'] = payload['Custom']['dynamicObject']['primitiveType']
+                dynamic_object_input_variable['content_value'] = payload['Custom']['dynamicObject']['variableName']
+
         elif 'PayloadParts' in payload:
             definition = payload['PayloadParts'][-1]
             if 'Custom' in definition:

--- a/restler/unit_tests/log_baseline_test_files/test_grammar.json
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar.json
@@ -99,11 +99,12 @@
             ]
           },
           {
-            "Custom": [
-                "UuidSuffix",
-                "cityName",
-                false
-            ]
+            "Custom": {
+              "payloadType": "UuidSuffix",
+              "primitiveType": "String",
+              "payloadValue": "cityName",
+              "isObject": false
+            }
           }
         ],
         "queryParameters": [
@@ -209,10 +210,11 @@
             ]
           },
           {
-            "DynamicObject": [
-              "String",
-              "_city_put_name"
-            ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -305,10 +307,11 @@
             ]
           },
           {
-            "DynamicObject": [
-              "String",
-              "_city_put_name"
-            ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -356,10 +359,11 @@
             ]
           },
           {
-            "DynamicObject": [
-              "String",
-              "_city_put_name"
-            ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -413,10 +417,11 @@
             ]
           },
           {
-            "DynamicObject": [
-              "String",
-              "_city_put_name"
-            ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -425,11 +430,12 @@
               ]
           },
           {
-            "Custom": [
-                "UuidSuffix",
-                "houseName",
-                false
-            ]
+            "Custom": {
+              "payloadType": "UuidSuffix",
+              "primitiveType":  "String",
+              "payloadValue": "houseName",
+              "isObject":  false
+            }
           }
         ],
         "queryParameters": [
@@ -531,10 +537,11 @@
             ]
           },
           {
-            "DynamicObject": [
-              "String",
-              "_city_put_name"
-            ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -543,7 +550,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_city_house_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_house_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -591,7 +602,11 @@
             ]
           },
           {
-                      "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -600,7 +615,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_city_house_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_house_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -648,7 +667,11 @@
             ]
           },
           {
-                      "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -657,7 +680,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_city_house_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_house_put_name",
+              "isWriter": false
+            }
           },
           {
             "Constant": [
@@ -711,7 +738,11 @@
             ]
           },
           {
-                      "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -720,7 +751,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_city_house_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_house_put_name",
+              "isWriter": false
+            }
           },
           {
             "Constant": [
@@ -729,11 +764,12 @@
             ]
           },
           {
-            "Custom": [
-                "UuidSuffix",
-                "colorName",
-                false
-            ]
+            "Custom": {
+              "payloadType": "UuidSuffix",
+              "primitiveType": "String",
+              "payloadValue": "colorName",
+              "isObject": false
+            }
           }
         ],
         "queryParameters": [
@@ -781,7 +817,11 @@
             ]
           },
           {
-                      "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -790,7 +830,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_city_house_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_house_put_name",
+              "isWriter": false
+            }
           },
           {
             "Constant": [
@@ -799,7 +843,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_city_house_color_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_house_color_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -847,7 +895,11 @@
             ]
           },
           {
-                      "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -856,7 +908,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_city_house_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_house_put_name",
+              "isWriter": false
+            }
           },
           {
             "Constant": [
@@ -865,7 +921,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_city_house_color_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_house_color_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -913,7 +973,11 @@
             ]
           },
           {
-                      "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -967,7 +1031,11 @@
             ]
           },
           {
-                      "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -976,11 +1044,12 @@
               ]
           },
           {
-            "Custom": [
-                "UuidSuffix",
-                "roadName",
-                false
-            ]
+            "Custom": {
+              "payloadType": "UuidSuffix",
+              "primitiveType": "String",
+              "payloadValue": "roadName",
+              "isObject": false
+            }
           }
         ],
         "queryParameters": [
@@ -1094,7 +1163,11 @@
             ]
           },
           {
-                      "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -1103,7 +1176,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_city_road_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_road_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -1151,7 +1228,11 @@
             ]
           },
           {
-                      "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -1160,7 +1241,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_city_road_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_road_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -1254,11 +1339,12 @@
             ]
           },
           {
-            "Custom": [
-                "UuidSuffix",
-                "farmName",
-                false
-            ]
+            "Custom": {
+              "payloadType": "UuidSuffix",
+              "primitiveType": "String",
+              "payloadValue": "farmName",
+              "isObject": false
+            }
           }
         ],
         "queryParameters": [
@@ -1500,7 +1586,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_farm_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_farm_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -1548,7 +1638,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_farm_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_farm_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -1596,7 +1690,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_farm_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_farm_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -1650,7 +1748,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_farm_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_farm_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -1659,11 +1761,12 @@
               ]
           },
           {
-            "Custom": [
-                "UuidSuffix",
-                "animalName",
-                false
-            ]
+            "Custom": {
+              "payloadType": "UuidSuffix",
+              "primitiveType": "String",
+              "payloadValue": "animalName",
+              "isObject": false
+            }
           }
         ],
         "queryParameters": [
@@ -1728,7 +1831,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_farm_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_farm_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -1737,7 +1844,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_farm_animal_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_farm_animal_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -1785,7 +1896,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_farm_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_farm_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -1794,7 +1909,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_farm_animal_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_farm_animal_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -1888,7 +2007,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_item_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_item_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -1936,7 +2059,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_item_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_item_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -1985,11 +2112,12 @@
             ]
           },
           {
-            "Custom": [
-              "UuidSuffix",
-              "itemName",
-              false
-            ]
+            "Custom": {
+              "payloadType": "UuidSuffix",
+              "primitiveType": "String",
+              "payloadValue": "itemName",
+              "isObject": false
+            }
           }
         ],
         "queryParameters": [
@@ -2186,7 +2314,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_group_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_group_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -2235,7 +2367,12 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_group_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_group_put_name",
+              "isWriter": false
+            }
+
           }
         ],
         "queryParameters": [
@@ -2284,11 +2421,12 @@
             ]
           },
           {
-            "Custom": [
-                "UuidSuffix",
-                "groupName",
-                false
-            ]
+            "Custom": {
+              "payloadType": "UuidSuffix",
+              "primitiveType": "String",
+              "payloadValue": "groupName",
+              "isObject": false
+            }
           }
         ],
         "queryParameters": [
@@ -2320,7 +2458,12 @@
                           "LeafNode": {
                             "name": "city",
                             "payload": {
-                                        "DynamicObject": [    "String", "_city_put_name" ]
+                              "DynamicObject": {
+                                "primitiveType": "String",
+                                "variableName": "_city_put_name",
+                                "isWriter": false
+                              }
+
                             },
                             "isRequired": false,
                             "isReadOnly": false
@@ -2330,7 +2473,11 @@
                           "LeafNode": {
                             "name": "item",
                             "payload": {
-                              "DynamicObject": [    "String", "_item_put_name" ]
+                              "DynamicObject": {
+                                "primitiveType": "String",
+                                "variableName": "_item_put_name",
+                                "isWriter": false
+                              }
                             },
                             "isRequired": false,
                             "isReadOnly": false

--- a/restler/unit_tests/log_baseline_test_files/test_grammar_body.json
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar_body.json
@@ -60,11 +60,12 @@
             ]
           },
           {
-            "Custom": [
-                "UuidSuffix",
-                "cityName",
-                false
-            ]
+            "Custom": {
+              "payloadType": "UuidSuffix",
+              "primitiveType": "String",
+              "payloadValue": "cityName",
+              "isObject": false
+            }
           }
         ],
         "queryParameters": [
@@ -228,7 +229,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -320,7 +325,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -368,7 +377,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -422,7 +435,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -431,11 +448,12 @@
               ]
           },
           {
-            "Custom": [
-                "UuidSuffix",
-                "houseName",
-                false
-            ]
+            "Custom": {
+              "payloadType": "UuidSuffix",
+              "primitiveType": "String",
+              "payloadValue": "houseName",
+              "isObject": false
+            }
           }
         ],
         "queryParameters": [
@@ -575,7 +593,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter":  false
+            }
           },
           {
               "Constant": [
@@ -584,7 +606,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_city_house_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_house_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [
@@ -632,7 +658,11 @@
             ]
           },
           {
-            "DynamicObject": [    "String", "_city_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_put_name",
+              "isWriter": false
+            }
           },
           {
               "Constant": [
@@ -641,7 +671,11 @@
               ]
           },
           {
-              "DynamicObject": [    "String", "_city_house_put_name" ]
+            "DynamicObject": {
+              "primitiveType": "String",
+              "variableName": "_city_house_put_name",
+              "isWriter": false
+            }
           }
         ],
         "queryParameters": [

--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -51,7 +51,7 @@ module CodeGenerator =
             let pathPayload =
                 [ (Constant (PrimitiveType.String, "api"))
                   (Constant (PrimitiveType.String, "accounts"))
-                  (DynamicObject (PrimitiveType.Int, "accountId")) ]
+                  (DynamicObject { primitiveType = PrimitiveType.Int ; variableName = "accountId"; isWriter = false }) ]
             let requestElements =
                 [
                     Method OperationMethod.Get
@@ -82,6 +82,7 @@ module CodeGenerator =
                                ("Content-Type", "application/json")]
                     token = (TokenKind.Static "SpringfieldToken: 12345")
                     responseParser = None
+                    inputDynamicObjectVariables = []
                     requestMetadata = { isLongRunningOperation = false }
                 }
             let elements = Restler.CodeGenerator.Python.getRequests [request] true

--- a/src/compiler/Restler.Compiler.Test/DependencyTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DependencyTests.fs
@@ -314,5 +314,28 @@ module Dependencies =
             let numberOfDynamicObjects = grammar |> Seq.filter (fun x -> x.Contains(grammarDynamicObject)) |> Seq.length
             Assert.Equal( 1, numberOfDynamicObjects)
 
+        [<Fact>]
+        let ``input producers work with annotations`` () =
+            let grammarOutputDirPath = ctx.testRootDirPath
+            let config = { Restler.Config.SampleConfig with
+                             IncludeOptionalParameters = true
+                             GrammarOutputDirectoryPath = Some grammarOutputDirPath
+                             ResolveBodyDependencies = true
+                             UseBodyExamples = Some true
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\input_producer_spec.json"))]
+                             CustomDictionaryFilePath = None
+                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\input_producer_annotations.json"))
+                             AllowGetProducers = true
+                         }
+            Restler.Workflow.generateRestlerGrammar None config
+
+            let grammarFilePath = Path.Combine(grammarOutputDirPath,
+                                               Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
+            let grammar = File.ReadAllText(grammarFilePath)
+
+            Assert.True(grammar.Contains("""restler_custom_payload_uuid4_suffix("fileId", writer=_file__fileId__post_fileId_path.writer())"""))
+            Assert.True(grammar.Contains("""restler_static_string(_file__fileId__post_fileId_path.reader(), quoted=False)"""))
+
+
         interface IClassFixture<Fixtures.TestSetupAndCleanup>
 

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -35,6 +35,12 @@
     <Content Include="swagger\dependencyTests\post_patch_dependency.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\dependencyTests\input_producer_spec.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\dependencyTests\input_producer_annotations.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\annotationTests\pathAnnotation.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/input_producer_annotations.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/input_producer_annotations.json
@@ -1,0 +1,10 @@
+{
+  "x-restler-global-annotations": [
+    {
+      "producer_endpoint": "/file/{fileId}",
+      "producer_method": "POST",
+      "producer_resource_name": "fileId",
+      "consumer_param": "fileId"
+    }
+  ]
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/input_producer_spec.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/input_producer_spec.json
@@ -1,0 +1,72 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "host": "localhost:8888",
+  "info": {
+    "description": "Small example for POST with input producer",
+    "title": "Input producer test case",
+    "version": "1.0.0"
+  },
+  "definitions": {
+    "fileId":{
+        "type": "String",
+        "description":  "the file id"
+
+    }
+  },
+  "paths": {
+    "/file/{fileId}": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "type": "String"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "type": "String"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/fileId"
+            }
+          }
+        }
+      },
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "type": "String"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler/Dictionary.fs
+++ b/src/compiler/Restler.Compiler/Dictionary.fs
@@ -85,9 +85,22 @@ type MutationsDictionary =
                         | Some entry ->
                             let payloadTrimmed = entry.Trim()
                             let isObject = payloadTrimmed.StartsWith "{" || payloadTrimmed.StartsWith "["
-                            DictionaryPayload (payloadType, primitiveType, payloadName, isObject) |> stn
+                            DictionaryPayload
+                                {
+                                    payloadType = payloadType
+                                    primitiveType = primitiveType
+                                    name = payloadName
+                                    isObject = isObject
+                                } |> stn
                 | Some _ ->
-                    DictionaryPayload (payloadType, primitiveType, payloadName, false) |> stn
+                    DictionaryPayload
+                        {
+                            payloadType = payloadType
+                            primitiveType = primitiveType
+                            name = payloadName
+                            isObject = false
+                        } |> stn
+
                 | None -> Seq.empty)
             |> Seq.concat
 
@@ -124,9 +137,21 @@ type MutationsDictionary =
             | Some entry when payloadType = CustomPayloadType.String ->
                 let payloadTrimmed = entry.Trim()
                 let isObject = payloadTrimmed.StartsWith "{" || payloadTrimmed.StartsWith "["
-                DictionaryPayload (payloadType, primitiveType, payloadName, isObject) |> stn
+                DictionaryPayload
+                    {
+                        payloadType = payloadType
+                        primitiveType = primitiveType
+                        name = payloadName
+                        isObject = isObject
+                    } |> stn
             | Some _ ->
-                DictionaryPayload (payloadType, primitiveType, payloadName, false) |> stn
+                DictionaryPayload
+                    {
+                        payloadType = payloadType
+                        primitiveType = primitiveType
+                        name = payloadName
+                        isObject = false
+                    } |> stn
             | None -> Seq.empty
 
 


### PR DESCRIPTION
This change adds support for producers that are not returned in the response.

Currently, this is supported via annotations only (which are specified in the same
way as usual).  For example, if PUT /A/{aId} does not return 'aId' in the
response, prior to this change it was not possible for GET /a/{aId} to use
the same ID if they are uniquely generated.  This is enabled by this change
by adding an annotation:

    {
      "producer_endpoint": "/A/{aId}",
      "producer_method": "PUT",
      "producer_resource_name": "aId",
      "consumer_param": "aId"
    }

In the future, scenarios such as the one above will also be enabled without
having to provide annotations.

See #114