### PR TITLE
Initial x-ms-paths support.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -68,7 +68,7 @@ module CodeGenerator =
                 ]
             let request:Request =
                 {
-                    id = { endpoint = "/api/accounts/{accountId}" ; method = OperationMethod.Put }
+                    id = { endpoint = "/api/accounts/{accountId}" ; method = OperationMethod.Put ; xMsPath = None }
 
                     method = OperationMethod.Get
                     path = pathPayload

--- a/src/compiler/Restler.Compiler.Test/DependencyTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DependencyTests.fs
@@ -17,7 +17,7 @@ module Dependencies =
     type DependencyTests(ctx:Fixtures.TestSetupAndCleanup, output:Xunit.Abstractions.ITestOutputHelper) =
 
         let dependenciesResolvedWithoutAnnotations config =
-            let swaggerDoc =
+            let swaggerDoc,_ =
                 Restler.Swagger.getSwaggerDocument config.SwaggerSpecFilePath.Value.[0] ctx.testRootDirPath
             let dictionary =
                 match config.CustomDictionaryFilePath with
@@ -28,7 +28,8 @@ module Dependencies =
 
             let grammar,dependencies, _, _ =
                 Restler.Compiler.Main.generateRequestGrammar
-                                    [{ swaggerDoc = swaggerDoc ; dictionary = None ; globalAnnotations = None}]
+                                    [{ swaggerDoc = swaggerDoc ; dictionary = None ; globalAnnotations = None;
+                                       xMsPathsMapping = None}]
                                     dictionary
                                     config
                                     List.empty

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -23,6 +23,12 @@
     <Content Include="baselines\dependencyTests\path_annotation_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="baselines\schemaTests\xMsPaths_grammar.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="baselines\schemaTests\xMsPaths_grammar.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="baselines\dictionaryTests\quoted_primitives_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -93,6 +99,15 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\schemaTests\requiredHeader.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\schemaTests\xMsPaths.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\schemaTests\xMsPaths_dict.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\schemaTests\xMsPaths_annotations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\dictionaryTests\customPayloadSwagger.json">

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
@@ -1,0 +1,681 @@
+{
+  "Requests": [
+    {
+      "id": {
+        "endpoint": "/{resourceName}?type=folder",
+        "xMsPath": {
+          "pathPart": "/{resourceName}",
+          "queryPart": "type=folder"
+        },
+        "method": "Put"
+      },
+      "method": "Put",
+      "path": [
+        {
+          "Custom": {
+            "payloadType": "UuidSuffix",
+            "primitiveType": "String",
+            "payloadValue": "resourceName",
+            "isObject": false,
+            "dynamicObject": {
+              "primitiveType": "String",
+              "variableName": "__resourceName__type_folder_put_resourceName_path",
+              "isWriter": false
+            }
+          }
+        },
+        {
+          "Constant": [
+            "String",
+            "?"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            ""
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "type=folder"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": [
+                        {
+                          "Enum": [
+                            "api-version",
+                            "String",
+                            [
+                              "2020-03-01"
+                            ],
+                            null
+                          ]
+                        },
+                        "2020-03-01",
+                        null,
+                        null
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "responseParser": {
+        "writerVariables": [],
+        "inputWriterVariables": [
+          {
+            "requestId": {
+              "endpoint": "/{resourceName}/type/folder",
+              "xMsPath": {
+                "pathPart": "/{resourceName}",
+                "queryPart": "type=folder"
+              },
+              "method": "Put"
+            },
+            "accessPathParts": {
+              "path": [
+                "resourceName",
+                "path"
+              ]
+            }
+          }
+        ]
+      },
+      "inputDynamicObjectVariables": [
+        {
+          "requestId": {
+            "endpoint": "/{resourceName}/type/folder",
+            "xMsPath": {
+              "pathPart": "/{resourceName}",
+              "queryPart": "type=folder"
+            },
+            "method": "Put"
+          },
+          "accessPathParts": {
+            "path": [
+              "resourceName",
+              "path"
+            ]
+          }
+        }
+      ],
+      "requestMetadata": {
+        "isLongRunningOperation": true
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/{resourceName}?type=file",
+        "xMsPath": {
+          "pathPart": "/{resourceName}",
+          "queryPart": "type=file"
+        },
+        "method": "Put"
+      },
+      "method": "Put",
+      "path": [
+        {
+          "Custom": {
+            "payloadType": "UuidSuffix",
+            "primitiveType": "String",
+            "payloadValue": "resourceName",
+            "isObject": false,
+            "dynamicObject": {
+              "primitiveType": "String",
+              "variableName": "__resourceName__type_file_put_resourceName_path",
+              "isWriter": false
+            }
+          }
+        },
+        {
+          "Constant": [
+            "String",
+            "?"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            ""
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "type=file"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": [
+                        {
+                          "Enum": [
+                            "api-version",
+                            "String",
+                            [
+                              "2020-03-01"
+                            ],
+                            null
+                          ]
+                        },
+                        "2020-03-01",
+                        null,
+                        null
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "responseParser": {
+        "writerVariables": [],
+        "inputWriterVariables": [
+          {
+            "requestId": {
+              "endpoint": "/{resourceName}/type/file",
+              "xMsPath": {
+                "pathPart": "/{resourceName}",
+                "queryPart": "type=file"
+              },
+              "method": "Put"
+            },
+            "accessPathParts": {
+              "path": [
+                "resourceName",
+                "path"
+              ]
+            }
+          }
+        ]
+      },
+      "inputDynamicObjectVariables": [
+        {
+          "requestId": {
+            "endpoint": "/{resourceName}/type/file",
+            "xMsPath": {
+              "pathPart": "/{resourceName}",
+              "queryPart": "type=file"
+            },
+            "method": "Put"
+          },
+          "accessPathParts": {
+            "path": [
+              "resourceName",
+              "path"
+            ]
+          }
+        }
+      ],
+      "requestMetadata": {
+        "isLongRunningOperation": true
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/{resourceName}?type=file&operation={operationId}",
+        "xMsPath": {
+          "pathPart": "/{resourceName}",
+          "queryPart": "type=file&operation={operationId}"
+        },
+        "method": "Get"
+      },
+      "method": "Get",
+      "path": [
+        {
+          "DynamicObject": {
+            "primitiveType": "String",
+            "variableName": "__resourceName__type_file_put_resourceName_path",
+            "isWriter": false
+          }
+        },
+        {
+          "Constant": [
+            "String",
+            "?"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "type=file&operation="
+          ]
+        },
+        {
+          "Custom": {
+            "payloadType": "String",
+            "primitiveType": "String",
+            "payloadValue": "operationId",
+            "isObject": false
+          }
+        },
+        {
+          "Constant": [
+            "String",
+            ""
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "tag",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Custom": {
+                        "payloadType": "String",
+                        "primitiveType": "String",
+                        "payloadValue": "tag",
+                        "isObject": false
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": [
+                        {
+                          "Enum": [
+                            "api-version",
+                            "String",
+                            [
+                              "2020-03-01"
+                            ],
+                            null
+                          ]
+                        },
+                        "2020-03-01",
+                        null,
+                        null
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "inputDynamicObjectVariables": [],
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/{resourceName}/{itemName}",
+        "method": "Get"
+      },
+      "method": "Get",
+      "path": [
+        {
+          "DynamicObject": {
+            "primitiveType": "String",
+            "variableName": "__resourceName__type_file_put_resourceName_path",
+            "isWriter": false
+          }
+        },
+        {
+          "Fuzzable": [
+            "String",
+            "fuzzstring",
+            null,
+            null
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": [
+                        {
+                          "Enum": [
+                            "api-version",
+                            "String",
+                            [
+                              "2020-03-01"
+                            ],
+                            null
+                          ]
+                        },
+                        "2020-03-01",
+                        null,
+                        null
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "inputDynamicObjectVariables": [],
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/{resourceName}/{itemName}",
+        "method": "Delete"
+      },
+      "method": "Delete",
+      "path": [
+        {
+          "DynamicObject": {
+            "primitiveType": "String",
+            "variableName": "__resourceName__type_file_put_resourceName_path",
+            "isWriter": false
+          }
+        },
+        {
+          "Fuzzable": [
+            "String",
+            "fuzzstring",
+            null,
+            null
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": [
+                        {
+                          "Enum": [
+                            "api-version",
+                            "String",
+                            [
+                              "2020-03-01"
+                            ],
+                            null
+                          ]
+                        },
+                        "2020-03-01",
+                        null,
+                        null
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "inputDynamicObjectVariables": [],
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    }
+  ]
+}

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.py
@@ -1,0 +1,142 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+__resourceName__type_folder_put_resourceName_path = dependencies.DynamicVariable("__resourceName__type_folder_put_resourceName_path")
+
+__resourceName__type_file_put_resourceName_path = dependencies.DynamicVariable("__resourceName__type_file_put_resourceName_path")
+req_collection = requests.RequestCollection([])
+# Endpoint: /{resourceName}?type=folder, method: Put
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/"),
+    primitives.restler_custom_payload_uuid4_suffix("resourceName", writer=__resourceName__type_folder_put_resourceName_path.writer()),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("type=folder"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("api-version: "),
+    primitives.restler_fuzzable_group("api-version", ['2020-03-01']  ,quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+        'post_send':
+        {
+            
+            'dependencies':
+            [
+                __resourceName__type_folder_put_resourceName_path.writer()
+            ]
+        }
+    },
+
+],
+requestId="/{resourceName}?type=folder"
+)
+req_collection.add_request(request)
+
+# Endpoint: /{resourceName}?type=file, method: Put
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/"),
+    primitives.restler_custom_payload_uuid4_suffix("resourceName", writer=__resourceName__type_file_put_resourceName_path.writer()),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("type=file"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("api-version: "),
+    primitives.restler_fuzzable_group("api-version", ['2020-03-01']  ,quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+        'post_send':
+        {
+            
+            'dependencies':
+            [
+                __resourceName__type_file_put_resourceName_path.writer()
+            ]
+        }
+    },
+
+],
+requestId="/{resourceName}?type=file"
+)
+req_collection.add_request(request)
+
+# Endpoint: /{resourceName}?type=file&operation={operationId}, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(__resourceName__type_file_put_resourceName_path.reader(), quoted=False),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("type=file&operation="),
+    primitives.restler_custom_payload("operationId", quoted=False),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("tag="),
+    primitives.restler_custom_payload("tag", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("api-version: "),
+    primitives.restler_fuzzable_group("api-version", ['2020-03-01']  ,quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/{resourceName}?type=file&operation={operationId}"
+)
+req_collection.add_request(request)
+
+# Endpoint: /{resourceName}/{itemName}, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(__resourceName__type_file_put_resourceName_path.reader(), quoted=False),
+    primitives.restler_static_string("/"),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("api-version: "),
+    primitives.restler_fuzzable_group("api-version", ['2020-03-01']  ,quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/{resourceName}/{itemName}"
+)
+req_collection.add_request(request)
+
+# Endpoint: /{resourceName}/{itemName}, method: Delete
+request = requests.Request([
+    primitives.restler_static_string("DELETE "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(__resourceName__type_file_put_resourceName_path.reader(), quoted=False),
+    primitives.restler_static_string("/"),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("api-version: "),
+    primitives.restler_fuzzable_group("api-version", ['2020-03-01']  ,quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/{resourceName}/{itemName}"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths.json
@@ -1,0 +1,203 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "XMsPaths test case",
+    "version": "1",
+    "x-ms-code-generation-settings": {
+      "header": "MIT",
+      "strictSpecAdherence": false
+    }
+  },
+  "x-ms-parameterized-host": {
+    "hostTemplate": "{url}",
+    "useSchemePrefix": false,
+    "positionInOperation": "first",
+    "parameters": [
+      {
+        "$ref": "#/parameters/Url"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/xml"
+  ],
+  "produces": [
+    "application/xml"
+  ],
+  "paths": {},
+  "x-ms-paths": {
+    "/{resourceName}?type=folder": {
+      "put": {
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "in": "path",
+            "name": "resourceName",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{resourceName}?type=file": {
+      "put": {
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "in": "path",
+            "name": "resourceName",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{resourceName}?type=folder&operation={operationId}": {},
+    "/{resourceName}?type=file&operation={operationId}": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Tag"
+          },
+          {
+            "in": "path",
+            "name": "resourceName",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "operationId",
+            "type": "string",
+            "required": true
+          },
+          {
+            $ref: "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/{resourceName}/{itemName}": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "in": "path",
+            "name": "resourceName",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "itemName",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      },
+      "delete": {
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "in": "path",
+            "name": "resourceName",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "itemName",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "Tag": {
+      "name": "tag",
+      "required": true,
+      "type": "string",
+      "in": "query"
+    },
+    "Url": {
+      "name": "url",
+      "required": true,
+      "type": "string",
+      "in": "path",
+      "x-ms-skip-url-encoding": true
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "x-ms-client-name": "version",
+      "in": "header",
+      "required": true,
+      "type": "string",
+      "description": "Specifies the version of the operation to use for this request.",
+      "enum": [
+        "2020-03-01"
+      ]
+    },
+    "File": {
+      "name": "file",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]+",
+      "minLength": 1,
+      "maxLength": 1024,
+      "x-ms-parameter-location": "method",
+      "description": "The file name."
+    },
+    "OperationId": {
+      "name": "operationid",
+      "x-ms-client-name": "operationId",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths_annotations.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths_annotations.json
@@ -1,0 +1,26 @@
+{
+  "x-restler-global-annotations": [
+      {
+          "producer_endpoint": "/{resourceName}?type=file",
+          "producer_method": "PUT",
+          "producer_resource_name": "resourceName",
+          "consumer_param": "resourceName",
+          "except": [
+            {
+                "consumer_endpoint": "/{resourceName}?type=folder",
+                "consumer_method": "PUT"
+            }]
+      },
+      {
+        "producer_endpoint": "/{resourceName}?type=folder",
+        "producer_method": "PUT",
+        "producer_resource_name": "resourceName",
+        "consumer_param": "resourceName",
+        "except": [
+          {
+              "consumer_endpoint": "/{resourceName}?type=file",
+              "consumer_method": "PUT"
+          }]
+    }
+  ]
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths_dict.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths_dict.json
@@ -1,0 +1,7 @@
+{
+  "restler_custom_payload": {
+    "type": ["T"],
+    "operationId": ["backup", "lock"],
+    "tag": ["tag1", "tag2"]
+  }
+}

--- a/src/compiler/Restler.Compiler/DependencyAnalysisTypes.fs
+++ b/src/compiler/Restler.Compiler/DependencyAnalysisTypes.fs
@@ -94,7 +94,8 @@ type Producers() =
                             if not producer.id.IsNestedBodyResource then
                                 resourceProducers.sortedByMatchNonNested.Add(sortKey, producer)
                             let key = { endpoint = producer.id.RequestId.endpoint.ToLower()
-                                        method = producer.id.RequestId.method }
+                                        method = producer.id.RequestId.method
+                                        xMsPath = None }
                             resourceProducers.indexedByEndpoint.TryAdd(key, new List<ResponseProducer>()) |> ignore
                             resourceProducers.indexedByEndpoint.[key].Add(producer)
 
@@ -108,7 +109,8 @@ type Producers() =
     member x.AddSamePayloadProducer(resourceName:string, producer:BodyPayloadInputProducer) =
         lock producers (fun () ->
                             let key = { endpoint = producer.id.RequestId.endpoint.ToLower()
-                                        method = producer.id.RequestId.method }
+                                        method = producer.id.RequestId.method
+                                        xMsPath = None }
                             let resourceProducers = tryAdd resourceName
                             resourceProducers.samePayloadProducers.TryAdd(key, new List<BodyPayloadInputProducer>()) |> ignore
                             resourceProducers.samePayloadProducers.[key].Add(producer))
@@ -118,7 +120,8 @@ type Producers() =
         | None -> Seq.empty
         | Some p ->
             let key = { endpoint = requestId.endpoint.ToLower()
-                        method = requestId.method }
+                        method = requestId.method
+                        xMsPath = None }
             match p.samePayloadProducers.TryGetValue(key) with
             | false, _ -> Seq.empty
             | true, lst ->
@@ -128,7 +131,8 @@ type Producers() =
         lock producers (fun () ->
                             let resourceProducers = tryAdd resourceName
                             let key = { endpoint = producer.id.RequestId.endpoint.ToLower()
-                                        method = producer.id.RequestId.method }
+                                        method = producer.id.RequestId.method
+                                        xMsPath = None }
 
                             resourceProducers.inputOnlyProducers.Add(producer))
 
@@ -145,7 +149,7 @@ type Producers() =
             let endpointLookup = endpoint.ToLower()
             seq {
                 for m in operations do
-                    match p.indexedByEndpoint.TryGetValue({ endpoint = endpointLookup ; method = m}) with
+                    match p.indexedByEndpoint.TryGetValue({ endpoint = endpointLookup ; method = m; xMsPath = None}) with
                     | false, _ -> ()
                     | true, p -> yield p |> seq
             }

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -5,6 +5,7 @@ module Restler.Grammar
 
 open System.IO
 open AccessPaths
+open Restler.XMsPaths
 
 /// Tree utilities.
 /// Reference: https://fsharpforfunandprofit.com/posts/recursive-types-and-folds/
@@ -171,10 +172,18 @@ type FuzzingPayload =
     /// In some cases, a payload may need to be split into multiple payload parts
     | PayloadParts of FuzzingPayload list
 
+
+
 /// The unique ID of a request.
 type RequestId =
     {
         endpoint : string
+
+        /// If a request is declared with an x-ms-path, 'xMsPath' contains the original path
+        /// from the specification.  The 'endpoint' above contains a transformed path for
+        /// so that the OpenAPI specification can be compiled with standard 'paths'.
+        xMsPath : XMsPath option
+
         method : OperationMethod
     }
 

--- a/src/compiler/Restler.Compiler/Restler.Compiler.fsproj
+++ b/src/compiler/Restler.Compiler/Restler.Compiler.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="Config.fs" />
     <Compile Include="Telemetry.fs" />
     <Compile Include="Utilities.fs" />
+    <Compile Include="XMsPaths.fs" />
     <Compile Include="SwaggerSpecPreprocessor.fs" />
     <Compile Include="Swagger.fs" />
     <Compile Include="AccessPaths.fs" />

--- a/src/compiler/Restler.Compiler/Utilities.fs
+++ b/src/compiler/Restler.Compiler/Utilities.fs
@@ -43,6 +43,10 @@ module JsonParse =
         obj.[propertyName].Value<JObject>().Add(newValue)
         obj
 
+    let removeProperty (obj:JObject) (propertyName:string) =
+        if obj.ContainsKey(propertyName) then
+            obj.Remove(propertyName) |> ignore
+
     let getPropertyAsString (obj:JObject) (propertyName:string) =
         if obj.ContainsKey(propertyName) then
             let v = obj.[propertyName]
@@ -68,9 +72,9 @@ module Stream =
     /// https://en.wikipedia.org/wiki/UTF-8
     /// Byte order mark (or Preamble)
     /// If the UTF-16 Unicode byte order mark (BOM) character is at the start of a UTF-8 file, the first three bytes will be 0xEF, 0xBB, 0xBF.
-    ///The Unicode Standard neither requires nor recommends the use of the BOM for UTF-8, but warns that it may be encountered at the 
-    /// start of a file trans-coded from another encoding.[46] While ASCII text encoded using UTF-8 is backward compatible with ASCII, 
-    /// this is not true when Unicode Standard recommendations are ignored and a BOM is added. Nevertheless, there was and still is 
+    ///The Unicode Standard neither requires nor recommends the use of the BOM for UTF-8, but warns that it may be encountered at the
+    /// start of a file trans-coded from another encoding.[46] While ASCII text encoded using UTF-8 is backward compatible with ASCII,
+    /// this is not true when Unicode Standard recommendations are ignored and a BOM is added. Nevertheless, there was and still is
     /// software that always inserts a BOM when writing UTF-8, and refuses to correctly interpret UTF-8 unless the first character is a BOM
     type FileStreamWithoutPreamble(filePath, mode: System.IO.FileMode) =
         inherit System.IO.FileStream(filePath, mode)

--- a/src/compiler/Restler.Compiler/XMsPaths.fs
+++ b/src/compiler/Restler.Compiler/XMsPaths.fs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+module Restler.XMsPaths
+
+/// A path in x-ms-path format
+type XMsPath =
+    {
+        /// The path part of the endpoint declared in the specification
+        pathPart : string
+
+        /// The query part of the endpoint
+        queryPart : string
+    }
+    member x.getEndpoint() =
+        sprintf "%s?%s" x.pathPart x.queryPart
+
+    member x.getNormalizedEndpoint() =
+        let transformedQuery =
+            x.queryPart.Replace("=", "/")
+                        .Replace("&", "/")
+
+        let normalizedEndpoint =
+            sprintf "%s%s%s"
+                x.pathPart
+                (if x.pathPart = "/" then "" else "/")
+                transformedQuery
+        normalizedEndpoint
+
+let getXMsPath (endpoint:string) =
+    let pathPart, queryPart =
+        match endpoint.Split('?') with
+        | [| p; q |] -> p, Some q
+        | [| p |] -> p, None
+        | _ ->
+            // Best-effort fallback - try to use the original endpoint
+            endpoint, None
+    match queryPart with
+    | None -> None
+    | Some qp ->
+        Some { pathPart = pathPart
+               queryPart = qp }
+
+/// Transform x-ms-paths present in the specification into paths, so they can be parsed
+/// with a regular OpenAPI specification parser.
+let convertXMsPathsToPaths (xMsPathsEndpoints:seq<string>) =
+    let mapping =
+        xMsPathsEndpoints
+
+        |> Seq.map (fun ep ->
+                        match getXMsPath ep with
+                        | None -> ep, ep
+                        | Some xMsPath ->
+                            let normalizedEnpoint = xMsPath.getNormalizedEndpoint()
+                            ep, normalizedEnpoint)
+        |> Map.ofSeq
+    mapping


### PR DESCRIPTION
With this change, if a specification has an 'x-ms-paths' property in addition to 'paths', the generated
grammar includes the request types from both.  Previously, 'x-ms-paths' was ignored.

The endpoints specified in x-ms-paths which contain a query portion are mapped to a normalized
endpoint that does not contain a query.  RESTler analyzes this normalized endpoint for producer-consumer dependencies as usual, then restores the original endpoint at the time it generates the grammar.

Testing: added unit test corresponding to the in-progress POC.  (Note: this also includes input producers.)