### PR TITLE
Search for path parameters in the global list of parameters.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -104,6 +104,9 @@
     <Content Include="swagger\schemaTests\xMsPaths.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\schemaTests\global_path_parameters.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\schemaTests\xMsPaths_dict.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/SchemaTests.fs
+++ b/src/compiler/Restler.Compiler.Test/SchemaTests.fs
@@ -39,7 +39,6 @@ module ApiSpecSchema =
         let ``required header is parsed successfully`` () =
             compileSpec @"swagger\schemaTests\requiredHeader.yml"
 
-
         [<Fact>]
         let ``spec with x-ms-paths is parsed successfully`` () =
             let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\xMsPaths.json")
@@ -69,6 +68,21 @@ module ApiSpecSchema =
             checkBaseline
                 (config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultJsonGrammarFileName)
                 (Path.Combine(Environment.CurrentDirectory, @"baselines\schemaTests\xMsPaths_grammar.json"))
+
+        [<Fact>]
+        let ``path parameter is read from the global parameters`` () =
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\global_path_parameters.json")
+            let config = { Restler.Config.SampleConfig with
+                             IncludeOptionalParameters = true
+                             GrammarOutputDirectoryPath = Some ctx.testRootDirPath
+                             ResolveBodyDependencies = true
+                             ResolveQueryDependencies = true
+                             SwaggerSpecFilePath = Some [specFilePath]
+                         }
+            Restler.Workflow.generateRestlerGrammar None config
+            let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
+            let grammar = File.ReadAllText(grammarOutputFilePath)
+            Assert.True(grammar.Contains("restler_custom_payload_uuid4_suffix(\"customerId\")"))
 
 
         interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/global_path_parameters.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/global_path_parameters.json
@@ -1,0 +1,29 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Global path parameters test case",
+    "version": "1"
+  },
+
+  "host": "localhost:8888",
+  "paths": {
+    "/customer/{customerId}": {
+      "put": {
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "parameters": {
+    "CustomerId": {
+      "name": "customerId",
+      "required": true,
+      "type": "string",
+      "in": "path"
+    }
+  }
+}


### PR DESCRIPTION
It is valid for a specification to declare a required path parameter in the parameters section
without referring to it explicitly.  RESTler was not previously searching in the global parameters list.
After this change, global parameters will be found and assigned even if they are not declared at
the level of the path or method.

Testing: new unit test.