### PR TITLE
Add engine option to test all query combinations.

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -106,7 +106,7 @@ The maximum number of parameter value combinations for parameters within a given
 The settings for advanced testing of parameter combinations.
 
 __header_param_combinations__
-Currently, testing
+Testing
 different combinations of headers is supported via the following property:
 ```json
 "test_combinations_settings": {
@@ -118,6 +118,17 @@ The supported values are 'optional', 'required', and 'all'.
 - optional: test all combinations of optional parameters, always sending the required parameters.
 - required: test combinations of required parameters, and omit all optional parameters.
 - all: test all combinations of headers, regardless of whether they are required or optional.
+
+__query_param_combinations__
+Testing
+different combinations of queries is supported via the following property:
+```json
+"test_combinations_settings": {
+      "query_param_combinations" : "required"
+}
+```
+The supported values are 'optional', 'required', and 'all'.  These have the same meaning as for
+header parameter combinations (see above).
 
 __example_payloads__
 

--- a/restler/engine/fuzzing_parameters/parameter_schema.py
+++ b/restler/engine/fuzzing_parameters/parameter_schema.py
@@ -7,6 +7,7 @@ from abc import ABCMeta, abstractmethod
 
 from engine.fuzzing_parameters.request_params import *
 from engine.fuzzing_parameters.request_schema_parser import *
+import engine.primitives as primitives
 import utils.logger as logger
 
 class NoHeaderSchemaFound(Exception):
@@ -111,6 +112,21 @@ class QueryList(KeyValueParamList):
                     for query_param in query_param_list:
                         self.append(query_param)
 
+    def get_blocks(self) -> list:
+        """ Returns the request blocks for the query list
+
+        @return: The request blocks for this schema
+        @rtype : List[]
+
+        """
+        query_blocks = []
+        for idx, query in enumerate(self.param_list):
+            query_blocks += query.get_blocks()
+            if idx < len(self.param_list) - 1:
+                # Add the query separator
+                query_blocks.append(primitives.restler_static_string('&'))
+        return query_blocks
+
 class HeaderList(KeyValueParamList):
     def __init__(self, request_schema_json=None, param=None):
         """ Initializes the HeaderList
@@ -157,3 +173,17 @@ class HeaderList(KeyValueParamList):
                     for header_param in header_param_list:
                         self.append(header_param)
 
+    def get_blocks(self) -> list:
+        """ Returns the request blocks for the header list
+
+        @return: The request blocks for this schema
+        @rtype : List[]
+
+        """
+        header_blocks = []
+        for idx, header in enumerate(self.param_list):
+            header_blocks += header.get_blocks()
+            if idx < len(self.param_list):
+                # Must add header separator \r\n after every header
+                header_blocks.append(primitives.restler_static_string('\r\n'))
+        return header_blocks

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -539,6 +539,12 @@ class RestlerSettings(object):
         return None
 
     @property
+    def query_param_combinations(self):
+        if 'query_param_combinations' in self._combinations_args.val:
+            return self._combinations_args.val['query_param_combinations']
+        return None
+
+    @property
     def example_payloads(self):
         if 'example_payloads' in self._combinations_args.val:
             return self._combinations_args.val['example_payloads']

--- a/restler/unit_tests/test_restler_settings.py
+++ b/restler/unit_tests/test_restler_settings.py
@@ -465,6 +465,7 @@ class RestlerSettingsTest(unittest.TestCase):
 
         self.assertEqual(20, settings.max_combinations)
         self.assertEqual("optional", settings.header_param_combinations)
+        self.assertEqual("required", settings.query_param_combinations)
         self.assertEqual("all", settings.example_payloads)
         self.assertEqual(90, settings.max_request_execution_time)
 


### PR DESCRIPTION
This works similarly to testing all header combinations, using the following engine setting:
```json
  "test_combinations_settings": {
    "query_param_combinations" : "all"
}
```

Closes #278

Testing: manual testing with demo_server.