### PR TITLE
Assign the correct primitive types in dependencies

### DIFF
--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -74,6 +74,26 @@ module Examples =
                         ExampleConfigFilePath = Some exampleConfigFile }
 
         [<Fact>]
+        let ``array example where the array itself is a dynamic object`` () =
+            let grammarDirectoryPath = ctx.testRootDirPath
+            let config = { Restler.Config.SampleConfig with
+                             IncludeOptionalParameters = true
+                             GrammarOutputDirectoryPath = Some grammarDirectoryPath
+                             ResolveBodyDependencies = false
+                             UseBodyExamples = Some true
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\array_example.json"))]
+                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\array_example_annotations.json"))
+                         }
+            Restler.Workflow.generateRestlerGrammar None config
+            let grammarFilePath = Path.Combine(grammarDirectoryPath,
+                                               Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
+            let grammar = File.ReadAllText(grammarFilePath)
+            // Check that the grammar contains the array dependency (here, it is an input producer)
+            // and the array item dependency
+            Assert.True(grammar.Contains("primitives.restler_static_string(_stores__storeId__order_post_order_items.reader(), quoted=False),"))
+            Assert.True(grammar.Contains("primitives.restler_static_string(_stores__storeId__order_post_order_items_0.reader(), quoted=False),"))
+
+        [<Fact>]
         let ``object example in grammar without dependencies`` () =
             let grammarDirectoryPath = ctx.testRootDirPath
             let config = { Restler.Config.SampleConfig with

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -159,6 +159,9 @@
     <Content Include="swagger\array_example.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\array_example_annotations.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\array_example_external.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/baselines/exampleTests/array_example_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/exampleTests/array_example_grammar.py
@@ -110,7 +110,7 @@ request = requests.Request([
         "awesome"
     ]}"""),
     primitives.restler_static_string("\r\n"),
-
+    
     {
         'post_send':
         {
@@ -140,6 +140,12 @@ request = requests.Request([
     primitives.restler_static_string("order"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string(_stores__storeId__order_post_id.reader(), quoted=False),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("arrayQueryParameter99="),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("stringQueryParameter77="),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
     primitives.restler_static_string("Accept: application/json\r\n"),
     primitives.restler_static_string("Host: localhost:8888\r\n"),

--- a/src/compiler/Restler.Compiler.Test/swagger/array_example.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/array_example.json
@@ -26,10 +26,16 @@
                     "description": "The date the order will be ready",
                     "type": "string"
                 },
-                "status": {
-                    "description": "The order status",
-                    "type": "string"
+              "status": {
+                "description": "The order status",
+                "type": "string"
+              },
+              "order_items": {
+                "type": "array",
+                "items": {
+                  "type":  "string"
                 }
+              }
             }
         },
         "GroceryList": {
@@ -225,21 +231,35 @@
         "/stores/{storeId}/order/{orderId}": {
             "get": {
                 "operationId": "get_order",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "orderId",
-                        "required": true,
-                        "type": "integer"
-                    },
-                    {
-                        "in": "path",
-                        "name": "storeId",
-                        "required": true,
-                        "type": "integer"
-                    }
-                ],
-
+              "parameters": [
+                {
+                  "in": "path",
+                  "name": "orderId",
+                  "required": true,
+                  "type": "integer"
+                },
+                {
+                  "in": "path",
+                  "name": "storeId",
+                  "required": true,
+                  "type": "integer"
+                },
+                {
+                  "in": "query",
+                  "name": "arrayQueryParameter99",
+                  "required": true,
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "in": "query",
+                  "name": "stringQueryParameter77",
+                  "required": true,
+                  "type": "string"
+                }
+              ],
                 "responses": {
                     "200": {
                         "description": "Success",

--- a/src/compiler/Restler.Compiler.Test/swagger/array_example_annotations.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/array_example_annotations.json
@@ -1,0 +1,16 @@
+{
+  "x-restler-global-annotations": [
+    {
+      "producer_resource_name": "order_items",
+      "producer_method": "POST",
+      "consumer_param": "arrayQueryParameter99",
+      "producer_endpoint": "/stores/{storeId}/order"
+    },
+    {
+      "producer_resource_name": "/order_items/[0]",
+      "producer_method": "POST",
+      "consumer_param": "stringQueryParameter77",
+      "producer_endpoint": "/stores/{storeId}/order"
+    }
+  ]
+}

--- a/src/compiler/Restler.Compiler/AccessPaths.fs
+++ b/src/compiler/Restler.Compiler/AccessPaths.fs
@@ -23,8 +23,7 @@ type AccessPath =
             else
                 x.path |> String.concat "/" |> Some
         member x.getNamePart() =
-            x.path |> Array.tryLast
-
+            x.getPathPropertyNameParts() |> Array.tryLast
 
 let EmptyAccessPath = { path = Array.empty }
 


### PR DESCRIPTION
The default type for a dependency was being assigned to a string.
However, it should be the original type of the property or parameter, since
this will determine how it is quoted.

(This bug was found when testing examples generated by the engine, directly
from the schema.)

While testing this issue, also fixed how array dependencies are handled, so
now both an array element and the array itself may be a producer.  Added a
unit test for this new behavior, which also confirms that the
dynamic object value is not quoted.