### PR TITLE
Add dynamic objects to the engine schema parser.

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -681,12 +681,14 @@ class Request(object):
             # Handle static whose value is the field name
             elif primitive_type == primitives.STATIC_STRING:
                 val = default_val
-                if quoted:
-                    val = f'"{val}"'
                 if val == None:
                     # the examplesChecker may inject None/null, so replace these with the string 'null'
                     logger.raw_network_logging(f"Warning: there is a None value in a STATIC_STRING.")
                     val = 'null'
+                    # Do not quote null values.
+                    quoted = False
+                if quoted:
+                    val = f'"{val}"'
                 values = [val]
             # Handle multipart form data
             elif primitive_type == primitives.FUZZABLE_MULTIPART_FORMDATA:

--- a/restler/engine/fuzzing_parameters/request_schema_parser.py
+++ b/restler/engine/fuzzing_parameters/request_schema_parser.py
@@ -178,6 +178,7 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
         content_value = 'Unknown'
         custom = False
         fuzzable = False
+        is_dynamic_object = False
 
         if 'Fuzzable' in payload:
             content_type = payload['Fuzzable'][0]
@@ -189,6 +190,7 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
         elif 'DynamicObject' in payload:
             content_type = payload['DynamicObject']['primitiveType']
             content_value = payload['DynamicObject']['variableName']
+            is_dynamic_object = True
         elif 'Custom' in payload:
             custom = True
             content_type = payload['Custom']['payloadType']
@@ -216,17 +218,17 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
             # If query parameter, assign as a value and not a string
             # because we don't want to wrap with quotes in the request
             if body_param:
-                value = ParamString(custom, is_required=is_required)
+                value = ParamString(custom, is_required=is_required, is_dynamic_object=is_dynamic_object)
             else:
-                value = ParamValue(custom=custom, is_required=is_required)
+                value = ParamValue(custom=custom, is_required=is_required, is_dynamic_object=is_dynamic_object)
         elif content_type == 'Int':
-            value = ParamNumber(is_required=is_required)
+            value = ParamNumber(is_required=is_required, is_dynamic_object=is_dynamic_object)
         elif content_type == 'Number':
-            value = ParamNumber(is_required=is_required)
+            value = ParamNumber(is_required=is_required, is_dynamic_object=is_dynamic_object)
         elif content_type == 'Bool':
-            value = ParamBoolean(is_required=is_required)
+            value = ParamBoolean(is_required=is_required, is_dynamic_object=is_dynamic_object)
         elif content_type == 'Object':
-            value = ParamObjectLeaf(is_required=is_required)
+            value = ParamObjectLeaf(is_required=is_required, is_dynamic_object=is_dynamic_object)
         elif content_type == 'UuidSuffix':
             value = ParamUuidSuffix(is_required=is_required)
             # Set as unknown for payload body fuzzing purposes.
@@ -255,7 +257,7 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
             else:
                 logger.write_to_main(f'Unexpected enum schema {name}')
         else:
-            value = ParamString(False, is_required=is_required)
+            value = ParamString(False, is_required=is_required, is_dynamic_object=is_dynamic_object)
             value.set_unknown()
 
         value.set_fuzzable(fuzzable)

--- a/restler/restler.py
+++ b/restler/restler.py
@@ -492,14 +492,14 @@ if __name__ == '__main__':
             print_to_console=True
         )
         postprocessing.delete_create_once_resources(failobj.destructors, fuzzing_requests)
-        sys.exit(-1)
-    except InvalidDictionaryException:
+        raise failobj
+    except InvalidDictionaryException as ex:
         print(f"Failed preprocessing:\n\t"
                "An error was identified in the dictionary.")
-        sys.exit(-1)
+        raise ex
     except Exception as error:
         print(f"Failed preprocessing:\n\t{error!s}")
-        sys.exit(-1)
+        raise error
 
     grammar_path = settings.grammar_schema
     if os.path.exists(grammar_path):


### PR DESCRIPTION
Before, the schema parser simply used the dynamic object identifier
as a string (so any payload containing a dynamic object was invalid).

This change fixes this by getting the dynamic object value.

Testing: manual testing with real-world example.  (Automated tests will be added in a separate follow-up checkin.)

Also contains a small change to improve exception handling in restler.py.