### PR TITLE
Perf fixes for ms graph + limited anyof support

### DIFF
--- a/src/compiler/Restler.Compiler.Test/ReferencesTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ReferencesTests.fs
@@ -49,4 +49,9 @@ module References =
             /// Both parsing first or second as the main Swagger file should work.
             testReferenceTypes "second.json"
 
+
+        [<Fact>]
+        let ``array circular reference test`` () =
+            testReferenceTypes "circular_array.json"
+
         interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -174,6 +174,9 @@
     <Content Include="swagger\referencesTests\first.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\referencesTests\circular_array.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\referencesTests\second.json">
     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/swagger/referencesTests/circular_array.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/referencesTests/circular_array.json
@@ -1,0 +1,78 @@
+{
+
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Partial Graph API",
+        "version": "beta"
+    },
+    "servers": [
+        {
+            "url": "https://restlertest/beta/",
+            "description": "references test"
+        }
+    ],
+    "components": {
+      "schemas": {
+
+    "recursion.calendar": {
+      "allOf": [
+          {
+              "title": "calendar",
+              "type": "object",
+              "properties": {
+                  "calendarView": {
+                      "type": "array",
+                      "items": {
+                          "$ref": "#/components/schemas/recursion.event"
+                      }
+                  }
+              }
+          }
+      ]
+  },
+    "recursion.event": {
+      "allOf": [
+          {
+              "title": "event",
+              "type": "object",
+              "properties": {
+                  "calendar": {
+                      "anyOf": [
+                          {
+                              "$ref": "#/components/schemas/recursion.calendar"
+                          }
+                      ],
+                      "nullable": "true"
+                  }
+                }
+              }
+            ]
+      }
+    }
+  },
+  "paths": {
+    "/calendar": {
+      "post": {
+        "parameters": [
+          {
+            "name": "calendar",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/recursion.calendar"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/components/schemas/recursion.calendar"
+            }
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -863,7 +863,6 @@ let getParameterDependencies parameterKind globalAnnotations
             let parameterDependency = getConsumer parameterName [] None
             consumerList.Add(parameterDependency)
     | ParameterKind.Body ->
-
         Tree.iterCtx visitLeaf visitInner PropertyAccessPaths.getInnerAccessPath [] parameterPayload
 
     consumerList |> List.ofSeq
@@ -1001,13 +1000,14 @@ let extractDependencies (requestData:(RequestId*RequestData)[])
             |> Seq.concat
         | _ -> Seq.empty
 
-    logTimingInfo "Getting consumers..."
+    logTimingInfo "Getting path consumers..."
 
     let pathConsumers =
         requestData
         |> Array.Parallel.map
             (fun (r, rd) -> r, getParameterConsumers r ParameterKind.Path rd.requestParameters.path true)
 
+    logTimingInfo "Getting query consumers..."
     let queryConsumers =
         requestData
         |> Array.Parallel.map
@@ -1035,6 +1035,9 @@ let extractDependencies (requestData:(RequestId*RequestData)[])
                 r, c)
 
     let producers = Producers()
+
+    logTimingInfo "Getting body consumers..."
+
     let bodyConsumers =
         requestData
         |> Array.Parallel.map


### PR DESCRIPTION
An OpenAPI specification (Microsoft Graph) was taking too long to compile due to its reference structure.

This check-in addresses the perf issue by adding a cache for the schemas.

Also added support for anyOf properties (just the first option), which is needed so the payloads are not malformed.

