### PR TITLE
Fix regression in query examples.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -68,6 +68,9 @@ module Examples =
                 let message = sprintf "Grammar Does not match baseline.  First difference: %A" grammarDiff
                 Assert.True(grammarDiff.IsNone, message)
             runTest config
+            // Also test this scenario when 'DataFuzzing' is false.  This tests the case where
+            // only examples are used for the schema.
+            runTest { config with DataFuzzing = false }
             let exampleConfigFile = Path.Combine(Environment.CurrentDirectory, "examples\example_config_file.json")
             runTest {config with
                         SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\array_example_external.json"))]

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -548,9 +548,12 @@ let generateRequestPrimitives (requestId:RequestId)
             |> Map.ofSeq
         | _ -> raise (UnsupportedType "Only a list of path parameters is supported.")
     let queryParameters =
-        let schemaQueryParameters = requestParameters.query |> List.tryFind (fun (s, t) -> s = ParameterPayloadSource.Schema)
-        match schemaQueryParameters with
-        | Some (_, ParameterList parameterList) ->
+        let queryParameterList =
+            match requestParameters.query |> List.tryFind (fun (s, t) -> s = ParameterPayloadSource.Schema) with
+            | Some schemaParameters -> schemaParameters
+            | None -> requestParameters.query |> List.head
+        match queryParameterList |> snd with
+        | ParameterList parameterList ->
             parameterList
             |> Seq.map (fun p -> p.name, p)
             |> Map.ofSeq


### PR DESCRIPTION
When 'DataFuzzing' is false, the full schema from the API specification is
not used.  This code path regressed recently, and we did not have test
coverage for it.

This change fixes the issue and adds tests.