### PR TITLE
Increase the maximum wait time for async resource creation.

### DIFF
--- a/restler/engine/core/async_request_utilities.py
+++ b/restler/engine/core/async_request_utilities.py
@@ -165,7 +165,7 @@ def try_async_poll(request_data, response, max_async_wait_time):
             async_waited = True
             poll_wait_seconds = 1
             start_time = time.time()
-            RAW_LOGGING("Waiting for resource to be available...")
+            RAW_LOGGING(f"Waiting for resource to be available...max wait time: {max_async_wait_time}")
             while (time.time() - start_time) < max_async_wait_time:
                 try:
                     # Send the polling request

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -296,7 +296,7 @@ MAX_REQUEST_EXECUTION_TIME_DEFAULT = 120
 # This time is used as a max timeout when waiting for resources to be created.
 # If the timeout is reached we will stop polling the status, but then immediately
 # send the GET request for the endpoint just in case it is now ready.
-MAX_ASYNC_RESOURCE_CREATION_TIME_DEFAULT = 20
+MAX_ASYNC_RESOURCE_CREATION_TIME_DEFAULT = 240
 # This small default for the maximum parameter combinations is intended for
 # first-time use, such as in Test mode.  Users are expected to increase this value
 # as needed for more extensive fuzzing.


### PR DESCRIPTION
The default was previously 20s, which was reported by users to be too small. 
It is desirable to avoid having to configure individual resource timing delays for one outliers.

Increasing the time to 4 minutes to address this issue.