### PR TITLE
Fix regression in initialization for status_code and status_text.

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -138,10 +138,6 @@ class SmokeTestStats(object):
 
     def set_all_stats(self, renderings):
 
-        if self.failure is not None and self.failure != FailureInformation.SEQUENCE:
-            self.status_code = renderings.final_request_response.status_code
-            self.status_text = renderings.final_request_response.status_text
-
         self.valid = 1 if renderings.valid else 0
         if self.valid:
             self.has_valid_rendering = 1
@@ -158,6 +154,9 @@ class SmokeTestStats(object):
                 self.sequence_failure_sample_request.set_response_stats(renderings.final_request_response,
                                                                         renderings.final_response_datetime)
             else:
+                self.status_code = renderings.final_request_response.status_code
+                self.status_text = renderings.final_request_response.status_text
+
                 self.sample_request = RenderedRequestStats()
                 self.sample_request.set_request_stats(
                     renderings.sequence.sent_request_data_list[-1].rendered_data)
@@ -167,7 +166,6 @@ class SmokeTestStats(object):
 
                 if not renderings.valid:
                     self.error_msg = response_body
-
 
             # Set tracked parameters
             last_req = renderings.sequence.last_request

--- a/restler/unit_tests/log_baseline_test_files/ab_flaky_b_all_combinations_speccov.json
+++ b/restler/unit_tests/log_baseline_test_files/ab_flaky_b_all_combinations_speccov.json
@@ -9,13 +9,13 @@
         "invalid_due_to_resource_failure": 0,
         "invalid_due_to_parser_failure": 0,
         "invalid_due_to_500": 0,
-        "status_code": null,
-        "status_text": null,
+        "status_code": "201",
+        "status_text": "Created",
         "error_message": null,
         "request_order": 0,
         "sample_request": {
             "request_sent_timestamp": null,
-            "response_received_timestamp": "2021-07-02 00:55:24",
+            "response_received_timestamp": "2021-08-28 04:35:43",
             "request_verb": "PUT",
             "request_uri": "/A/A",
             "request_headers": [
@@ -48,13 +48,13 @@
         "invalid_due_to_resource_failure": 0,
         "invalid_due_to_parser_failure": 0,
         "invalid_due_to_500": 0,
-        "status_code": null,
-        "status_text": null,
+        "status_code": "400",
+        "status_text": "Bad Request",
         "error_message": "{\"error\": \"{\\\"flaky\\\": 2}\"}",
         "request_order": 0,
         "sample_request": {
             "request_sent_timestamp": null,
-            "response_received_timestamp": "2021-07-02 00:55:24",
+            "response_received_timestamp": "2021-08-28 04:35:43",
             "request_verb": "PUT",
             "request_uri": "/A/A",
             "request_headers": [
@@ -92,13 +92,13 @@
         "invalid_due_to_resource_failure": 0,
         "invalid_due_to_parser_failure": 0,
         "invalid_due_to_500": 0,
-        "status_code": null,
-        "status_text": null,
+        "status_code": "200",
+        "status_text": "OK",
         "error_message": null,
         "request_order": 1,
         "sample_request": {
             "request_sent_timestamp": null,
-            "response_received_timestamp": "2021-07-02 00:55:25",
+            "response_received_timestamp": "2021-08-28 04:35:43",
             "request_verb": "GET",
             "request_uri": "/A/A",
             "request_headers": [
@@ -144,7 +144,7 @@
         "request_order": 1,
         "sequence_failure_sample_request": {
             "request_sent_timestamp": null,
-            "response_received_timestamp": "2021-07-02 00:55:25",
+            "response_received_timestamp": "2021-08-28 04:35:43",
             "request_verb": "PUT",
             "request_uri": "/A/A",
             "request_headers": [

--- a/restler/unit_tests/test_basic_functionality_end_to_end.py
+++ b/restler/unit_tests/test_basic_functionality_end_to_end.py
@@ -80,8 +80,7 @@ class FunctionalityTests(unittest.TestCase):
 
     def tearDown(self):
         try:
-            #shutil.rmtree(self.get_experiments_dir())
-            print("")
+            shutil.rmtree(self.get_experiments_dir())
         except Exception as err:
             print(f"tearDown function failed: {err!s}.\n"
                   "Experiments directory was not deleted.")


### PR DESCRIPTION
These should only be excluded for sequence failures, but were erroneously excluded for
successful requests as well.