### PR TITLE
Fix dependency boolean python conversion.

### DIFF
--- a/restler/engine/dependencies.py
+++ b/restler/engine/dependencies.py
@@ -99,8 +99,6 @@ def get_variable(type):
         return ''
 
     # Make sure the value is properly escaped for being sent
-    # This also handles cases when the variable is a boolean -
-    # and needs to be converted back to its json representation
     value = tlb[type]
     encoded_value = json.dumps(value)
     if isinstance(value, (str)):

--- a/src/compiler/Restler.Compiler.Test/SchemaTests.fs
+++ b/src/compiler/Restler.Compiler.Test/SchemaTests.fs
@@ -55,19 +55,19 @@ module ApiSpecSchema =
                          }
             Restler.Workflow.generateRestlerGrammar None config
 
-            let checkBaseline actualFilePath expectedFilePath =
-                // Check that the baselines match
-                let resultText = File.ReadAllLines(actualFilePath) |> Array.map (fun x -> x.Trim())
-                let baselineText = File.ReadAllLines(expectedFilePath) |> Array.map (fun x -> x.Trim())
-                Assert.True((resultText = baselineText))
+            let grammarDiff =
+                getLineDifferences
+                    (config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
+                    (Path.Combine(Environment.CurrentDirectory, @"baselines\schemaTests\xMsPaths_grammar.py"))
+            let message = sprintf "grammar.py does not match baseline.  First difference: %A" grammarDiff
+            Assert.True(grammarDiff.IsNone, message)
 
-            checkBaseline
-                (config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
-                (Path.Combine(Environment.CurrentDirectory, @"baselines\schemaTests\xMsPaths_grammar.py"))
-
-            checkBaseline
-                (config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultJsonGrammarFileName)
-                (Path.Combine(Environment.CurrentDirectory, @"baselines\schemaTests\xMsPaths_grammar.json"))
+            let grammarDiff =
+                getLineDifferences
+                    (config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultJsonGrammarFileName)
+                    (Path.Combine(Environment.CurrentDirectory, @"baselines\schemaTests\xMsPaths_grammar.json"))
+            let message = sprintf "grammar.json does not match baseline.  First difference: %A" grammarDiff
+            Assert.True(grammarDiff.IsNone, message)
 
         [<Fact>]
         let ``path parameter is read from the global parameters`` () =

--- a/src/compiler/Restler.Compiler.Test/TestUtilities.fs
+++ b/src/compiler/Restler.Compiler.Test/TestUtilities.fs
@@ -12,7 +12,9 @@ open Tree
 let getLineDifferences grammar1FilePath grammar2FilePath =
 
     let g1 = File.ReadAllLines(grammar1FilePath)
+             |> Array.filter (fun x -> not (String.IsNullOrWhiteSpace x))
     let g2 = File.ReadAllLines(grammar2FilePath)
+             |> Array.filter (fun x -> not (String.IsNullOrWhiteSpace x))
 
     let diffElements =
         Seq.zip g1 g2

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
@@ -136,7 +136,8 @@
                 "resourceName",
                 "path"
               ]
-            }
+            },
+            "primitiveType": "String"
           }
         ]
       },
@@ -155,7 +156,8 @@
               "resourceName",
               "path"
             ]
-          }
+          },
+          "primitiveType": "String"
         }
       ],
       "requestMetadata": {
@@ -298,7 +300,8 @@
                 "resourceName",
                 "path"
               ]
-            }
+            },
+            "primitiveType": "String"
           }
         ]
       },
@@ -317,7 +320,8 @@
               "resourceName",
               "path"
             ]
-          }
+          },
+          "primitiveType": "String"
         }
       ],
       "requestMetadata": {

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -57,11 +57,13 @@ let getWriterVariable (producer:Producer) =
         {
             requestId = iop.id.RequestId
             accessPathParts = iop.getInputParameterAccessPath()
+            primitiveType = iop.id.PrimitiveType
         }
     | ResponseObject rp ->
         {
             requestId = rp.id.RequestId
             accessPathParts = rp.id.AccessPathParts
+            primitiveType = rp.id.PrimitiveType
         }
     | _ ->
         raise (invalidArg "producer" "only input parameter and response producers have an associated dynamic object")

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -325,6 +325,9 @@ type DynamicObjectWriterVariable =
 
         /// The access path to the parameter associated with this dynamic object
         accessPathParts: AccessPath
+
+        /// The type of the variable
+        primitiveType : PrimitiveType
     }
 
 /// Information needed to generate a response parser


### PR DESCRIPTION
The previous fix for this was incorrect - the correct fix is to only convert the value, if boolean, at
the time it is parsed from the response.

Testing: manual testing only.