### PR TITLE
Easily replace the entire body of a request.

### DIFF
--- a/docs/user-guide/FuzzingDictionary.md
+++ b/docs/user-guide/FuzzingDictionary.md
@@ -29,6 +29,19 @@ The following describes how each property in the dictionary is used in a RESTler
   }
   ```
 
+A special syntax may be used to replace the entire contents
+of the body of a request.  For a request with endpoint
+```/api/blog/{blogId}``` and method ```GET```, the following replaces the body of this request with the
+specified custom payloads.
+
+  ``` json
+  {
+     "restler_custom_payload": {
+         "/api/blog/{blogId}/get/__body__": "new body"
+     }
+  }
+  ```
+
 - *restler_custom_payload_header* - specifies a list of specific values required for header parameters.
 
   There are two use cases:

--- a/src/compiler/Restler.Compiler/CodeGenerator.fs
+++ b/src/compiler/Restler.Compiler/CodeGenerator.fs
@@ -512,6 +512,9 @@ let generatePythonFromRequestElement includeOptionalParameters (requestId:Reques
                     Restler_static_string_constant RETURN
                     Restler_static_string_constant exString
                 ]
+        | Example (FuzzingPayload.Custom customBodyPayload) ->
+            (Restler_static_string_constant RETURN)::
+            getRestlerPythonPayload (FuzzingPayload.Custom customBodyPayload) false
         | _ ->
             raise (UnsupportedType (sprintf "This request parameters payload type is not supported: %A." b))
 

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -1053,6 +1053,19 @@ let extractDependencies (requestData:(RequestId*RequestData)[])
 
     let bodyConsumers =
         requestData
+        |> Array.filter
+            (fun (r, rd) ->
+                // Special case: if the entire body is being replaced by a dictionary payload,
+                // the body schema should be ignored since there are no producer-consumer dependencies for it.
+                // Note: this is not the same as specifying an example payload for the body.
+                let endpoint =
+                    match r.xMsPath with
+                    | None -> r.endpoint
+                    | Some xMsPath -> xMsPath.getEndpoint()
+                match customDictionary.findBodyCustomPayload endpoint (r.method.ToString()) with
+                | None -> true
+                | Some _ -> false
+            )
         |> Array.Parallel.map
             (fun (r, rd) ->
                 let bodyParametersList =

--- a/src/compiler/Restler.Compiler/Dictionary.fs
+++ b/src/compiler/Restler.Compiler/Dictionary.fs
@@ -54,10 +54,14 @@ type MutationsDictionary =
                 m |> Map.tryFind entryName
             | None -> None
 
+        member x.findBodyCustomPayload endpoint (method:string) =
+            let bodyPayloadName = sprintf "%s/%s/__body__" endpoint (method.ToLower())
+            match x.findPayloadEntry x.restler_custom_payload bodyPayloadName with
+            | Some _ -> Some bodyPayloadName
+            | None -> None
+
         // Note: per-endpoint dictionaries allow restricting a payload to a specific endpoint.
         member x.getParameterForCustomPayload consumerResourceName (accessPathParts: AccessPath) primitiveType parameterKind =
-
-
             // Check both custom payloads and unquoted custom payloads.
             [
                 (if parameterKind = ParameterKind.Query then


### PR DESCRIPTION
This change adds the ability to specify that the entire body of a request type should be
replaced by custom values specified in the dictionary.