### PR TITLE
Make schema combinations 'max_combinations' setting optional.

### DIFF
--- a/restler/engine/fuzzing_parameters/param_combinations.py
+++ b/restler/engine/fuzzing_parameters/param_combinations.py
@@ -8,6 +8,7 @@ import json
 
 import engine.primitives as primitives
 import utils.logger as logger
+from restler_settings import Settings
 
 def get_param_list_combinations(param_list, max_combinations):
     """


### PR DESCRIPTION
This was intended in #320, but not currently working due to a bug.

For schema combinations: the local max_combinations take precedence over the global value.

However, for overall combinations (schema + values), the usual global setting of 'max_combinations' is used.

If the settings are 10 parameter combinations, and 100 schema+value combinations, multiple schema combinations will only be tested if there are fewer than 100 schema+value combinations per schema.