### PR TITLE
Fix root cause of regression introduced in #310

### DIFF
--- a/src/compiler/Restler.Compiler.Test/ReferencesTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ReferencesTests.fs
@@ -54,4 +54,9 @@ module References =
         let ``array circular reference test`` () =
             testReferenceTypes "circular_array.json"
 
+        [<Fact>]
+        let ``cached circular references - infinite recursion regression test`` () =
+            testReferenceTypes "multiple_circular_paths.json"
+
+
         interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -177,6 +177,9 @@
     <Content Include="swagger\referencesTests\circular_array.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\referencesTests\multiple_circular_paths.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\referencesTests\second.json">
     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/swagger/referencesTests/multiple_circular_paths.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/referencesTests/multiple_circular_paths.json
@@ -1,0 +1,94 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "2021-01-01",
+        "title": "Spec with recursive type definitions."
+    },
+    "schemes": [
+        "https"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+
+        "/one": {
+            "put": {
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiVersionParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/Export"
+                        }
+                    }
+                }
+            }
+        },
+        "/two": {
+            "get": {
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiVersionParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/ExportExecutionListResult"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Export": {
+            "type": "object",
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/CommonExportProperties"
+                }
+            }
+        },
+        "CommonExportProperties": {
+            "type": "object",
+            "properties": {
+                "format": {
+                    "description": "This property is necessary for the repro, and it must be the first one.",
+                    "type": "string"
+                },
+                "runHistory": {
+                    "$ref": "#/definitions/ExportExecutionListResult"
+                }
+            }
+        },
+        "ExportExecutionListResult": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "array",
+                    "readOnly": true,
+                    "items": {
+                        "$ref": "#/definitions/CommonExportProperties"
+                    }
+                }
+            }
+        }
+    },
+    "parameters": {
+        "apiVersionParameter": {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Version of the API to be used with the client request."
+        }
+    }
+}

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -223,7 +223,6 @@ module private Parameters =
                                                                         (Some payloadValue, false) trackParameters
                                                                         (declaredParameter.IsRequired, (parameterIsReadOnly declaredParameter))
                                                                         []
-                                                                        (SchemaCache())
                                                                         id
                                     Some { name = declaredParameter.Name
                                            payload = parameterGrammarElement
@@ -397,7 +396,6 @@ module private Parameters =
                                                                 trackParameters
                                                                 (p.IsRequired, (parameterIsReadOnly p))
                                                                 []
-                                                                (SchemaCache())
                                                                 id
 
                                     // Add the name to the parameter payload
@@ -947,7 +945,7 @@ let generateRequestGrammar (swaggerDocs:Types.ApiSpecFuzzingConfig list)
                                 if validResponseCodes |> List.contains r.Key && not (isNull r.Value.ActualResponse.Schema) then
                                     yield generateGrammarElementForSchema r.Value.ActualResponse.Schema (None, false) false
                                                                           (true (*isRequired*), false (*isReadOnly*)) []
-                                                                          (SchemaCache()) id
+                                                                          id
 
                         }
 

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -63,6 +63,16 @@ module Tree =
             subtrees |> Seq.iter (recurse newCtx)
             fNode ctx nodeInfo
 
+    /// Iterate over the tree, and visit each tree node
+    let rec iterTree fNode (tree:Tree<'LeafData,'INodeData>) : unit =
+        let recurse = iterTree fNode
+        match tree with
+        | LeafNode _ ->
+            fNode tree
+        | InternalNode (_,subtrees) ->
+            subtrees |> Seq.iter (recurse)
+            fNode tree
+
 type OperationMethod =
     | Get
     | Post


### PR DESCRIPTION
Remove the workaround added in #322 and add the fix for the root cause,
which is that cycle detection now needs to be performed on the cached schemas
in addition to the previous case of newly traversed schemas.

Testing: added unit test.