### PR TITLE
Fix to allow specifying restler_multipart_formdata directly in the grammar

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -653,6 +653,7 @@ class Request(object):
             elif primitive_type in [ primitives.CUSTOM_PAYLOAD,
                                      primitives.CUSTOM_PAYLOAD_HEADER,
                                      primitives.CUSTOM_PAYLOAD_QUERY,
+                                     primitives.FUZZABLE_MULTIPART_FORMDATA,
                                      primitives.CUSTOM_PAYLOAD_UUID4_SUFFIX ]:
                 field_name = request_block[1]
                 quoted = request_block[2]
@@ -692,7 +693,7 @@ class Request(object):
             elif primitive_type == primitives.FUZZABLE_MULTIPART_FORMDATA:
                 try:
                     current_fuzzable_values = candidate_values_pool.\
-                        get_candidate_values(primitive_type, request_id=self._request_id, tag=default_val, quoted=quoted)
+                        get_candidate_values(primitive_type, request_id=self._request_id, tag=field_name, quoted=quoted)
                     values = [multipart_formdata.render(current_fuzzable_values)]
                 except primitives.CandidateValueException:
                     _raise_dict_err(primitive_type, default_val)

--- a/restler/engine/primitives.py
+++ b/restler/engine/primitives.py
@@ -131,6 +131,7 @@ class CandidateValuesPool(object):
             CUSTOM_PAYLOAD_HEADER,
             CUSTOM_PAYLOAD_QUERY,
             CUSTOM_PAYLOAD_UUID4_SUFFIX,
+            FUZZABLE_MULTIPART_FORMDATA,
             REFRESHABLE_AUTHENTICATION_TOKEN,
             SHADOW_VALUES
         ]


### PR DESCRIPTION
Using the following in the dictionary and grammar, with this change, restler_multipart_formdata can be used to send a file as the body of the corresponding
POST request:
```python
    # Remove this next Content-Type line
    #primitives.restler_static_string("Content-Type: application/json\r\n"),
    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
    primitives.restler_static_string("\r\n"), # Make sure this is here
    primitives.restler_multipart_formdata("file1"),
    primitives.restler_static_string("\r\n"),
```
Dictionary:
```json
  "restler_multipart_formdata": {
    "file1": [
      {
        "content-disposition": "name=\"file1\"; filename=\"test0.txt\"",
        "datastream": "c:\\temp\\restler\\test0.txt"
      },
      {
          "content-disposition": "name=\"file2\"; filename=\"test1.txt\"",
          "datastream": "c:\\temp\\restler\\test1.txt"
      }
    ]
  }
```