### PR TITLE
Initial implementation for header dependencies

### DIFF
--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -262,7 +262,14 @@ def call_response_parser(parser, response, request=None):
     # parse response and set dependent variables (for garbage collector)
     try:
         if parser:
-            parser(response.json_body)
+            # For backwards compatibility, check if the parser accepts named arguments.
+            # If not, this is an older grammar that only supports a json body as the argument
+            import inspect
+            args, varargs, varkw, defaults = inspect.getargspec(parser)
+            if varkw=='kwargs':
+                parser(response.json_body, headers=response.headers_dict)
+            else:
+                parser(response.json_body)
             # Check request's producers to verify dynamic objects were set
             if request:
                 for producer in request.produces:

--- a/restler/engine/transport_layer/response.py
+++ b/restler/engine/transport_layer/response.py
@@ -82,6 +82,27 @@ class HttpResponse(object):
             return None
 
     @property
+    def headers_dict(self):
+        """ The parsed name-value pairs of the headers of the response
+        Headers which are not in the expected format are ignored.
+
+        @return: The headers
+        @rtype : Dict[Str, Str]
+
+        """
+        headers_dict = {}
+        for header in self.headers:
+            payload_start_idx = header.index(":")
+            try:
+                header_name = header[0:payload_start_idx]
+                header_val = header[payload_start_idx+1:]
+                headers_dict[header_name] = header_val
+            except Exception as error:
+                print(f"Error parsing header: {x}", x)
+                pass
+        return headers_dict
+
+    @property
     def json_body(self):
         """ The json portion of the body if exists.
 

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -38,6 +38,12 @@
     <Content Include="baselines\dependencyTests\path_in_dictionary_payload_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="baselines\dependencyTests\header_response_writer_grammar.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="baselines\dependencyTests\header_response_writer_annotation_grammar.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\dependencyTests\post_patch_dependency.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -123,6 +129,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\DependencyTests\lowercase_paths.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\DependencyTests\response_headers.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\DependencyTests\response_headers_annotations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\DependencyTests\inconsistent_casing_paths.json">

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/header_response_writer_annotation_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/header_response_writer_annotation_grammar.py
@@ -1,0 +1,145 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_service_user_post_Location_header = dependencies.DynamicVariable("_service_user_post_Location_header")
+
+def parse_serviceuserpost(data, **kwargs):
+    """ Automatically generated response parser """
+    # Declare response variables
+
+    temp_7262 = None
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        pass
+
+    # Try to extract each dynamic object
+
+
+
+    if headers:
+        # Try to extract dynamic objects from headers
+
+        try:
+            temp_7262 = str(headers["Location"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
+
+        pass
+        
+    # If no dynamic objects were extracted, throw.
+    if not (temp_7262):
+        raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
+
+    # Set dynamic variables
+    if temp_7262:
+        dependencies.set_variable("_service_user_post_Location_header", temp_7262)
+
+req_collection = requests.RequestCollection([])
+# Endpoint: /service/user, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("service"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("user"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+        'post_send':
+        {
+            'parser': parse_serviceuserpost,
+            'dependencies':
+            [
+                _service_user_post_Location_header.writer()
+            ]
+        }
+    },
+
+],
+requestId="/service/user"
+)
+req_collection.add_request(request)
+
+# Endpoint: /service/user/{userId}, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("service"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("user"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_service_user_post_Location_header.reader(), quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/service/user/{userId}"
+)
+req_collection.add_request(request)
+
+# Endpoint: /service/user/{userId}, method: Put
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("service"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("user"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_service_user_post_Location_header.reader(), quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/service/user/{userId}"
+)
+req_collection.add_request(request)
+
+# Endpoint: /service/user/{userId}, method: Delete
+request = requests.Request([
+    primitives.restler_static_string("DELETE "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("service"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("user"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_service_user_post_Location_header.reader(), quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/service/user/{userId}"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/header_response_writer_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/header_response_writer_grammar.py
@@ -1,0 +1,145 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_service_user_post_userId_header = dependencies.DynamicVariable("_service_user_post_userId_header")
+
+def parse_serviceuserpost(data, **kwargs):
+    """ Automatically generated response parser """
+    # Declare response variables
+
+    temp_7262 = None
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        pass
+
+    # Try to extract each dynamic object
+
+
+
+    if headers:
+        # Try to extract dynamic objects from headers
+
+        try:
+            temp_7262 = str(headers["userId"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
+
+        pass
+        
+    # If no dynamic objects were extracted, throw.
+    if not (temp_7262):
+        raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
+
+    # Set dynamic variables
+    if temp_7262:
+        dependencies.set_variable("_service_user_post_userId_header", temp_7262)
+
+req_collection = requests.RequestCollection([])
+# Endpoint: /service/user, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("service"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("user"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+        'post_send':
+        {
+            'parser': parse_serviceuserpost,
+            'dependencies':
+            [
+                _service_user_post_userId_header.writer()
+            ]
+        }
+    },
+
+],
+requestId="/service/user"
+)
+req_collection.add_request(request)
+
+# Endpoint: /service/user/{userId}, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("service"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("user"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_service_user_post_userId_header.reader(), quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/service/user/{userId}"
+)
+req_collection.add_request(request)
+
+# Endpoint: /service/user/{userId}, method: Put
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("service"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("user"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_service_user_post_userId_header.reader(), quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/service/user/{userId}"
+)
+req_collection.add_request(request)
+
+# Endpoint: /service/user/{userId}, method: Delete
+request = requests.Request([
+    primitives.restler_static_string("DELETE "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("service"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("user"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_service_user_post_userId_header.reader(), quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/service/user/{userId}"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_annotation_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_annotation_grammar.py
@@ -12,40 +12,51 @@ _stores_post_id = dependencies.DynamicVariable("_stores_post_id")
 
 _stores_post_metadata = dependencies.DynamicVariable("_stores_post_metadata")
 
-def parse_storespost(data):
+def parse_storespost(data, **kwargs):
     """ Automatically generated response parser """
     # Declare response variables
     temp_7262 = None
     temp_8173 = None
     temp_7680 = None
-    # Parse the response into json
-    try:
-        data = json.loads(data)
-    except Exception as error:
-        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        try:
+            data = json.loads(data)
+        except Exception as error:
+            raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+        pass
 
     # Try to extract each dynamic object
 
-
-    try:
-        temp_7262 = str(data["delivery"]["metadata"])
-    except Exception as error:
-        # This is not an error, since some properties are not always returned
-        pass
-
-
-    try:
-        temp_8173 = str(data["id"])
-    except Exception as error:
-        # This is not an error, since some properties are not always returned
-        pass
+        try:
+            temp_7262 = str(data["delivery"]["metadata"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
 
 
-    try:
-        temp_7680 = str(data["metadata"])
-    except Exception as error:
-        # This is not an error, since some properties are not always returned
-        pass
+        try:
+            temp_8173 = str(data["id"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
+
+
+        try:
+            temp_7680 = str(data["metadata"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
+
 
 
     # If no dynamic objects were extracted, throw.
@@ -73,7 +84,7 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-
+    
     {
         'post_send':
         {

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_in_dictionary_payload_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_in_dictionary_payload_grammar.py
@@ -8,24 +8,33 @@ from engine import dependencies
 
 _stores_post_id = dependencies.DynamicVariable("_stores_post_id")
 
-def parse_storespost(data):
+def parse_storespost(data, **kwargs):
     """ Automatically generated response parser """
     # Declare response variables
     temp_7262 = None
-    # Parse the response into json
-    try:
-        data = json.loads(data)
-    except Exception as error:
-        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        try:
+            data = json.loads(data)
+        except Exception as error:
+            raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+        pass
 
     # Try to extract each dynamic object
 
+        try:
+            temp_7262 = str(data["id"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
 
-    try:
-        temp_7262 = str(data["id"])
-    except Exception as error:
-        # This is not an error, since some properties are not always returned
-        pass
 
 
     # If no dynamic objects were extracted, throw.
@@ -49,7 +58,7 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-
+    
     {
         'post_send':
         {

--- a/src/compiler/Restler.Compiler.Test/baselines/dictionaryTests/quoted_primitives_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dictionaryTests/quoted_primitives_grammar.py
@@ -8,24 +8,33 @@ from engine import dependencies
 
 _stores_post_id = dependencies.DynamicVariable("_stores_post_id")
 
-def parse_storespost(data):
+def parse_storespost(data, **kwargs):
     """ Automatically generated response parser """
     # Declare response variables
     temp_7262 = None
-    # Parse the response into json
-    try:
-        data = json.loads(data)
-    except Exception as error:
-        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        try:
+            data = json.loads(data)
+        except Exception as error:
+            raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+        pass
 
     # Try to extract each dynamic object
 
+        try:
+            temp_7262 = str(data["id"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
 
-    try:
-        temp_7262 = str(data["id"])
-    except Exception as error:
-        # This is not an error, since some properties are not always returned
-        pass
 
 
     # If no dynamic objects were extracted, throw.
@@ -49,7 +58,7 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-
+    
     {
         'post_send':
         {

--- a/src/compiler/Restler.Compiler.Test/baselines/exampleTests/array_example_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/exampleTests/array_example_grammar.py
@@ -8,24 +8,33 @@ from engine import dependencies
 
 _stores__storeId__order_post_id = dependencies.DynamicVariable("_stores__storeId__order_post_id")
 
-def parse_storesstoreIdorderpost(data):
+def parse_storesstoreIdorderpost(data, **kwargs):
     """ Automatically generated response parser """
     # Declare response variables
     temp_7262 = None
-    # Parse the response into json
-    try:
-        data = json.loads(data)
-    except Exception as error:
-        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        try:
+            data = json.loads(data)
+        except Exception as error:
+            raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+        pass
 
     # Try to extract each dynamic object
 
+        try:
+            temp_7262 = str(data["id"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
 
-    try:
-        temp_7262 = str(data["id"])
-    except Exception as error:
-        # This is not an error, since some properties are not always returned
-        pass
 
 
     # If no dynamic objects were extracted, throw.
@@ -112,7 +121,7 @@ request = requests.Request([
         "awesome"
     ]}"""),
     primitives.restler_static_string("\r\n"),
-
+    
     {
         'post_send':
         {

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
@@ -121,6 +121,7 @@
       "httpVersion": "1.1",
       "responseParser": {
         "writerVariables": [],
+        "headerWriterVariables": [],
         "inputWriterVariables": [
           {
             "requestId": {
@@ -137,7 +138,8 @@
                 "path"
               ]
             },
-            "primitiveType": "String"
+            "primitiveType": "String",
+            "kind": "InputParameter"
           }
         ]
       },
@@ -157,7 +159,8 @@
               "path"
             ]
           },
-          "primitiveType": "String"
+          "primitiveType": "String",
+          "kind": "InputParameter"
         }
       ],
       "requestMetadata": {
@@ -285,6 +288,7 @@
       "httpVersion": "1.1",
       "responseParser": {
         "writerVariables": [],
+        "headerWriterVariables": [],
         "inputWriterVariables": [
           {
             "requestId": {
@@ -301,7 +305,8 @@
                 "path"
               ]
             },
-            "primitiveType": "String"
+            "primitiveType": "String",
+            "kind": "InputParameter"
           }
         ]
       },
@@ -321,7 +326,8 @@
               "path"
             ]
           },
-          "primitiveType": "String"
+          "primitiveType": "String",
+          "kind": "InputParameter"
         }
       ],
       "requestMetadata": {

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/response_headers.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/response_headers.json
@@ -1,0 +1,85 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "host": "localhost:8888",
+  "info": {
+    "description": "Small example for header dependencies.",
+    "title": "The title.",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/service/user": {
+      "post": {
+        "responses": {
+          "201": {
+            "headers": {
+              "Location": {
+                "description": "The location (URI) of the new resource",
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "userId": {
+                "description": "The ID of the new user.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service/user/{userId}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "type": "string",
+            "required": true
+          }
+        ]
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/response_headers_annotations.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/response_headers_annotations.json
@@ -1,0 +1,10 @@
+{
+  "x-restler-global-annotations": [
+    {
+      "producer_endpoint": "/service/user",
+      "producer_method": "POST",
+      "producer_resource_name": "Location",
+      "consumer_param": "userId"
+    }
+  ]
+}

--- a/src/compiler/Restler.Compiler/DependencyAnalysisTypes.fs
+++ b/src/compiler/Restler.Compiler/DependencyAnalysisTypes.fs
@@ -16,6 +16,7 @@ type RequestData =
         requestParameters : RequestParameters
         localAnnotations : seq<ProducerConsumerAnnotation>
         responseProperties : ResponseProperties option
+        responseHeaders : (string * ResponseProperties) list
         requestMetadata : RequestMetadata
         exampleConfig : ExampleRequestPayload list option
     }

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -222,21 +222,6 @@ type ProducerConsumerAnnotation =
         consumerParameter : AnnotationResourceReference
         exceptConsumerId: RequestId list option
     }
-    //with
-    //    /// Given the 'consumerParameter', returns the access path or None if the consumer parameter
-    //    /// is a name.
-    //    member x.tryGetConsumerAccessPath =
-    //        match x.consumerParameter with
-    //        | ResourceName _ -> None
-    //        | ResourcePath parts ->
-    //            Some (parts |> String.concat ";")
-
-    //    member x.tryGetProducerAccessPath =
-    //        match x.producerParameter with
-    //        | ResourceName _ -> None
-    //        | ResourcePath parts ->
-    //            Some (parts |> String.concat ";")
-
 
 /// A property that does not have any nested properties
 type LeafProperty =
@@ -327,6 +312,11 @@ type TokenKind =
     | Static of string
     | Refreshable
 
+/// The type of dynamic object variable
+type DynamicObjectVariableKind =
+    | BodyResponseProperty
+    | Header
+    | InputParameter
 
 type DynamicObjectWriterVariable =
     {
@@ -338,6 +328,9 @@ type DynamicObjectWriterVariable =
 
         /// The type of the variable
         primitiveType : PrimitiveType
+
+        /// The kind of the variable (e.g. header or response property)
+        kind : DynamicObjectVariableKind
     }
 
 /// Information needed to generate a response parser
@@ -345,6 +338,9 @@ type ResponseParser =
     {
         /// The writer variables returned in the response
         writerVariables : DynamicObjectWriterVariable list
+
+        /// The writer variables returned in the response headers
+        headerWriterVariables : DynamicObjectWriterVariable list
 
         /// The writer variables that are written when the request is sent, and which
         /// are not returned in the response
@@ -416,7 +412,6 @@ type GrammarDefinition =
     {
         Requests : Request list
     }
-
 
 let generateDynamicObjectVariableName (requestId:RequestId) (accessPath:AccessPath option) delimiter =
     // split endpoint, add "id" at the end.  TBD: jobs_0 vs jobs_1 - where is the increment?


### PR DESCRIPTION
1) Compiler changes:
- add kwargs and parse out headers from the parser arguments
- add ability to infer header dependencies using the header names, similar to
query parameters

2) Engine changes:
- parse the headers and invoke the parser with the additional named argument