### PR TITLE
make path_regex option more robust to different python versions

### DIFF
--- a/restler/engine/core/preprocessing.py
+++ b/restler/engine/core/preprocessing.py
@@ -58,7 +58,7 @@ def create_fuzzing_req_collection(path_regex):
                 reqs = driver.compute_request_goal_seq(
                     request, GrammarRequestCollection())
                 for req in reqs:
-                    included_requests.add(req)
+                    included_requests.append(req)
     else:
         included_requests = list (GrammarRequestCollection()._requests)
 


### PR DESCRIPTION
Closes #343 

Testing: manual with --regex_path option

(This fix is backward compatible: it does work with the officially supported Python version 3.8.2)