### PR TITLE
add reproducible_bug_buckets data to testing_summary.json

### DIFF
--- a/restler/engine/bug_bucketing.py
+++ b/restler/engine/bug_bucketing.py
@@ -219,8 +219,7 @@ class BugBuckets(object):
                 lock.release()
 
     def num_bug_buckets(self, lock=None):
-        """ Calculates the total number of bug buckets and the buckets
-        per class.
+        """ Calculates the total number of bug buckets per bucket class.
 
         @param lock: Lock object used for sync of more than one fuzzing jobs.
         @type  lock: thread.Lock object
@@ -236,6 +235,35 @@ class BugBuckets(object):
             d = OrderedDict()
             for k in sorted(self._bug_buckets):
                 d[k] = len(self._bug_buckets[k])
+        finally:
+            if lock is not None:
+                lock.release()
+
+        return dict(d)
+
+    def repro_bug_buckets(self, lock=None):
+        """ Calculates the total number of reproducible bug buckets
+        per class.
+
+        @param lock: Lock object used for sync of more than one fuzzing jobs.
+        @type  lock: thread.Lock object
+
+        @return: Number of requests sent so far.
+        @rtype : Dict
+
+        """
+        if lock is not None:
+            lock.acquire()
+
+        try:
+            d = OrderedDict()
+            for k in sorted(self._bug_buckets):
+                count_repro_buckets = 0
+                bucket_class = self._bug_buckets[k]
+                for bucket in bucket_class:
+                    if bucket_class[bucket].reproducible:
+                        count_repro_buckets += 1
+                d[k] = count_repro_buckets
         finally:
             if lock is not None:
                 lock.release()

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -813,6 +813,7 @@ def print_generation_stats(req_collection, fuzzing_monitor, global_lock, final=F
         testing_summary['total_object_creations'] = total_object_creations
         testing_summary['total_requests_sent'] = total_requests_sent
         testing_summary['bug_buckets'] = bug_buckets
+        testing_summary['reproducible_bug_buckets'] = BugBuckets.Instance().repro_bug_buckets()
 
         with open(os.path.join(LOGS_DIR, "testing_summary.json"), "w+", encoding='utf-8') as summary_json:
             json.dump(testing_summary, summary_json, indent=4)

--- a/src/driver/Types.fs
+++ b/src/driver/Types.fs
@@ -167,7 +167,10 @@ module Engine =
     //        "main_driver": 66
     //    },
     //    "bug_buckets": {
-    //        "main_driver_500": 0
+    //        "main_driver_500": 1
+    //    },
+    //    "reproducible_bug_buckets": {}
+    //        "main_driver_500": 1
     //    }
     //}
     type TestingSummary =
@@ -181,6 +184,7 @@ module Engine =
             total_object_creations : int
             total_requests_sent : Dictionary<string, int>
             bug_buckets : Dictionary<string, int>
+            reproducible_bug_buckets : Dictionary<string, int>
         }
 
 /// Helper module to produce compact messages in the console, but more

--- a/src/driver/Types.fs
+++ b/src/driver/Types.fs
@@ -169,7 +169,7 @@ module Engine =
     //    "bug_buckets": {
     //        "main_driver_500": 1
     //    },
-    //    "reproducible_bug_buckets": {}
+    //    "reproducible_bug_buckets": {
     //        "main_driver_500": 1
     //    }
     //}


### PR DESCRIPTION
closes #345 

Testing: manually

Note: because new data is added to testing_summary.json without modifying the format for previously existing data, these new edits/additions should be backward compatible to existing post-processing tools for testing_summary.json