### PR TITLE
Fix bug in how query parameters are injected.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
@@ -49,12 +49,6 @@
           {
             "ParameterList": []
           }
-        ],
-        [
-          "DictionaryCustomPayload",
-          {
-            "ParameterList": []
-          }
         ]
       ],
       "bodyParameters": [
@@ -213,12 +207,6 @@
       "queryParameters": [
         [
           "Schema",
-          {
-            "ParameterList": []
-          }
-        ],
-        [
-          "DictionaryCustomPayload",
           {
             "ParameterList": []
           }
@@ -404,12 +392,6 @@
               }
             ]
           }
-        ],
-        [
-          "DictionaryCustomPayload",
-          {
-            "ParameterList": []
-          }
         ]
       ],
       "bodyParameters": [
@@ -508,12 +490,6 @@
           {
             "ParameterList": []
           }
-        ],
-        [
-          "DictionaryCustomPayload",
-          {
-            "ParameterList": []
-          }
         ]
       ],
       "bodyParameters": [
@@ -609,12 +585,6 @@
       "queryParameters": [
         [
           "Schema",
-          {
-            "ParameterList": []
-          }
-        ],
-        [
-          "DictionaryCustomPayload",
           {
             "ParameterList": []
           }


### PR DESCRIPTION
The following case was not working correctly:

Spec: api-version exists
Example 1: api-version exists
Example 2: there is no 'api-version' parameter
The dictionary contains ```restler_custom_payload_query("api-version")```

Expected: each of the above schemas contains just one 'api-version' parameter.  It is injected in Example 2, and replaced in example 1 and the spec schema.

Actual: the api-version parameter was not injected in the third case.