### PR TITLE
Two new options for specifying example payloads.

### DIFF
--- a/docs/user-guide/CompilerConfig.md
+++ b/docs/user-guide/CompilerConfig.md
@@ -71,6 +71,41 @@ directory.  If *DiscoverExamples* is false, every time an example is used
 in the Swagger file, RESTler will first look for it in metadata,
 and, if found, the externally specified example will override the example from the specification.
 
+    See /docs/user-guide/Examples.md for a description of the file format.
+If this setting is not specified, and *DiscoverExamples* is set to ```false```,
+the compiler looks for a default file named ```examples.json``` in the specified examples
+directory.  If *DiscoverExamples* is false, every time an example is used
+in the Swagger file, RESTler will first look for it in metadata,
+and, if found, the externally specified example will override the example from the specification.
+
+
+* *ExampleConfigFiles* is a setting that allows specifying several example config files
+(files in which example parameter payload metadata is located), plus additional settings.
+The currently supported settings are:
+```
+  "ExampleConfigFiles": [
+    {
+      "filePath": "C:\\examples_1.json",
+      "exactCopy": false
+    },
+    {
+      "filePath": "C:\\examples_2.json",
+      "exactCopy": true
+    },
+  ]
+```
+
+- ```filePath``` is the path to the file containing metadata about example parameter payloads
+- ```exactCopy``` specifies whether the example values should be merged with the schema and dictionary
+(for example, this will discard parameters that are not present in the spec), or
+used exactly as specified (for example, this will not substitute any values from the dictionary).
+```exactCopy``` is ```false``` by default.
+
+* *UseAllExamplePayloads* When set to ```true```, all available example payloads are used (currently, both
+the ones referenced in the specification and the ones
+specified by the user in one or more example config files). ```False``` by default (the user-specified examples override
+the ones from the specification).
+
 * *ExamplesDirectory* is the directory where the compiler will copy example payloads
 found in the Swagger file if *DiscoverExamples* is set to ```true```.
 If *DiscoverExamples* is set to ```false```, RESTler tries to use examples in the

--- a/src/compiler/Restler.Compiler.Test/DependencyTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DependencyTests.fs
@@ -33,7 +33,7 @@ module Dependencies =
                                     dictionary
                                     config
                                     List.empty
-                                    None
+                                    []
             let unresolvedPathDeps =
                 dependencies
                 |> List.filter (fun d -> d.producer.IsNone)

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -71,6 +71,15 @@
     <Content Include="swagger\configTests\maindict.json">
     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\configTests\exampleConfigTestPut.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\configTests\exampleConfigTestConfig1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\configTests\exampleConfigTestConfig2.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\configTests\restlerEngineSettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/swagger/configTests/exampleConfigTestConfig1.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/configTests/exampleConfigTestConfig1.json
@@ -1,0 +1,16 @@
+{
+  "paths": {
+    "/stores": {
+      "post": {
+        "1": {
+          "parameters": {
+            "__body__": {
+              "window": "xyz",
+              "door": 123
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/configTests/exampleConfigTestConfig2.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/configTests/exampleConfigTestConfig2.json
@@ -1,0 +1,15 @@
+{
+  "paths": {
+    "/stores/{storeId}": {
+      "put": {
+        "1": {
+          "parameters": {
+            "__body__": {
+              "wood": "abc"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/configTests/exampleConfigTestPut.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/configTests/exampleConfigTestPut.json
@@ -1,0 +1,91 @@
+{
+  "swagger": "2.0",
+  "basePath": "/api",
+  "paths": {
+    "/stores": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Success"
+
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Store"
+            }
+          }
+        ],
+        "tags": [
+          "blog/posts"
+        ]
+      }
+    },
+    "/stores/{storeId}": {
+      "put": {
+        "responses": {
+          "200": {
+            "description": "Success"
+
+          }
+        },
+        "parameters": [
+          {
+            "name": "storeId",
+            "required": true,
+            "in": "path",
+            "type":  "string"
+          },
+          {
+            "name": "body",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Store"
+            }
+          }
+        ],
+        "tags": [
+          "blog/posts"
+        ]
+      }
+    }
+
+  },
+  "info": {
+    "title": "One PUT API with examples",
+    "version": "1.0"
+  },
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "tags": [
+    {
+      "name": "blog/posts",
+      "description": "Operations related to blog posts"
+    },
+    {
+      "name": "/",
+      "description": "Operations related to blog categories"
+    }
+  ],
+  "definitions": {
+    "Store": {
+      "properties": {
+        "window": {
+          "type": "integer",
+          "description": "The unique identifier of a blog post",
+          "example": 123
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/src/compiler/Restler.Compiler/Config.fs
+++ b/src/compiler/Restler.Compiler/Config.fs
@@ -34,6 +34,19 @@ type SwaggerSpecConfig =
         AnnotationFilePath: string option
     }
 
+/// The configuration for the payload examples.
+type ExampleFileConfig =
+    {
+        /// The path to the example configuration file that contains the examples associated with
+        /// one or more request types from the spec.
+        filePath : string
+
+        // If 'true', copy these examples exactly, without substituting any parameter values from the dictionary
+        // If 'false' (default), the examples are merged with the schema.  In particular, parameters with names
+        // that do not match the schema are discarded.
+        exactCopy : bool
+    }
+
 /// User-specified compiler configuration
 type Config =
     {
@@ -66,6 +79,11 @@ type Config =
 
         UseBodyExamples : bool option
 
+        /// When specified, all example payloads are used - both the ones in the specification and the ones in the
+        /// example config file.
+        /// False by default - example config files override any other available payload examples
+        UseAllExamplePayloads : bool option
+
         /// When set to 'true', discovers examples and outputs them to a directory next to the grammar.
         /// If an existing directory exists, does not over-write it.
         DiscoverExamples : bool
@@ -79,6 +97,10 @@ type Config =
 
         /// File path specifying the example config file
         ExampleConfigFilePath : string option
+
+        /// Specifies the example config files.  If the example config file path
+        /// is specified, both are used.
+        ExampleConfigFiles : ExampleFileConfig list option
 
         /// Perform data fuzzing
         DataFuzzing : bool
@@ -198,6 +220,7 @@ let SampleConfig =
         CustomDictionaryFilePath = None
         AnnotationFilePath = None
         ExampleConfigFilePath = None
+        ExampleConfigFiles = None
         GrammarOutputDirectoryPath = None
         IncludeOptionalParameters = true
         UsePathExamples = None
@@ -205,6 +228,7 @@ let SampleConfig =
         UseBodyExamples = None
         UseHeaderExamples = None
         DiscoverExamples = false
+        UseAllExamplePayloads = None
         ExamplesDirectory = ""
         ResolveQueryDependencies = true
         ResolveBodyDependencies = false
@@ -228,12 +252,14 @@ let DefaultConfig =
         CustomDictionaryFilePath = None
         AnnotationFilePath = None
         ExampleConfigFilePath = None
+        ExampleConfigFiles = None
         GrammarOutputDirectoryPath = None
         IncludeOptionalParameters = true
         UseQueryExamples = Some true
         UseHeaderExamples = Some true
         UseBodyExamples = Some true
         UsePathExamples = Some false
+        UseAllExamplePayloads = Some false
         DiscoverExamples = false
         ExamplesDirectory = ""
         ResolveQueryDependencies = true


### PR DESCRIPTION
This change adds two new Compile options to config.json to allow more fine-grained specification of 
example payloads to RESTler.

1) New option "UseAllExamplePayloads" - when set to 'true', use both the spec examples and the payloads in the example config files provided by the user.

2) New option "ExampleConfigFiles" to specify several example config files in a list, and also specify whether the examples should be used without modification or merged with the spec and only extracts the parameters that are declared in the spec.

Testing: added new unit test.

Sample new config.json block:
```
  "ExampleConfigFiles": [
    {
      "filePath": "examples.json",
      "exactCopy": true
    },
    {
      "filePath": "examples2.json",
      "exactCopy": false
    }
  ]
```