### PR TITLE
Fix crash in leakage rule checker

### DIFF
--- a/restler/checkers/examples_checker.py
+++ b/restler/checkers/examples_checker.py
@@ -8,6 +8,7 @@ from engine.fuzzing_parameters.fuzzing_utils import *
 from engine.bug_bucketing import BugBuckets
 from engine.core.request_utilities import str_to_hex_def
 from engine.core.requests import Request
+from engine.core.requests import FailureInformation
 from engine.core.sequences import Sequence
 import engine.primitives as primitives
 
@@ -34,7 +35,7 @@ class ExamplesChecker(CheckerBase):
         @type  : None
 
         """
-        if not rendered_sequence.sequence:
+        if rendered_sequence.sequence is None or rendered_sequence.failure_info == FailureInformation.SEQUENCE:
             return
 
         self._sequence = copy.copy(rendered_sequence.sequence)

--- a/restler/checkers/payload_body_checker.py
+++ b/restler/checkers/payload_body_checker.py
@@ -18,6 +18,7 @@ from copy import copy
 from engine.bug_bucketing import BugBuckets
 import engine.dependencies as dependencies
 import engine.core.requests as requests
+from engine.core.requests import FailureInformation
 import engine.core.sequences as sequences
 from engine.core.fuzzing_monitor import Monitor
 from engine.core.request_utilities import str_to_hex_def
@@ -120,7 +121,8 @@ class PayloadBodyChecker(CheckerBase):
             # finish one-time setup
             self._setup_done = True
 
-        if not rendered_sequence.sequence or\
+        if rendered_sequence.sequence is None or\
+        rendered_sequence.failure_info == FailureInformation.SEQUENCE or\
         (rendered_sequence.valid and not self._fuzz_valid) or\
         (not rendered_sequence.valid and not self._fuzz_invalid):
             return


### PR DESCRIPTION
Recently, RESTler was changed to return rendering information for sequences with a prefix that failed to re-render (for improved root cause analysis in speccov.json).

However, the checkers should not be executed in this case.  This was missed, and now discovered by triggering a crash in the leakage rule checker.
The fix is to simply not run the checkers in this case (it used to be covered by the check that the rendered sequence is None).

This was not caught because there are only 'smoketest' tests for failures to re-render, not covering the checkers.