### PR TITLE
Support 'date' format and allow 'datetime'

### DIFF
--- a/restler/unit_tests/log_baseline_test_files/test_dict.json
+++ b/restler/unit_tests/log_baseline_test_files/test_dict.json
@@ -4,6 +4,8 @@
     "enable"
   ],
   "restler_fuzzable_datetime": [ "2021-01-01", "2021-10-01" ],
+  "restler_fuzzable_date": [ "2022-01-01" ],
+  "restler_fuzzable_date_unquoted": [ "2023-01-01" ],
   "restler_fuzzable_int": [
     "0",
     "1"

--- a/restler/unit_tests/log_baseline_test_files/test_grammar.py
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar.py
@@ -804,7 +804,7 @@ request = requests.Request([
     primitives.restler_static_string(_item_put_name.reader()),
     primitives.restler_static_string("?"),
     primitives.restler_static_string("date="),
-    primitives.restler_fuzzable_datetime("2020-1-1"),
+    primitives.restler_fuzzable_date("2020-1-1"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
     primitives.restler_static_string("Accept: application/json\r\n"),
     primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/array_dep_multiple_items.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/array_dep_multiple_items.json
@@ -110,8 +110,8 @@
             "properties": {
                 "notAfter": {
                     "type": "string",
-                    "format": "date-time",
-                    "description": "The expiry time."
+                    "format": "date",
+                    "description": "The expiry date."
                 },
                 "keyType": {
                     "$ref": "#/definitions/KeyType",

--- a/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/customPayloadDict.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/customPayloadDict.json
@@ -2,6 +2,8 @@
   "restler_fuzzable_string": [ "str" ],
   "restler_fuzzable_string_unquoted": [ "str" ],
   "restler_fuzzable_datetime": [ "dt" ],
+  "restler_fuzzable_date": [ "d" ],
+  "restler_fuzzable_date_unquoted": [ "d" ],
   "restler_fuzzable_datetime_unquoted": [ "dt" ],
   "restler_fuzzable_uuid4": [ "id" ],
   "restler_fuzzable_uuid4_unquoted": [ "id" ],
@@ -15,6 +17,6 @@
   "restler_custom_payload_unquoted": {
     "/storeProperties/tags": [ "custom2" ],
     "message": [ "4" ],
-    "count2":  ["true"]
+    "count2": [ "true" ]
   }
 }

--- a/src/compiler/Restler.Compiler/CodeGenerator.fs
+++ b/src/compiler/Restler.Compiler/CodeGenerator.fs
@@ -32,6 +32,7 @@ module Types =
         | Restler_static_string_jtoken_delim of string
         | Restler_fuzzable_string of RequestPrimitiveTypeData
         | Restler_fuzzable_datetime of RequestPrimitiveTypeData
+        | Restler_fuzzable_date of RequestPrimitiveTypeData
         | Restler_fuzzable_object of RequestPrimitiveTypeData
         | Restler_fuzzable_delim of RequestPrimitiveTypeData
         | Restler_fuzzable_uuid4 of RequestPrimitiveTypeData
@@ -70,6 +71,8 @@ let rec getRestlerPythonPayload (payload:FuzzingPayload) (isQuoted:bool) : Reque
             | Bool -> Restler_fuzzable_bool { defaultValue = v ; isQuoted = false ; exampleValue = exv ; trackedParameterName = parameterName }
             | PrimitiveType.DateTime ->
                 Restler_fuzzable_datetime { defaultValue = v ; isQuoted = isQuoted ; exampleValue = exv ; trackedParameterName = parameterName }
+            | PrimitiveType.Date ->
+                Restler_fuzzable_date { defaultValue = v ; isQuoted = isQuoted ; exampleValue = exv ; trackedParameterName = parameterName }
             | PrimitiveType.String ->
                 Restler_fuzzable_string { defaultValue = v ; isQuoted = isQuoted ; exampleValue = exv ; trackedParameterName = parameterName }
             | PrimitiveType.Object -> Restler_fuzzable_object { defaultValue = v ; isQuoted = false ; exampleValue = exv  ; trackedParameterName = parameterName }
@@ -299,6 +302,7 @@ let generatePythonParameter includeOptionalParameters parameterKind (requestPara
             | _ when isNullValue -> false
             | PrimitiveType.String
             | PrimitiveType.DateTime
+            | PrimitiveType.Date
             | PrimitiveType.Uuid ->
                 true
             | PrimitiveType.Enum (_, enumType, _, _) ->
@@ -1034,6 +1038,12 @@ let getRequests(requests:Request list) includeOptionalParameters =
                         (getTrackedParamPrimitiveParameter s.trackedParameterName)
             | Restler_fuzzable_datetime s ->
                 sprintf "primitives.restler_fuzzable_datetime(\"%s\", quoted=%s%s%s)"
+                        s.defaultValue
+                        (if s.isQuoted then "True" else "False")
+                        (getExamplePrimitiveParameter s.exampleValue)
+                        (getTrackedParamPrimitiveParameter s.trackedParameterName)
+            | Restler_fuzzable_date s ->
+                sprintf "primitives.restler_fuzzable_date(\"%s\", quoted=%s%s%s)"
                         s.defaultValue
                         (if s.isQuoted then "True" else "False")
                         (getExamplePrimitiveParameter s.exampleValue)

--- a/src/compiler/Restler.Compiler/Dictionary.fs
+++ b/src/compiler/Restler.Compiler/Dictionary.fs
@@ -17,6 +17,8 @@ type MutationsDictionary =
         restler_fuzzable_string_unquoted : string list
         restler_fuzzable_datetime : string list
         restler_fuzzable_datetime_unquoted : string list
+        restler_fuzzable_date : string list
+        restler_fuzzable_date_unquoted : string list
         restler_fuzzable_uuid4 : string list
         restler_fuzzable_uuid4_unquoted : string list
 
@@ -199,6 +201,8 @@ let DefaultMutationsDictionary =
         restler_fuzzable_bool = [DefaultPrimitiveValues.[PrimitiveType.Bool]]
         restler_fuzzable_datetime = [DefaultPrimitiveValues.[PrimitiveType.DateTime]]
         restler_fuzzable_datetime_unquoted = []
+        restler_fuzzable_date = [DefaultPrimitiveValues.[PrimitiveType.Date]]
+        restler_fuzzable_date_unquoted = []
         restler_fuzzable_object = [DefaultPrimitiveValues.[PrimitiveType.Object]]
         restler_fuzzable_uuid4 = [DefaultPrimitiveValues.[PrimitiveType.Uuid]]
         restler_fuzzable_uuid4_unquoted = []

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -111,6 +111,7 @@ type PrimitiveType =
     | Uuid
     | Bool
     | DateTime
+    | Date
     /// The enum type specifies the list of possible enum values
     /// and the default value, if specified.
     /// (tag, data type, possible values, default value if present)
@@ -467,6 +468,7 @@ let DefaultPrimitiveValues =
         PrimitiveType.String, "fuzzstring" // Note: quotes are intentionally omitted.
         PrimitiveType.Uuid, "566048da-ed19-4cd3-8e0a-b7e0e1ec4d72" // Note: quotes are intentionally omitted.
         PrimitiveType.DateTime, "2019-06-26T20:20:39+00:00" // Note: quotes are intentionally omitted.
+        PrimitiveType.Date, "2019-06-26" // Note: quotes are intentionally omitted.
         PrimitiveType.Number, "1.23" // Note: quotes are intentionally omitted.
         PrimitiveType.Int, "1"
         PrimitiveType.Bool, "true"

--- a/src/compiler/Restler.Compiler/SwaggerVisitors.fs
+++ b/src/compiler/Restler.Compiler/SwaggerVisitors.fs
@@ -81,9 +81,13 @@ module SchemaUtilities =
                     | "guid" ->
                         PrimitiveType.Uuid,
                         DefaultPrimitiveValues.[PrimitiveType.Uuid]
-                    | "date-time" ->
+                    | "date-time"
+                    | "datetime "-> // Support both officially defined "date-time" and "datetime" because some specs use the latter
                          PrimitiveType.DateTime,
                          DefaultPrimitiveValues.[PrimitiveType.DateTime]
+                    | "date" ->
+                        PrimitiveType.Date,
+                        DefaultPrimitiveValues.[PrimitiveType.Date]
                     | "double" ->
                         PrimitiveType.Number,
                         DefaultPrimitiveValues.[PrimitiveType.Number]


### PR DESCRIPTION
This change adds support for 'restler_fuzzable_date'.

It also allows 'datetime' in addition to 'date-time' for the datetime type.

Closes #153 