### PR TITLE
Enable ordering constraints in annotations - compiler changes

### DIFF
--- a/docs/user-guide/Annotations.md
+++ b/docs/user-guide/Annotations.md
@@ -1,6 +1,11 @@
-# RESTler annotations in Swagger files
+# RESTler annotations
 
 RESTler allows the user to provide annotations with information about producer-consumer dependencies between requests.  This is helpful when RESTler cannot automatically infer such dependencies, which can happen for a variety of reasons (most often, because of very generic or inconsistent naming in the specification, or if the naming convention is not implemented in RESTler).
+
+## Annotation format
+
+Annotations are supported either globally (apply to all requests) or locally (apply only to a single request).  They may be specified inline in the Swagger specification (preferred if generated from the code, to evolve with the API) or outside in a separate file,
+which can be specified in the [Compiler config](CompilerConfig.md).  The latter is preferred when modifications to the Swagger/OpenAPI spec are not acceptable, or maintaining a separate file is easier in your specific workflow.
 
 ## Supported types of dependencies
 RESTler currently supports the following types of producer-consumer dependencies:
@@ -15,11 +20,10 @@ The annotation format for this annotation is the same as for annotations for pro
 3. Between two properties in the body.
 For example: "request ```PUT /A/{aId}``` has properties in the body that also need to refer to ```aId```, whose value is unique for each request invocation (via ```restler_custom_payload_uuid4_suffix```)
 
-Annotations are only supported for dependencies of type (1) and (2) above.
+4. Between two requests.  These ordering constraints may be specified as global annotations.
 
-## Annotation format
+Annotations are only supported for dependencies of type (1), (2) and (4) above.
 
-Annotations are supported either globally (apply to all requests) or locally (apply only to a single request).  They may be specified inline in the Swagger specification (preferred if generated from the code, to evolve with the API) or outside in a separate file (preferred when modifications to the Swagger/OpenAPI spec are not acceptable, or maintaining a separate file is easier in your specific workflow).
 
 ## Global annotations
 
@@ -108,4 +112,15 @@ In some cases, the resource names in the above may be ambiguous, e.g. because se
 }
 ```
 
+An ordering constraint may also be specified, which only includes the request type,
+without any resource names.  For example:
+
+```json
+{
+    "producer_endpoint": "/resource/{resourceId}/start",
+    "producer_method": "POST",
+    "consumer_endpoint": "/resource/{resourceId}/stop",
+    "consumer_method": "POST",
+}
+```
 

--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -81,8 +81,7 @@ module CodeGenerator =
                                ("Host", "fromSwagger")
                                ("Content-Type", "application/json")]
                     token = (TokenKind.Static "SpringfieldToken: 12345")
-                    responseParser = None
-                    inputDynamicObjectVariables = []
+                    dependencyData = None
                     requestMetadata = { isLongRunningOperation = false }
                 }
             let elements = Restler.CodeGenerator.Python.getRequests [request] true

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -44,6 +44,9 @@
     <Content Include="baselines\dependencyTests\header_deps_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="baselines\dependencyTests\ordering_test_grammar.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="baselines\dependencyTests\header_response_writer_annotation_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -150,6 +153,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\DependencyTests\header_deps.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\DependencyTests\ordering_test.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\DependencyTests\ordering_test_annotations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\DependencyTests\header_deps_annotations.json">

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/ordering_test_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/ordering_test_grammar.py
@@ -1,0 +1,112 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+__ordering____services_managementTools = dependencies.DynamicVariable("__ordering____services_managementTools")
+
+__ordering____managementTools_products = dependencies.DynamicVariable("__ordering____managementTools_products")
+req_collection = requests.RequestCollection([])
+# Endpoint: /products, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("products"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+
+        'pre_send':
+        {
+            'dependencies':
+            [
+                __ordering____managementTools_products.reader()
+            ]
+        }
+
+    },
+
+],
+requestId="/products"
+)
+req_collection.add_request(request)
+
+# Endpoint: /services, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("services"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+
+        'post_send':
+        {
+            
+            'dependencies':
+            [
+                __ordering____services_managementTools.writer()
+            ]
+        }
+
+    },
+
+],
+requestId="/services"
+)
+req_collection.add_request(request)
+
+# Endpoint: /managementTools, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("managementTools"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+
+        'pre_send':
+        {
+            'dependencies':
+            [
+                __ordering____services_managementTools.reader()
+            ]
+        }
+,
+
+        'post_send':
+        {
+            
+            'dependencies':
+            [
+                __ordering____managementTools_products.writer()
+            ]
+        }
+
+    },
+
+],
+requestId="/managementTools"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
@@ -113,9 +113,11 @@
         ]
       ],
       "httpVersion": "1.1",
-      "responseParser": {
-        "writerVariables": [],
-        "headerWriterVariables": [],
+      "dependencyData": {
+        "responseParser": {
+          "writerVariables": [],
+          "headerWriterVariables": []
+        },
         "inputWriterVariables": [
           {
             "requestId": {
@@ -135,28 +137,10 @@
             "primitiveType": "String",
             "kind": "InputParameter"
           }
-        ]
+        ],
+        "orderingConstraintWriterVariables": [],
+        "orderingConstraintReaderVariables": []
       },
-      "inputDynamicObjectVariables": [
-        {
-          "requestId": {
-            "endpoint": "/{resourceName}/type/folder",
-            "xMsPath": {
-              "pathPart": "/{resourceName}",
-              "queryPart": "type=folder"
-            },
-            "method": "Put"
-          },
-          "accessPathParts": {
-            "path": [
-              "resourceName",
-              "path"
-            ]
-          },
-          "primitiveType": "String",
-          "kind": "InputParameter"
-        }
-      ],
       "requestMetadata": {
         "isLongRunningOperation": true
       }
@@ -274,9 +258,11 @@
         ]
       ],
       "httpVersion": "1.1",
-      "responseParser": {
-        "writerVariables": [],
-        "headerWriterVariables": [],
+      "dependencyData": {
+        "responseParser": {
+          "writerVariables": [],
+          "headerWriterVariables": []
+        },
         "inputWriterVariables": [
           {
             "requestId": {
@@ -296,28 +282,10 @@
             "primitiveType": "String",
             "kind": "InputParameter"
           }
-        ]
+        ],
+        "orderingConstraintWriterVariables": [],
+        "orderingConstraintReaderVariables": []
       },
-      "inputDynamicObjectVariables": [
-        {
-          "requestId": {
-            "endpoint": "/{resourceName}/type/file",
-            "xMsPath": {
-              "pathPart": "/{resourceName}",
-              "queryPart": "type=file"
-            },
-            "method": "Put"
-          },
-          "accessPathParts": {
-            "path": [
-              "resourceName",
-              "path"
-            ]
-          },
-          "primitiveType": "String",
-          "kind": "InputParameter"
-        }
-      ],
       "requestMetadata": {
         "isLongRunningOperation": true
       }
@@ -456,7 +424,6 @@
         ]
       ],
       "httpVersion": "1.1",
-      "inputDynamicObjectVariables": [],
       "requestMetadata": {
         "isLongRunningOperation": false
       }
@@ -554,7 +521,6 @@
         ]
       ],
       "httpVersion": "1.1",
-      "inputDynamicObjectVariables": [],
       "requestMetadata": {
         "isLongRunningOperation": false
       }
@@ -652,7 +618,6 @@
         ]
       ],
       "httpVersion": "1.1",
-      "inputDynamicObjectVariables": [],
       "requestMetadata": {
         "isLongRunningOperation": false
       }

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/ordering_test.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/ordering_test.json
@@ -1,0 +1,45 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "host": "localhost:8888",
+  "info": {
+    "description": "Small example for ordering constraints.",
+    "title": "The title.",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/products": {
+      "get": {
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/services": {
+      "get": {
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/managementTools": {
+      "get": {
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/ordering_test_annotations.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/ordering_test_annotations.json
@@ -1,0 +1,16 @@
+{
+  "x-restler-global-annotations": [
+    {
+      "producer_endpoint": "/services",
+      "producer_method": "GET",
+      "consumer_endpoint":  "/managementTools",
+      "consumer_method": "GET"
+    },
+    {
+      "producer_endpoint": "/managementTools",
+      "producer_method": "GET",
+      "consumer_endpoint":  "/products",
+      "consumer_method": "GET"
+    }
+  ]
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/ordering_test_anntations.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/ordering_test_anntations.json
@@ -1,0 +1,10 @@
+{
+  "x-restler-global-annotations": [
+    {
+      "producer_endpoint": "/service/user",
+      "producer_method": "POST",
+      "producer_resource_name": "user-id",
+      "consumer_param": "user-id"
+    }
+  ]
+}

--- a/src/compiler/Restler.Compiler/ApiResourceTypes.fs
+++ b/src/compiler/Restler.Compiler/ApiResourceTypes.fs
@@ -321,6 +321,13 @@ type BodyPayloadInputProducer =
         id : ApiResource
     }
 
+
+type OrderingConstraintProducer =
+    {
+        /// The request ID of the source request
+        requestId : RequestId
+    }
+
 /// A producer in the request that is not returned in the response
 /// Example: unique ID specified by a user.
 type InputOnlyProducer =
@@ -366,6 +373,8 @@ type Producer =
     /// The dictionary payload is an option type because it is only present when
     /// the initial payload is being generated.
     | InputParameter of InputOnlyProducer * DictionaryPayload option
+
+    | OrderingConstraintParameter of OrderingConstraintProducer
 
 type ProducerConsumerDependency =
     {


### PR DESCRIPTION
This change adds the ability to specify that two requests should be
executed in a specific order.

If this is specified in the global annotations, a dependency variable
will be created in the grammar, and used by the RESTler engine to order
the requests.

Testing: added unit test.