### PR TITLE
Enable ordering constraints in the engine

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -263,6 +263,12 @@ class Request(object):
             var_name = self._get_var_name_from_definition_line(line)
             if var_name:
                 self._consumes.add(var_name)
+        # Also look for reader placeholders in the pre_send section
+        if bool(self.metadata) and 'pre_send' in self.metadata\
+        and 'dependencies' in self.metadata['pre_send']:
+            for reader_var in self.metadata['pre_send']['dependencies']:
+                var_name = reader_var.split(dependencies.RDELIM)[1]
+                self._consumes.add(var_name)
 
         # Look for writer placeholders
         if bool(self.metadata) and 'post_send' in self.metadata\


### PR DESCRIPTION
When specified in the 'pre_send' section of the grammar, reader variables
are added to the _consumer list, in the same way as when they are
part of the payload.

Testing: tested manually by adding the following annotations to demo_server,
and confirming that every sequence starts with the GET request.
```json
{"x-restler-global-annotations":
[{
  "producer_endpoint": "/blog/posts",
  "producer_method": "GET",
  "consumer_endpoint": "/blog/posts",
  "consumer_method": "POST"
}]
}
```