### PR TITLE
Always try to parse responses from GET after async polling

### DIFF
--- a/restler/checkers/checker_base.py
+++ b/restler/checkers/checker_base.py
@@ -117,9 +117,9 @@ class CheckerBase:
         async_wait = Settings().get_max_async_resource_creation_time(request.request_id)
 
         if check_async:
-            response_to_parse, _, _ = async_request_utilities.try_async_poll(
+            responses_to_parse, _, _ = async_request_utilities.try_async_poll(
                 rendered_data, response, async_wait)
-        request_utilities.call_response_parser(parser, response_to_parse)
+        request_utilities.call_response_parser(parser, None, responses=responses_to_parse)
         seq.append_data_to_sent_list(rendered_data, parser, response, producer_timing_delay=0, max_async_wait_time=async_wait)
         return response, response_to_parse
 

--- a/restler/checkers/payload_body_checker.py
+++ b/restler/checkers/payload_body_checker.py
@@ -1166,9 +1166,9 @@ class PayloadBodyChecker(CheckerBase):
             # send out the request and parse the response
             response = self._send_request(parser, rendered_data)
             async_wait = Settings().get_max_async_resource_creation_time(request.request_id)
-            response_to_parse, _, _ = async_request_utilities.try_async_poll(
+            responses_to_parse, _, _ = async_request_utilities.try_async_poll(
                 rendered_data, response, async_wait)
-            request_utilities.call_response_parser(parser, response_to_parse)
+            request_utilities.call_response_parser(parser, None, responses=responses_to_parse)
 
             self._set_refresh_req(request, response)
 

--- a/restler/engine/core/sequences.py
+++ b/restler/engine/core/sequences.py
@@ -380,12 +380,12 @@ class Sequence(object):
                 prev_producer_timing_delay = Settings().get_producer_timing_delay(prev_request.request_id)
 
                 prev_response = request_utilities.send_request_data(prev_rendered_data)
-                prev_response_to_parse, resource_error, async_waited = async_request_utilities.try_async_poll(
+                prev_responses_to_parse, resource_error, async_waited = async_request_utilities.try_async_poll(
                     prev_rendered_data, prev_response, prev_req_async_wait)
                 prev_parser_threw_exception = False
                 # Response may not exist if there was an error sending the request or a timeout
-                if prev_parser and prev_response_to_parse:
-                    prev_parser_threw_exception = not request_utilities.call_response_parser(prev_parser, prev_response_to_parse, prev_request)
+                if prev_parser and prev_responses_to_parse:
+                    prev_parser_threw_exception = not request_utilities.call_response_parser(prev_parser, None, request=prev_request, responses=prev_responses_to_parse)
                 prev_status_code = prev_response.status_code
 
                 # If the async logic waited for the resource, this wait already included the required
@@ -487,12 +487,12 @@ class Sequence(object):
             req_async_wait = Settings().get_max_async_resource_creation_time(request.request_id)
 
             response = request_utilities.send_request_data(rendered_data)
-            response_to_parse, resource_error, _ = async_request_utilities.try_async_poll(
+            responses_to_parse, resource_error, _ = async_request_utilities.try_async_poll(
                 rendered_data, response, req_async_wait)
             parser_exception_occurred = False
             # Response may not exist if there was an error sending the request or a timeout
-            if parser and response_to_parse:
-                parser_exception_occurred = not request_utilities.call_response_parser(parser, response_to_parse, request)
+            if parser and responses_to_parse:
+                parser_exception_occurred = not request_utilities.call_response_parser(parser, None, request=request, responses=responses_to_parse)
             status_code = response.status_code
             if not status_code:
                 return RenderedSequence(failure_info=FailureInformation.MISSING_STATUS_CODE)
@@ -652,10 +652,10 @@ class Sequence(object):
             """ Gets the token, sends the requst, performs async wait, parses response, returns status code """
             rendered_data = self.get_request_data_with_token(request_data.rendered_data)
             response = request_utilities.send_request_data(rendered_data)
-            response_to_parse, _, _ = async_request_utilities.try_async_poll(
+            responses_to_parse, _, _ = async_request_utilities.try_async_poll(
                 rendered_data, response, request_data.max_async_wait_time)
             if request_data.parser:
-                request_utilities.call_response_parser(request_data.parser, response_to_parse)
+                request_utilities.call_response_parser(request_data.parser, None, responses=responses_to_parse)
             return response.status_code
 
         # Send all but the last request in the sequence


### PR DESCRIPTION
Previously, if async polling from a PUT response in a certain format was received, that was used as the final
response from which to parse dynamic objects, otherwise the GET request was used.   This did not always work -
in some cases, there were properties missing from the response or an empty body was returned.

After this change, the first response on which the response parser will be invoked will be the one from the GET
request.  If the GET failed or parsing the response of the GET, the response from the PUT will still be tried as before.

Testing: ad-hoc testing using original repro (in progress).