### PR TITLE
Several bug fixes in the engine schema parser.

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -984,13 +984,21 @@ class Request(object):
         # These special headers are not fuzzed, and should not be replaced
         skipped_headers_str = ["Accept", "Host", "Content-Type"]
         required_header_blocks = []
+        append_header = False
         for line in old_request.definition[header_start_index : header_end_index]:
             if line[0] == "restler_refreshable_authentication_token":
                 required_header_blocks.append(line)
                 continue
+            if append_header:
+                required_header_blocks.append(line)
+                if line[1].endswith("\r\n"):
+                    append_header = False
             for str in skipped_headers_str:
                 if line[1].startswith(str):
                     required_header_blocks.append(line)
+                    if not line[1].endswith("\r\n"):
+                        # Continue to append
+                        append_header = True
 
         # Make sure there is still a delimiter between headers and the remainder of the payload
         new_header_blocks.append(primitives.restler_static_string("\r\n"))

--- a/restler/engine/fuzzing_parameters/body_schema.py
+++ b/restler/engine/fuzzing_parameters/body_schema.py
@@ -279,7 +279,7 @@ class BodySchema():
 
         """
         for body_parameter in body_parameters:
-            if body_parameter[0] == 'Schema':
+            if body_parameter[0] in ['Schema', 'DictionaryCustomPayload']:
                 payload = des_body_param(body_parameter[1])
                 if payload:
                     self._schema = des_param_payload(payload)

--- a/restler/engine/fuzzing_parameters/parameter_schema.py
+++ b/restler/engine/fuzzing_parameters/parameter_schema.py
@@ -105,7 +105,7 @@ class QueryList(KeyValueParamList):
 
         """
         for query_parameter in query_parameters:
-            if query_parameter[0] == 'Schema':
+            if query_parameter[0] in ['Schema', 'DictionaryCustomPayload']:
                 # Set each query parameter of the query
                 query_param_list = des_query_param(query_parameter[1])
                 if query_param_list:
@@ -166,7 +166,7 @@ class HeaderList(KeyValueParamList):
 
         """
         for header_parameter in header_parameters:
-            if header_parameter[0] == 'Schema':
+            if header_parameter[0] in ['Schema', 'DictionaryCustomPayload']:
                 # Set each query parameter of the query
                 header_param_list = des_header_param(header_parameter[1])
                 if header_param_list:

--- a/restler/engine/fuzzing_parameters/request_params.py
+++ b/restler/engine/fuzzing_parameters/request_params.py
@@ -185,7 +185,7 @@ class ParamValue(ParamBase):
     """ Base class for value type parameters. Value can be Object, Array,
     String, Number, Boolean, ObjectLeaf, and Enum.
     """
-    def __init__(self, custom=False, is_required=True, is_dynamic_object=False):
+    def __init__(self, custom_payload_type=None, is_required=True, is_dynamic_object=False):
         """ Initialize a ParamValue.
 
         @return: None
@@ -194,7 +194,7 @@ class ParamValue(ParamBase):
         """
         ParamBase.__init__(self, is_required, is_dynamic_object)
         self._content = None
-        self._custom = custom
+        self._custom_payload_type = custom_payload_type
 
     def __eq__(self, other):
         """ Operator equals
@@ -260,8 +260,15 @@ class ParamValue(ParamBase):
         @rtype : List[str]
 
         """
-        if self._custom:
-            return[primitives.restler_custom_payload(self._content)]
+        if self._custom_payload_type is not None:
+            if self._custom_payload_type == "String":
+                return [primitives.restler_custom_payload(self._content)]
+            elif self._custom_payload_type == "Query":
+                return [primitives.restler_custom_payload(self._content)]
+            elif self._custom_payload_type == "Header":
+                return [primitives.restler_custom_payload_header(self._content)]
+            else:
+                raise Exception(f"Unknown custom payload type: {self._custom_payload_type}")
 
         content = self._content
         if self.is_dynamic_object:
@@ -671,7 +678,7 @@ class ParamArray(ParamBase):
 class ParamString(ParamValue):
     """ Class for string type parameters """
 
-    def __init__(self, custom=False, is_required=True, is_dynamic_object=False):
+    def __init__(self, custom_payload_type=None, is_required=True, is_dynamic_object=False):
         """ Initialize a string type parameter
 
         @param custom: Whether or not this is a custom payload
@@ -683,7 +690,7 @@ class ParamString(ParamValue):
         """
         ParamValue.__init__(self, is_required=is_required, is_dynamic_object=is_dynamic_object)
 
-        self._is_custom = custom
+        self._custom_payload_type=custom_payload_type
         self._unknown = False
 
     @property
@@ -704,9 +711,11 @@ class ParamString(ParamValue):
         @rtype : List[str]
 
         """
-        if self._is_custom:
-            return [primitives.restler_custom_payload(self._content, quoted=True)]
-
+        if self._custom_payload_type is not None:
+            if self._custom_payload_type == "String":
+                return [primitives.restler_custom_payload(self._content, quoted=True)]
+            else:
+                raise Exception(f"Unexpected custom payload type: {self._custom_payload_type}")
         if self.is_dynamic_object:
             content = dependencies.RDELIM + self._content + dependencies.RDELIM
         else:

--- a/restler/engine/fuzzing_parameters/request_schema_parser.py
+++ b/restler/engine/fuzzing_parameters/request_schema_parser.py
@@ -176,7 +176,6 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
 
         content_type = 'Unknown'
         content_value = 'Unknown'
-        custom = False
         custom_payload_type = None
         fuzzable = False
         is_dynamic_object = False
@@ -193,7 +192,6 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
             content_value = payload['DynamicObject']['variableName']
             is_dynamic_object = True
         elif 'Custom' in payload:
-            custom = True
             content_type = payload['Custom']['primitiveType']
             content_value = payload['Custom']['payloadValue']
             custom_payload_type = payload['Custom']['payloadType']
@@ -210,9 +208,9 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
         elif 'PayloadParts' in payload:
             definition = payload['PayloadParts'][-1]
             if 'Custom' in definition:
-                custom = True
-                content_type = definition['Custom']['payloadType']
+                content_type = definition['Custom']['primitiveType']
                 content_value = definition['Custom']['payloadValue']
+                custom_payload_type = definition['Custom']['payloadType']
 
         # create value w.r.t. the type
         value = None
@@ -220,9 +218,9 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
             # If query parameter, assign as a value and not a string
             # because we don't want to wrap with quotes in the request
             if body_param:
-                value = ParamString(custom, is_required=is_required, is_dynamic_object=is_dynamic_object)
+                value = ParamString(custom_payload_type=custom_payload_type, is_required=is_required, is_dynamic_object=is_dynamic_object)
             else:
-                value = ParamValue(custom=custom, is_required=is_required, is_dynamic_object=is_dynamic_object)
+                value = ParamValue(custom_payload_type=custom_payload_type, is_required=is_required, is_dynamic_object=is_dynamic_object)
         elif content_type == 'Int':
             value = ParamNumber(is_required=is_required, is_dynamic_object=is_dynamic_object)
         elif content_type == 'Number':
@@ -231,7 +229,7 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
             value = ParamBoolean(is_required=is_required, is_dynamic_object=is_dynamic_object)
         elif content_type == 'Object':
             value = ParamObjectLeaf(is_required=is_required, is_dynamic_object=is_dynamic_object)
-        elif custom and custom_payload_type == 'UuidSuffix':
+        elif custom_payload_type is not None and custom_payload_type == 'UuidSuffix':
             value = ParamUuidSuffix(is_required=is_required)
             # Set as unknown for payload body fuzzing purposes.
             # This will be fuzzed as a string.


### PR DESCRIPTION
Fix #1: The main parsing logic was not supporting restler_custom_payload_header and restler_custom_payload_query
Fix #2: The ad-hoc grammar.py parsing for header parameters that should not be fuzzed
did not handle the case when they are on multiple lines, which is the case for Content-Type after recent changes.
Fix #3: The 'DictionaryCustomPayload' payload type should be included in the list of schema parameters, since these are
the additional parameters injected by the user.

These issues were found testing parameter combinations with demo_server in the presence of the above grammar elements.
Testing: manual testing.

(Lack of automated tests for the schema parser is a known test gap that will be addressed soon.)