### PR TITLE
Fix: Avoid waiting five seconds when retries equal one

### DIFF
--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -234,9 +234,9 @@ def send_request_data(rendered_data):
             return HttpResponse()
 
         if status_code in RETRY_CODES:
-            time.sleep(RETRY_SLEEP_SEC)
             num_retries += 1
             if num_retries < MAX_RETRIES:
+                time.sleep(RETRY_SLEEP_SEC)
                 _RAW_LOGGING("Retrying request")
                 continue
             else:


### PR DESCRIPTION
When the number of MAX_RETRIES equals one (basically meaning no retries), the thread will end up waiting for five seconds just to return, which seems not the desirable ^.^