### PR TITLE
Fix garbage collector to use the specified max_request_execution_time

### DIFF
--- a/restler/engine/dependencies.py
+++ b/restler/engine/dependencies.py
@@ -417,7 +417,7 @@ class GarbageCollectorThread(threading.Thread):
                         return
 
                     # Send the request and receive the response
-                    success, response = sock.sendRecv(fully_rendered_data)
+                    success, response = sock.sendRecv(fully_rendered_data, Settings().max_request_execution_time)
                     if success:
                         self.monitor.increment_requests_count('gc')
                     else:

--- a/restler/engine/transport_layer/messaging.py
+++ b/restler/engine/transport_layer/messaging.py
@@ -77,7 +77,7 @@ class HttpSock(object):
         method_name = message[0:end_of_method_idx]
         return method_name
 
-    def sendRecv(self, message, req_timeout_sec=600):
+    def sendRecv(self, message, req_timeout_sec):
         """ Sends a specified request to the server and waits for a response
 
         @param message: Message to be sent.


### PR DESCRIPTION
Using RESTler in CI/CD, it was reported that runs occasionally take 10 minutes while usually finishing in a few seconds.
This was determined to be due to DELETE requests that non-deterministically hung,
and the RESTler GC not using the timeout in the settings, but the default parameter value timeout of 600s.

As part of this fix, the default value of 600 is removed to avoid such issues in the future.