### PR TITLE
ci: full multi-stage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine as builder
+
+RUN apk add --no-cache python3 py3-pip
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+COPY src ./src
+COPY restler ./restler
+COPY build-restler.py .
+
+RUN python3 build-restler.py --dest_dir /build
+
+RUN python3 -m compileall -b /build/engine
+
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine as target
+
+RUN apk add --no-cache python3 py3-pip
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN pip3 install requests applicationinsights
+
+COPY --from=builder /build /RESTler

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ RESTler was designed to run on 64-bit machines with Windows or Linux.  Experimen
 
 ### **Build instructions**
 
+#### Docker
+
+In the root of this repo, run
+
+```shell
+docker build -f docker/Dockerfile -t restler .
+```
+
+#### Local
+
 Prerequisites: Install [Python 3.8.2](https://www.python.org/downloads/) and
 [.NET 5.0](https://dotnet.microsoft.com/download/dotnet-core?utm_source=getdotnetcorecli&utm_medium=referral), for your appropriate OS.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RESTler was designed to run on 64-bit machines with Windows or Linux.  Experimen
 In the root of this repo, run
 
 ```shell
-docker build -f docker/Dockerfile -t restler .
+docker build -t restler .
 ```
 
 #### Local

--- a/build-restler.py
+++ b/build-restler.py
@@ -116,10 +116,11 @@ def publish_engine_py(dirs):
     try:
         copy_python_files(dirs.repository_root_dir, dirs.engine_build_dir)
 
-        output = subprocess.run(f'{dirs.python_path} -m compileall {dirs.engine_build_dir}', shell=True, capture_output=True)
-        if output.stderr:
+        try:
+            output = subprocess.run(f'{dirs.python_path} -m compileall {dirs.engine_build_dir}', shell=True, capture_output=True, check=True)
+        except subprocess.CalledProcessError as e:
             print("Build failed!")
-            print(output.stderr)
+            print(e.stderr)
             sys.exit(-1)
 
         stdout = str(output.stdout)
@@ -163,15 +164,17 @@ def publish_dotnet_apps(dirs, configuration, dotnet_package_source):
         restore_args = f"dotnet restore \"{proj_file_path}\" --use-lock-file --locked-mode --force"
         if dotnet_package_source is not None:
             restore_args = f"{restore_args} -s {dotnet_package_source}"
-        output = subprocess.run(restore_args, shell=True, stderr=subprocess.PIPE)
-        if output.stderr:
+        try:
+            subprocess.run(restore_args, shell=True, stderr=subprocess.PIPE, check=True)
+        except subprocess.CalledProcessError as e:
             print("Build failed!")
-            print(str(output.stderr))
+            print(str(e.stderr))
             sys.exit(-1)
-        output = subprocess.run(f"dotnet publish \"{proj_file_path}\" --no-restore -o \"{proj_output_dir}\" -c {configuration} -f netcoreapp5.0", shell=True, stderr=subprocess.PIPE)
-        if output.stderr:
+        try:
+            subprocess.run(f"dotnet publish \"{proj_file_path}\" --no-restore -o \"{proj_output_dir}\" -c {configuration} -f netcoreapp5.0", shell=True, stderr=subprocess.PIPE, check=True)
+        except subprocess.CalledProcessError as e:
             print("Build failed!")
-            print(str(output.stderr))
+            print(str(e.stderr))
             sys.exit(-1)
 
 if __name__ == '__main__':

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,20 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine as builder
 
-COPY ./compiler /RESTler/compiler
-COPY ./restler /RESTler/restler
+RUN apk add --no-cache python3 py3-pip
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
-#Get the source code for the engine, and
-#copy source code to the image
-#RESTler Python dependency
-RUN apk add --no-cache python3
-RUN python3 -m ensurepip
-RUN pip3 install --upgrade pip
-RUN pip3 install requests
-RUN pip3 install requests
-RUN pip3 install applicationinsights
-COPY ./engine /RESTler/engine
-RUN python3 -m compileall -b /RESTler/engine
-COPY ./resultsAnalyzer /RESTler/resultsAnalyzer
+COPY src ./src
+COPY restler ./restler
+COPY build-restler.py .
+
+RUN python3 build-restler.py --dest_dir /build
+
+RUN python3 -m compileall -b /build/engine
+
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine as target
+
+RUN apk add --no-cache python3 py3-pip
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN pip3 install requests applicationinsights
+
+COPY --from=builder /build /RESTler

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,17 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine as builder
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine
 
-RUN apk add --no-cache python3 py3-pip
-RUN ln -s /usr/bin/python3 /usr/bin/python
+COPY ./compiler /RESTler/compiler
+COPY ./restler /RESTler/restler
 
-COPY src ./src
-COPY restler ./restler
-COPY build-restler.py .
-
-RUN python3 build-restler.py --dest_dir /build
-
-RUN python3 -m compileall -b /build/engine
-
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine as target
-
-RUN apk add --no-cache python3 py3-pip
-RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN pip3 install requests applicationinsights
-
-COPY --from=builder /build /RESTler
+#Get the source code for the engine, and
+#copy source code to the image
+#RESTler Python dependency
+RUN apk add --no-cache python3
+RUN python3 -m ensurepip
+RUN pip3 install --upgrade pip
+RUN pip3 install requests
+RUN pip3 install requests
+RUN pip3 install applicationinsights
+COPY ./engine /RESTler/engine
+RUN python3 -m compileall -b /RESTler/engine
+COPY ./resultsAnalyzer /RESTler/resultsAnalyzer


### PR DESCRIPTION
Wanting to be able to run the latest main in Docker, I needed a Dockerfile which would do all the building for me.

The current Dockerfile had some quirks and could use a touch up, so I've rewritten it to do the entire build process, so the current state of the repo can quickly be built locally or in CI.

This uses multistage, so any source files will not clutter the final result. As such the final image is as small as possible.

I'm not sure how this will interfere with your current build and test pipelines, hopefully this can easily be integrated.

## latest

It would also be highly useful to have a `:latest` tag for this repo which would match a build from main. Could you implement that in the pipeline?