### PR TITLE
Do not print the entire list of fuzzable strings for each sent request.

### DIFF
--- a/restler/engine/core/driver.py
+++ b/restler/engine/core/driver.py
@@ -406,7 +406,8 @@ def render_with_cache(seq_collection, fuzzing_pool, checkers, generation, global
                     logger.write_to_main(f"{formatting.timestamp()}: Rendering INVALID")
 
                     logger.format_rendering_stats_definition(
-                        current_seq.last_request, GrammarRequestCollection().candidate_values_pool
+                        current_seq.last_request, GrammarRequestCollection().candidate_values_pool,
+                        log_all_fuzzable_values=True
                     )
 
                     # Request should not be rendered, stop searching for prefixes
@@ -457,7 +458,8 @@ def render_with_cache(seq_collection, fuzzing_pool, checkers, generation, global
                             print_rendering_to_main_txt(valid_rendering)
                             logger.write_to_main(f"{formatting.timestamp()}: Rendering VALID")
                             logger.format_rendering_stats_definition(
-                                valid_rendering.last_request, GrammarRequestCollection().candidate_values_pool
+                                valid_rendering.last_request, GrammarRequestCollection().candidate_values_pool,
+                                log_all_fuzzable_values=True
                             )
                     rendered_sequences.extend(valid_renderings)
                 else:
@@ -468,7 +470,8 @@ def render_with_cache(seq_collection, fuzzing_pool, checkers, generation, global
 
                     logger.write_to_main(f"{formatting.timestamp()}: Rendering INVALID")
                     logger.format_rendering_stats_definition(
-                        current_seq.last_request, GrammarRequestCollection().candidate_values_pool
+                        current_seq.last_request, GrammarRequestCollection().candidate_values_pool,
+                        log_all_fuzzable_values=True
                     )
 
                     break

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -471,13 +471,9 @@ def custom_network_logging(sequence, candidate_values_pool, **kwargs):
             network_log.write(f"\n\tRequest: {req_i + 1}"
                               " (Current combination: "
                               f"{request._current_combination_id} / {request.num_combinations(candidate_values_pool)})")
-        for request_block in definition:
-            primitive, values, default_val = format_request_block(request.request_id, request_block, candidate_values_pool)
-            if len(values) > 1:
-                network_log.write(f"\t\t+ {primitive}: {values}")
-            else:
-                print_val = values[0] if values else default_val
-                network_log.write(f"\t\t- {primitive}: {print_val!r}")
+
+        print_data = get_rendering_stats_definition(request, candidate_values_pool)
+        network_log.write(print_data)
     network_log.write("")
 
 BugTuple = namedtuple('BugTuple', ['filename_of_replay_log', 'bug_hash', 'reproduce_attempts', 'reproduce_successes'])
@@ -876,23 +872,33 @@ def format_request_block(request_id, request_block, candidate_values_pool):
         values = candidate_values_pool.get_fuzzable_values(primitive, default_val, request_id, quoted=quoted, examples=examples)
     return primitive, values, default_val
 
-def format_rendering_stats_definition(request, candidate_values_pool, log_file=None):
+
+def get_rendering_stats_definition(request, candidate_values_pool, log_file=None, log_all_fuzzable_values=False):
+    print_values=[]
+
     for request_block in request.definition:
         primitive, values, default_val = format_request_block(request.request_id, request_block, candidate_values_pool)
 
-        if len(values) > 1:
-            data = f"\t\t+ {primitive}: {values}"
+        if isinstance(values, list) and len(values) > 1:
+            print_val=values if log_all_fuzzable_values else f"[{values[0]}, {values[1]}, ...]"
+            print_values.append(f"\t\t+ {primitive}: {print_val}")
+        elif isinstance(default_val, list) and len(default_val) > 1:
+            print_val=default_val if log_all_fuzzable_values else f"{default_val[0]}, {default_val[1]}, ...]"
+            print_values.append(f"\t\t- {primitive}: {default_val[:3]}")
         else:
-            data = f"\t\t- {primitive}: {default_val[:100]!r}"
+            print_val = values[0] if values else default_val
+            print_values.append(f"\t\t- {primitive}: {print_val!r}")
 
-        if log_file:
-            print(data, file=log_file)
-        else:
-            write_to_main(data)
+    return "\n".join(print_values)
+
+def format_rendering_stats_definition(request, candidate_values_pool, log_file=None, log_all_fuzzable_values=False):
+    print_data = get_rendering_stats_definition(request, candidate_values_pool, log_file=log_file, log_all_fuzzable_values=log_all_fuzzable_values)
 
     if log_file:
+        print(print_data, file=log_file)
         print("", file=log_file)
     else:
+        write_to_main(print_data)
         write_to_main("")
 
 def print_request_rendering_stats(candidate_values_pool, fuzzing_requests, fuzzing_monitor, num_rendered_requests, generation, global_lock):


### PR DESCRIPTION
This causes perf issues when fuzzing a large number of strings.
Printing all of the array elements is not necessary - printing these one time at the top
of the network log is sufficient.

Closes #266