### PR TITLE
Add option to disable network logs.

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -183,6 +183,9 @@ Example: `disk|virtualNetwork`
 ### save_results_in_fixed_dirname: bool (default False)
 Save the results in a directory with a fixed name (skip the 'experiment\<pid\>' subdir).
 
+### disable_logging: bool (default False)
+Set to True to disable logging to the network logs and main.txt.
+
 ### request_throttle_ms: float (default None)
 The time, in milliseconds, to throttle each request being sent.
 This is here for special cases where the server will block requests from connections that arrive too quickly.

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -441,6 +441,8 @@ class RestlerSettings(object):
         self._test_server = SettingsArg('test_server', str, DEFAULT_TEST_SERVER_ID, user_args)
         ## Stops fuzzing after given time (hours)
         self._time_budget = SettingsArg('time_budget', (int, float), TIME_BUDGET_DEFAULT, user_args, minval=0)
+        ## Disable the network logs and main.txt
+        self._disable_logging = SettingsArg('disable_logging', bool, False, user_args)
         ## Add current dates in addition to the ones specified in the dictionary
         self._add_fuzzable_dates = SettingsArg('add_fuzzable_dates', bool, False, user_args)
         ## The command to execute in order to refresh the authentication token
@@ -469,9 +471,13 @@ class RestlerSettings(object):
         return self
 
     @property
+    def disable_logging(self):
+        return self._disable_logging.val
+
+    @property
     def client_certificate_path(self):
         return self._client_certificate_path.val
-    
+
     @property
     def client_certificate_key_path(self):
         return self._client_certificate_key_path.val

--- a/restler/unit_tests/restler_user_settings.json
+++ b/restler/unit_tests/restler_user_settings.json
@@ -28,6 +28,7 @@
   "max_sequence_length": 11,
   "no_ssl": true,
   "disable_cert_validation": true,
+  "disable_logging": true,
   "no_tokens_in_logs": true,
   "path_regex": "(\\w*)/ddosProtectionPlans(\\w*)",
   "ignore_decoding_failures": true,

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -16,6 +16,7 @@ from collections import namedtuple
 
 import engine.primitives as primitives
 import engine.dependencies as dependencies
+from restler_settings import Settings
 
 import utils.formatting as formatting
 
@@ -91,6 +92,9 @@ class NetworkLog(object):
         @rtype : None
 
         """
+        if Settings().disable_logging:
+            return
+
         if os.path.getsize(self._current_log_path) > NetworkLog._MaxLogSize:
             # Create a new log if the current log has grown beyond the max size
             self._current_log_num += 1
@@ -206,6 +210,9 @@ class SpecCoverageLog(object):
         @rtype : None
 
         """
+        if Settings().disable_logging:
+            return
+
         from engine.core.requests import FailureInformation
         if rendered_sequence:
             req=rendered_sequence.sequence.last_request
@@ -371,6 +378,8 @@ def write_to_main(data: str, print_to_console: bool=False):
     @return: None
 
     """
+    if Settings().disable_logging:
+        return
     try:
         main_lock.acquire()
         with open(MAIN_LOGS, "a+", encoding='utf-8') as f:


### PR DESCRIPTION
Logs may be turned off via a new option, "disable_logging.
This can be useful for long fuzzing runs when it
is not desired to log every request for performance reasons.