### PR TITLE
Fix bug in re-try logic

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -191,6 +191,48 @@ The time, in milliseconds, to throttle each request being sent.
 This is here for special cases where the server will block requests from connections that arrive too quickly.
 Using this setting is not recommended.
 
+### custom_retry_settings: dict (default empty)
+
+The settings for specifying custom status codes or status text on which to re-try the request.  These
+override the default values.
+
+__status_codes__
+
+A list of response status codes on which the request should be re-tried may be specified as follows
+(shown below with the default value):
+
+```json
+"custom_retry_settings": {
+     "status_codes": [
+         "429"
+     ]
+}
+```
+
+__response_text__
+
+A list of strings in the response on which the request should be re-tried may be specified as follows
+(shown below with the default value):
+
+```json
+"custom_retry_settings": {
+     "response_text": [
+         "AnotherOperationInProgress"
+     ]
+}
+```
+
+___interval_sec__
+
+The number of seconds to wait between retries (shown below with the default value).
+
+```json
+"custom_retry_settings": {
+     "interval_sec": 5
+}
+```
+
+
 ### target_ip: str (default None)
 The IP address of the target webserver.
 

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -425,6 +425,8 @@ class RestlerSettings(object):
         self._path_regex = SettingsArg('path_regex', str, None, user_args)
         ## Minimum time, in milliseconds, to wait between sending requests
         self._request_throttle_ms = SettingsArg('request_throttle_ms', (int, float), None, user_args, minval=0)
+        ## Settings for customizing re-try logic for requests
+        self._retry_args = SettingsArg('custom_retry_settings', dict, {}, user_args)
         ## Ignore data UTF decoding failures (see https://github.com/microsoft/restler-fuzzer/issues/164)
         self._ignore_decoding_failures = SettingsArg('ignore_decoding_failures', bool, False, user_args)
         ## Collection of endpoint specific producer timing delays - will be set with other per_resource settings
@@ -587,6 +589,25 @@ class RestlerSettings(object):
     @property
     def request_throttle_ms(self):
         return self._request_throttle_ms.val
+
+    @property
+    def custom_retry_codes(self):
+        if 'status_codes' in self._retry_args.val:
+            return self._retry_args.val['status_codes']
+        return None
+
+    @property
+    def custom_retry_text(self):
+        if 'response_text' in self._retry_args.val:
+            return self._retry_args.val['response_text']
+        return None
+
+    @property
+    def custom_retry_interval_sec(self):
+        if 'interval_sec' in self._retry_args.val:
+            return self._retry_args.val['interval_sec']
+        return None
+
 
     @property
     def ignore_decoding_failures(self):

--- a/restler/unit_tests/restler_user_settings.json
+++ b/restler/unit_tests/restler_user_settings.json
@@ -33,6 +33,15 @@
   "path_regex": "(\\w*)/ddosProtectionPlans(\\w*)",
   "ignore_decoding_failures": true,
   "request_throttle_ms": 500,
+  "custom_retry_settings": {
+    "status_codes": [
+      "429"
+    ],
+    "response_text": [
+      "please re-try"
+    ],
+    "interval_sec": 5
+  },
   "target_ip": "100.100.100.100",
   "target_port": 500,
   "time_budget": 12,

--- a/restler/unit_tests/test_restler_settings.py
+++ b/restler/unit_tests/test_restler_settings.py
@@ -507,3 +507,6 @@ class RestlerSettingsTest(unittest.TestCase):
         code5 = re.compile('500')
         self.assertEqual([code1, code2, code3], settings.custom_bug_codes)
         self.assertEqual([code4, code5], settings.custom_non_bug_codes)
+        self.assertEqual(settings.custom_retry_interval_sec, 5)
+        self.assertEqual(settings.custom_retry_codes, ["429"])
+        self.assertEqual(settings.custom_retry_text, ["please re-try"])


### PR DESCRIPTION
Closes issue Conflict should not be always re-tried #416.

For backwards compatibility, kept a hard-coded default value with the original re-try for which the
unconditional 409 was added.

Also added a custom re-try interval setting.

Testing: manual testing with demo_server for all 3 new settings.