### PR TITLE
Dockerfile for demo server

### DIFF
--- a/demo_server/Dockerfile
+++ b/demo_server/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.8-alpine
+
+RUN apk add --no-cache build-base
+
+COPY demo_server/  /app/demo_server
+COPY requirements.txt logging.conf swagger.json /app/
+
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+EXPOSE 8888
+
+CMD ["python", "demo_server/app.py"]

--- a/demo_server/Dockerfile
+++ b/demo_server/Dockerfile
@@ -11,4 +11,6 @@ RUN pip install -r requirements.txt
 
 EXPOSE 8888
 
+ENV FLASK_RUN_HOST=0.0.0.0
+
 CMD ["python", "demo_server/app.py"]

--- a/demo_server/README.md
+++ b/demo_server/README.md
@@ -44,3 +44,6 @@ Swagger
 Start trying the endpoints from the swagger API at your browser and you will
 see logs coming in the terminal where the server is running. Moreover, you should
 see coverage information produced in demo_server/coverage_stats.txt.
+
+> Ensure your request `Host` header matches the value of `FLASK_SERVER_NAME` in
+`settings.py`, else each request will return an HTTP 404.

--- a/demo_server/demo_server/app.py
+++ b/demo_server/demo_server/app.py
@@ -58,7 +58,7 @@ def main():
     # with app.app_context():
     #     db.create_all()
     log.info('>>>>> Starting development server at http://{}/api/ <<<<<'.format(app.config['SERVER_NAME']))
-    app.run(threaded=True, use_reloader=False, debug=settings.FLASK_DEBUG)
+    app.run(threaded=True, use_reloader=False, debug=settings.FLASK_DEBUG, host="0.0.0.0")
 
 if __name__ == "__main__":
     main()

--- a/demo_server/demo_server/app.py
+++ b/demo_server/demo_server/app.py
@@ -58,7 +58,7 @@ def main():
     # with app.app_context():
     #     db.create_all()
     log.info('>>>>> Starting development server at http://{}/api/ <<<<<'.format(app.config['SERVER_NAME']))
-    app.run(threaded=True, use_reloader=False, debug=settings.FLASK_DEBUG, host="0.0.0.0")
+    app.run(threaded=True, use_reloader=False, debug=settings.FLASK_DEBUG, host=os.getenv("FLASK_RUN_HOST", "localhost"))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Wanting to test out RESTler with a simple demo server, I created a Dockerfile so this demo server can be easily run.

Since `FLASK_RUN_HOST` didn't work, I've added it to the run command. It will keep the default `localhost` binding, but allows setting it as `0.0.0.0` for when run in a container.