### PR TITLE
Fix schema cache recursion issue

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -219,6 +219,9 @@
     <Content Include="swagger\referencesTests\circular_array.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\referencesTests\circular_path.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\referencesTests\multiple_circular_paths.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/swagger/referencesTests/circular_path.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/referencesTests/circular_path.json
@@ -1,0 +1,106 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "2021-01-01",
+        "title": "Spec with recursion. Note: the order of requests is important for this test."
+    },
+    "schemes": [
+        "https"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/customer/{customerName}": {
+            "get": {
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/nameParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/Customer"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/nameParameter"
+                    },
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                          "$ref": "#/definitions/Customer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/Customer"
+                        }
+                    }
+                }
+            }
+        },
+        "/customer": {
+            "post": {
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                          "$ref": "#/definitions/Customer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/Customer"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Customer": {
+            "type": "object",
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/CustomerProperties"
+                }
+            }
+        },
+        "CustomerProperties": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "related": {
+                    "$ref": "#/definitions/Customer"
+                }
+            }
+        }
+    },
+    "parameters": {
+        "nameParameter": {
+            "name": "customerName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+        }
+    }
+}

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -315,6 +315,7 @@ module private Parameters =
                                                                         (Some payloadValue, false) trackParameters
                                                                         (declaredParameter.IsRequired, (parameterIsReadOnly declaredParameter))
                                                                         []
+                                                                        (SchemaCache())
                                                                         id
                                     Some { name = declaredParameter.Name
                                            payload = parameterGrammarElement
@@ -514,6 +515,7 @@ module private Parameters =
                                                                 trackParameters
                                                                 (p.IsRequired, (parameterIsReadOnly p))
                                                                 []
+                                                                (SchemaCache())
                                                                 id
 
                                     // Add the name to the parameter payload
@@ -1020,6 +1022,7 @@ let generateRequestGrammar (swaggerDocs:Types.ApiSpecFuzzingConfig list)
                            (userSpecifiedExamples:ExampleConfigFile list) =
 
     let getRequestData (swaggerDoc:OpenApiDocument) (xMsPathsMapping:Map<string,string> option) =
+        let schemaCache = SchemaCache()
         let requestDataSeq = seq {
             for path in swaggerDoc.Paths do
                 let ep = path.Key.TrimEnd([|'/'|])
@@ -1135,6 +1138,7 @@ let generateRequestGrammar (swaggerDocs:Types.ApiSpecFuzzingConfig list)
                                     |> Seq.map (fun h -> let headerSchema =
                                                              generateGrammarElementForSchema h.Value (None, false) false
                                                                                              (true (*isRequired*), false (*isReadOnly*)) []
+                                                                                             schemaCache
                                                                                              id
                                                          h.Key, headerSchema)
                                     |> Seq.toList
@@ -1144,6 +1148,7 @@ let generateRequestGrammar (swaggerDocs:Types.ApiSpecFuzzingConfig list)
                                     else
                                         generateGrammarElementForSchema r.Value.ActualResponse.Schema (None, false) false
                                                                         (true (*isRequired*), false (*isReadOnly*)) []
+                                                                        schemaCache
                                                                         id
                                         |> Some
                                 {| bodyResponse = bodyResponseSchema


### PR DESCRIPTION
The logic was incorrectly caching the leaf instead of root node of the cycle.

Unfortunately, this was not caught in testing because triggering this
in a user-visible way requires a specific ordering of requests (e.g.,
a get or delete followed by a put).  This resulted in response properties
not being extracted from the schema in some cases, causing some missing
producer-consumer dependencies.

Testing: added unit test.