### PR TITLE
Add compiler option to limit maximum depth for json schemas.

### DIFF
--- a/docs/user-guide/CompilerConfig.md
+++ b/docs/user-guide/CompilerConfig.md
@@ -137,3 +137,6 @@ catch consistency bugs in the specification because producer-consumer dependenci
 * *TrackFuzzedParameterNames* False by default.  When true, every fuzzable primitive will
 include an additional parameter `param_name` which is the name of the property or
 parameter being fuzzed.  These will be used to capture fuzzed parameters in ```tracked_parameters``` in the spec coverage file.
+
+* *JsonPropertyMaxDepth* is the maximum depth for Json properties in the schema to test.
+Any properties exceeding this depth are removed.  There is no maximum by default.

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -131,6 +131,9 @@
     <Content Include="swagger\schemaTests\xMsPaths_dict.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\schemaTests\large_json_body.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\schemaTests\xMsPaths_annotations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/SchemaTests.fs
+++ b/src/compiler/Restler.Compiler.Test/SchemaTests.fs
@@ -84,5 +84,34 @@ module ApiSpecSchema =
             let grammar = File.ReadAllText(grammarOutputFilePath)
             Assert.True(grammar.Contains("restler_custom_payload_uuid4_suffix(\"customerId\")"))
 
+        [<Fact>]
+        let ``json depth limit test`` () =
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\large_json_body.json")
+            let config = { Restler.Config.SampleConfig with
+                             IncludeOptionalParameters = true
+                             GrammarOutputDirectoryPath = Some ctx.testRootDirPath
+                             ResolveBodyDependencies = true
+                             ResolveQueryDependencies = true
+                             SwaggerSpecFilePath = Some [specFilePath]
+                         }
+
+            Restler.Workflow.generateRestlerGrammar None config
+            let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
+            let noDepthLimitGrammar = File.ReadAllText(grammarOutputFilePath)
+
+            let upperLimit = 6
+            let lowerLimit = 0
+            for depthLimit in lowerLimit..upperLimit do
+                let objectName = sprintf "object_level_%d" depthLimit
+                let nextObjectName = sprintf "object_level_%d" (depthLimit + 1)
+                Restler.Workflow.generateRestlerGrammar None { config with JsonPropertyMaxDepth = Some depthLimit }
+                let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
+                let grammar = File.ReadAllText(grammarOutputFilePath)
+                if depthLimit < upperLimit then
+                    Assert.True(grammar <> noDepthLimitGrammar)
+                // Make sure the object for this level is present, and the one for the next level is not
+                if depthLimit > lowerLimit then
+                    Assert.True(grammar.Contains(objectName))
+                    Assert.False(grammar.Contains(nextObjectName))
 
         interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/large_json_body.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/large_json_body.json
@@ -1,0 +1,162 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "definitions": {
+    "RecentOrderItem": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object"
+        },
+        "object_level_6": {
+          "type": "object"
+        },
+      "level8properties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Object8"
+        }
+      }
+      }
+    },
+    "OrderItem": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object"
+        },
+        "object_level_4": {
+          "type": "object"
+        }
+      }
+    },
+    "Order": {
+      "properties": {
+        "recentOrder": {
+            "$ref": "#/definitions/RecentOrderItem"
+        },
+        "object_level_5": {
+          "type": "object"
+        }
+      }
+    },
+    "OrderPropertiesFormat": {
+      "properties": {
+        "recentOrders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Order"
+          }
+        },
+        "object_level_3": {
+          "type": "object"
+        },
+        "rushOrderItem": {
+          "$ref": "#/definitions/OrderItem"
+        }
+      }
+    },
+    "CustomerPropertiesFormat": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "nickname": {
+          "type": "string"
+        },
+        "relatives": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Customer"
+            }
+        },
+        "orderProfile": {
+           "$ref": "#/definitions/OrderPropertiesFormat"
+        },
+        "object_level_2": {
+          "type": "object"
+        }
+      }
+    },
+    "Customer": {
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CustomerPropertiesFormat"
+        },
+        "name": {
+          "type": "string"
+        },
+        "object_level_1": {
+          "type": "object"
+        }
+      },
+
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubResource"
+        }
+      ]
+    },
+    "SubResource": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "Object8": {
+      "properties": {
+        "object_level_8": {
+          "type": "string"
+        }
+      }
+    }
+
+  },
+  "host": "localhost:8888",
+  "info": {
+    "description": "Example with deep json body and both arrays, properties, and objects.",
+    "title": "Test json nesting depth",
+    "version": "1.0"
+  },
+  "paths": {
+    "/customers/{customerId}": {
+      "put": {
+          "parameters": [
+            {
+              "in": "path",
+              "name": "customerName",
+              "required": true,
+              "type": "String"
+            },
+            {
+              "in": "body",
+              "name": "body",
+              "required": true,
+              "schema": {
+                "$ref": "#/definitions/Customer"
+              }
+            }
+          ],
+          "responses": {
+            "201": {
+              "description": "Success",
+              "schema": {
+                "$ref": "#/definitions/Customer"
+              }
+            }
+          }
+        }
+      }
+    },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler/Config.fs
+++ b/src/compiler/Restler.Compiler/Config.fs
@@ -131,6 +131,10 @@ type Config =
         // parameter names for all fuzzable values.  For example:
         // restler_fuzzable_string("1", param_name="num_items")
         TrackFuzzedParameterNames : bool
+
+        // The maximum depth for Json properties in the schema to test
+        // Any properties exceeding this depth are removed.
+        JsonPropertyMaxDepth : int option
     }
 
 let convertToAbsPath (currentDirPath:string) (filePath:string) =
@@ -242,6 +246,7 @@ let SampleConfig =
         DataFuzzing = true
         ApiNamingConvention = None
         TrackFuzzedParameterNames = false
+        JsonPropertyMaxDepth = None
     }
 
 /// The default config used for unit tests.  Most of these should also be the defaults for
@@ -275,4 +280,5 @@ let DefaultConfig =
         DataFuzzing = false
         ApiNamingConvention = None
         TrackFuzzedParameterNames = false
+        JsonPropertyMaxDepth = None
     }


### PR DESCRIPTION
In some cases, the schema in the specification is very large, causing
out of memory when generating grammar.json (and, the RESTler engine
has not been tested with such large schemas).

Allow users to limit the depth of properties when compiling the spec to
reduce the schema size.