### PR TITLE
Support openapi3.0 requestBody

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -134,6 +134,10 @@
     <Content Include="swagger\schemaTests\large_json_body.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\schemaTests\openapi3_requestbody.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+
     <Content Include="swagger\schemaTests\xMsPaths_annotations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/SchemaTests.fs
+++ b/src/compiler/Restler.Compiler.Test/SchemaTests.fs
@@ -85,6 +85,24 @@ module ApiSpecSchema =
             Assert.True(grammar.Contains("restler_custom_payload_uuid4_suffix(\"customerId\")"))
 
         [<Fact>]
+        let ``openapi3 requestBody`` () =
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\openapi3_requestbody.json")
+            let config = { Restler.Config.SampleConfig with
+                                IncludeOptionalParameters = true
+                                GrammarOutputDirectoryPath = Some ctx.testRootDirPath
+                                ResolveBodyDependencies = true
+                                ResolveQueryDependencies = true
+                                SwaggerSpecFilePath = Some [specFilePath]
+                            }
+            Restler.Workflow.generateRestlerGrammar None config
+            let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
+            let grammar = File.ReadAllText(grammarOutputFilePath)
+            Assert.True(grammar.Contains("\"treeId\":"))
+            Assert.True(grammar.Contains("\"beachId\":"))
+            Assert.True(grammar.Contains("_bananas_post_results_id.reader()"))
+
+
+        [<Fact>]
         let ``json depth limit test`` () =
             let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\large_json_body.json")
             let config = { Restler.Config.SampleConfig with

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/openapi3_requestbody.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/openapi3_requestbody.json
@@ -1,0 +1,389 @@
+{
+  "openapi" : "3.0.0",
+  "servers" : [ {
+    "url" : "http://localhost:4000/"
+  } ],
+  "security" : [ {
+    "bearerAuth" : [ ]
+  } ],
+  "paths" : {
+    "/bananas" : {
+      "get" : {
+        "operationId" : "listbananas",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "createdAtMin",
+          "schema" : {
+            "example" : "2021-06-30T18:54:00.089Z",
+            "format" : "date-time",
+            "type" : "string"
+          }
+        }, {
+          "in" : "query",
+          "name" : "createdAtMax",
+          "schema" : {
+            "example" : "2021-06-30T18:54:00.089Z",
+            "format" : "date-time",
+            "type" : "string"
+          }
+        }, {
+          "description" : "which page",
+          "in" : "query",
+          "name" : "page",
+          "required" : false,
+          "schema" : {
+            "example" : 100,
+            "minimum" : 1,
+            "type" : "integer"
+          }
+        }, {
+          "description" : "how many results in one page",
+          "in" : "query",
+          "name" : "pageLength",
+          "required" : false,
+          "schema" : {
+            "minimum" : 1,
+            "type" : "integer"
+          }
+        }, {
+          "description" : "how many results are in the database",
+          "in" : "query",
+          "name" : "includeTotalCount",
+          "required" : false,
+          "schema" : {
+            "default" : true,
+            "type" : "boolean"
+          }
+        }, {
+          "description" : "field to sort by",
+          "in" : "query",
+          "name" : "sortBy",
+          "schema" : {
+            "example" : "createdAt",
+            "type" : "string"
+          }
+        }, {
+          "in" : "query",
+          "name" : "ids",
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "in" : "query",
+          "name" : "treeIds",
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "in" : "query",
+          "name" : "ownerIds",
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "in" : "query",
+          "name" : "beachIds",
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/inline_response_200"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "5XX" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/inline_response_5XX"
+                }
+              }
+            },
+            "description" : "Unhandled server exception"
+          }
+        },
+        "summary" : "Lists banana",
+        "tags" : [ "banana" ]
+      },
+      "post" : {
+        "operationId" : "createbanana",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/bananaCreate"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/inline_response_201"
+                }
+              }
+            },
+            "description" : "Created"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/inline_response_400"
+                }
+              }
+            },
+            "description" : "Invalid request"
+          },
+          "5XX" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/inline_response_5XX"
+                }
+              }
+            },
+            "description" : "Unhandled server exception"
+          }
+        },
+        "summary" : "Create a banana",
+        "tags" : [ "banana" ]
+      }
+    },
+    "/bananas/{id}" : {
+      "delete" : {
+        "operationId" : "deletebanana",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/inline_response_201"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "404" : {
+            "description" : "Not found"
+          },
+          "5XX" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/inline_response_5XX"
+                }
+              }
+            },
+            "description" : "Unhandled server exception"
+          }
+        },
+        "summary" : "Delete a banana",
+        "tags" : [ "banana" ]
+      },
+      "get" : {
+        "operationId" : "getbanana",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/inline_response_201"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "404" : {
+            "description" : "Not found"
+          },
+          "5XX" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/inline_response_5XX"
+                }
+              }
+            },
+            "description" : "Unhandled server exception"
+          }
+        },
+        "tags" : [ "banana" ]
+      }
+    }
+  },
+  "components" : {
+    "requestBodies" : {
+      "createbanana" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/bananaCreate"
+            }
+          }
+        },
+        "required" : true
+      }
+    },
+    "schemas" : {
+      "paging" : {
+        "properties" : {
+          "page" : {
+            "format" : "integer",
+            "readOnly" : true,
+            "type" : "number"
+          },
+          "pageLength" : {
+            "format" : "integer",
+            "readOnly" : true,
+            "type" : "number"
+          },
+          "totalCount" : {
+            "format" : "integer",
+            "readOnly" : true,
+            "type" : "number"
+          }
+        },
+        "type" : "object"
+      },
+      "banana" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/bananaReadOnlyProperties"
+        }, {
+          "$ref" : "#/components/schemas/postOnlyProperties"
+        } ]
+      },
+      "bananaReadOnlyProperties" : {
+        "properties" : {
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "createdAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "snazzyId" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "postOnlyProperties" : {
+        "properties" : {
+          "treeId" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "beachId" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "bananaCreate" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/postOnlyProperties"
+        } ],
+        "required" : [ "treeId", "beachId" ],
+        "type" : "object"
+      },
+      "inline_response_200" : {
+        "properties" : {
+          "paging" : {
+            "$ref" : "#/components/schemas/paging"
+          },
+          "results" : {
+            "items" : {
+              "$ref" : "#/components/schemas/banana"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "inline_response_5XX" : {
+        "properties" : {
+          "message" : {
+            "example" : "An unhandled exception has occured. Ref #abc429df",
+            "type" : "string"
+          }
+        },
+        "required" : [ "message" ],
+        "type" : "object"
+      },
+      "inline_response_201" : {
+        "properties" : {
+          "results" : {
+            "$ref" : "#/components/schemas/banana"
+          }
+        },
+        "type" : "object"
+      },
+      "inline_response_400_issues" : {
+        "properties" : {
+          "errors" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "inline_response_400" : {
+        "properties" : {
+          "issues" : {
+            "$ref" : "#/components/schemas/inline_response_400_issues"
+          }
+        },
+        "required" : [ "issues" ],
+        "type" : "object"
+      }
+    },
+    "securitySchemes" : {
+      "bearerAuth" : {
+        "bearerFormat" : "JWT",
+        "scheme" : "bearer",
+        "type" : "http"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- passes all existing tests
- TODO: new unit test
- Does not fix issue #421 schema - content type and schema must be moved into the 'requestBody', as follows:
```json
        "requestBody" : {
          "content" : {
            "application/json" : {
              "schema" : {
                "$ref" : "#/components/schemas/bananaCreate"
              }
            }
          }

```