### PR TITLE
Bug fix: the payloadbody checker should not modify auth-tokens

### DIFF
--- a/restler/checkers/payload_body_checker.py
+++ b/restler/checkers/payload_body_checker.py
@@ -65,6 +65,7 @@ class PayloadBodyChecker(CheckerBase):
         self._size_dep_budget = True
         self._setup_done = False
         self._use_feedback = True
+        self._skip_uuid_substitution = False
         self._current_task_tag = ''
         self._fuzzed_requests = set()
         self._buckets = PayloadBodyBuckets()
@@ -83,6 +84,7 @@ class PayloadBodyChecker(CheckerBase):
         self._start_with_examples = set_var(self._start_with_examples, 'start_with_examples')
         self._size_dep_budget = set_var(self._size_dep_budget, 'size_dep_budget')
         self._use_feedback = set_var(self._use_feedback, 'use_feedback')
+        self._skip_uuid_substitution = set_var(self._skip_uuid_substitution, 'skip_uuid_substitution')
         self._fixed_budget_max_combination = set_var(self._fixed_budget_max_combination, 'fixed_budget_max_combination')
         self._fixed_budget_pipeline_width = set_var(self._fixed_budget_pipeline_width, 'fixed_budget_pipeline_width')
         self._recipe_file = Settings().get_checker_arg(
@@ -116,6 +118,7 @@ class PayloadBodyChecker(CheckerBase):
             self._log(f'start with examples {self._start_with_examples}')
             self._log(f'size dep budget {self._size_dep_budget}')
             self._log(f'use feedback {self._use_feedback}')
+            self._log(f'skip_uuid_substitution {self._skip_uuid_substitution}')
             self._log(f'recipe {self._recipe_file}')
 
             # finish one-time setup
@@ -1135,41 +1138,59 @@ class PayloadBodyChecker(CheckerBase):
             # render the data
             rendered_data = seq.resolve_dependencies(rendered_data)
 
-            # substitute if there is UUID suffix
-            original_rendered_data = rendered_data
-            uuid4_suffix_dict = self._get_custom_payload_uuid4_suffix()
-            # Bug: tries all the uuid suffixes in the dictionary
-            #  even though this payload may not contain most of them
-            for uuid4_suffix in uuid4_suffix_dict:
-                suffix = uuid4_suffix_dict[uuid4_suffix]
-                len_suffix = len(suffix)
-                # need the query to partition path and body
+            if not self._skip_uuid_substitution:
+                # substitute if there is UUID suffix
+                original_rendered_data = rendered_data
+                uuid4_suffix_dict = self._get_custom_payload_uuid4_suffix()
                 try:
+                    # need the query to partition path and body;
+                    # everything before '?' is treated as the path
                     partition = rendered_data.index('?')
-                    # If the suffix is present in the path
-                    # Bug: the code below assumes the path ends with the suffix
-                    # and the suffix is unique, i.e. does not occur in the path.
-                    # this cannot be assumed, since the user can make the suffix any value
-                    if suffix in rendered_data[:partition]:
-                        new_val_start = rendered_data[:partition].index(suffix)
-                        if new_val_start + len_suffix + 10 > partition:
-                            self._log('unexpected uuid')
-                            continue
-                        new_val = rendered_data[new_val_start:new_val_start + len_suffix + 10]
 
-                        # find all occurence in the body
-                        suffix_in_body = [
-                            # Bug: Finds all occurrences of *the value text string* of suffix in the
-                            # payload and does replacement
-                            # Instead, should search in the grammar for the 'restler_custom_payload_uuid_suffix' and
-                            # replace with new rendered value
-                            # For example, if "name" appears in a token, this will replace it.
-                            m.start() for m in re.finditer(suffix, rendered_data)
-                        ][1:]
-                        for si in suffix_in_body:
-                            old_val = rendered_data[si: si + len_suffix + 10]
-                            rendered_data = rendered_data.replace(
-                                old_val, new_val)
+                    # If an auth-token is used, it should NEVER be modified;
+                    # hence, compute the start_body position after the token
+                    start_body = partition + 1
+                    partition2 = rendered_data.find('Authorization: Bearer')
+                    if partition2 != -1:
+                        # search for '\r\n' at the end of the token
+                        partition3 = rendered_data[partition2:].index('\r\n')
+                        start_body = partition2 + partition3 + 6
+
+                    # Bug: tries all the uuid suffixes in the dictionary
+                    # even though this payload may not contain most of them
+                    for uuid4_suffix in uuid4_suffix_dict:
+                        suffix = uuid4_suffix_dict[uuid4_suffix]
+                        len_suffix = len(suffix)
+
+                        # If the suffix is present in the path
+                        # Bug: the code below assumes the path ends with the suffix
+                        # and the suffix is unique, i.e. does not occur twice in the path;
+                        # this cannot be assumed, since the user can make the suffix any value
+                        if suffix in rendered_data[:partition]:
+                            new_val_start = rendered_data[:partition].index(suffix)
+                            if new_val_start + len_suffix + 10 > partition:
+                                self._log('unexpected uuid')
+                                continue
+                            new_val = rendered_data[new_val_start:new_val_start + len_suffix + 10]
+
+                            new_body = rendered_data[start_body:]
+                            # find all occurence in the body
+                            suffix_in_body = [
+                                # Bug: Finds all occurrences of *the value text string* of suffix in the
+                                # payload and does replacement
+                                # Instead, should search in the grammar for the 'restler_custom_payload_uuid_suffix' and
+                                # replace with new rendered value
+                                # Note: the replacement done below can be incorrect in 2 ways in an example like this:
+                                #   Ex: "name":"Standard" will be replaced by "nameaa1e45cbb5d"
+                                # 1. the right-hand-side should be replaced, not the left-hand-side in a case like this
+                                # 2. the length of old_val should be the length of suffix, not the length of new_val
+                                m.start() for m in re.finditer(suffix, new_body)
+                            ]
+                            for si in suffix_in_body:
+                                old_val = new_body[si: si + len_suffix + 10]
+                                new_body = new_body.replace(old_val, new_val)
+                            # replace the old body with the new_body
+                            rendered_data = rendered_data[:start_body] + new_body
                 except Exception:
                     rendered_data = original_rendered_data
 


### PR DESCRIPTION
Closes #324 

This PR fixes a bug in the payloadbody checker: it should not modify auth-tokens when substituting uuid-suffixes in the body of a request. (The bug was: auth-tokens were erroneously included in the 'body' part of a request.)

This PR also includes a new option skip_uuid_substitution to skip this part of the payloadbody checker. This new option can be turned on by adding the following in the engine settings.json file:

```
"checkers": {
    "payloadbody": {
        "skip_uuid_substitution" : true
    }
  },
```

Indeed, the uuid_substitution code should be rewritten - a new issue #429 was opened to track this work-item.

Testing: manually with a RESTler job where the payloadbody checker erroneously modified auth-tokens, resulting in tokens being printed in the network.testing logs and REST API requests returning "401 unauthorized" errors.