### PR TITLE
Make 'isRequired' in grammar.json match the spec

### DIFF
--- a/docs/user-guide/CompilerConfig.md
+++ b/docs/user-guide/CompilerConfig.md
@@ -140,3 +140,5 @@ parameter being fuzzed.  These will be used to capture fuzzed parameters in ```t
 
 * *JsonPropertyMaxDepth* is the maximum depth for Json properties in the schema to test.
 Any properties exceeding this depth are removed.  There is no maximum by default.
+
+* *IncludeOptionalParameters* True by default.  When false, RESTler will only pass required parameters when trying to successfully exercise each request.  The full schema including optional parameters is always included in the json grammar, so optional parameters will still be fuzzed by the payload body checker and available to test with ```test_combinations_settings``` when this option is set to false.

--- a/src/compiler/Restler.Compiler.Test/JsonGrammarTests.fs
+++ b/src/compiler/Restler.Compiler.Test/JsonGrammarTests.fs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Restler.Test
+open System
+open System.IO
+open Xunit
+open SwaggerSpecs
+open Utilities
+
+[<Trait("TestCategory", "GrammarJson")>]
+module GrammarTests =
+    type JsonGrammarTests(ctx:Fixtures.TestSetupAndCleanup, output:Xunit.Abstractions.ITestOutputHelper) =
+
+        /// For a simple API with required and optional parameters,
+        /// check that grammar.json matches what was declared in the specification
+        /// Also, check that the grammar.py does not change when a parameter changes from
+        /// optional to required (note: this will change in the future).
+        [<Fact>]
+        let ``required and optional properties correctly set`` () =
+            let grammarOutputDirectoryPath = ctx.testRootDirPath
+            let config = { Restler.Config.SampleConfig with
+                             GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
+                             ResolveBodyDependencies = false
+                             UseBodyExamples = Some true
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\grammarTests\required_params.json"))]
+                         }
+
+            // Confirm the baselines match for grammar.json and grammar.py
+            for includeOptionalParameters in [true ; false] do
+                Restler.Workflow.generateRestlerGrammar None { config with IncludeOptionalParameters = includeOptionalParameters }
+
+                for extension in [".json"; ".py"] do
+                    let actualGrammarFileName =
+                        Path.GetFileNameWithoutExtension(Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
+                    let expectedGrammarFileName =
+                        if extension = ".json" || includeOptionalParameters then "required_params_grammar"
+                        else "required_params_grammar_requiredonly"
+                    let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
+                                                               sprintf @"baselines\grammarTests\%s%s" expectedGrammarFileName extension)
+                    let actualGrammarFilePath = Path.Combine(grammarOutputDirectoryPath,
+                                                             actualGrammarFileName + extension)
+                    let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
+                    let message = sprintf "Python grammar Does not match baseline.  First difference: %A" grammarDiff
+                    Assert.True(grammarDiff.IsNone, message)
+
+
+
+
+        interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="ExampleTests.fs" />
     <Compile Include="ReferencesTests.fs" />
     <Compile Include="SchemaTests.fs" />
+    <Compile Include="JsonGrammarTests.fs" />
     <Compile Include="RealWorldTests.fs" />
     <Content Include="packages.lock.json" />
     <Content Include="swagger\example_config_file.json">
@@ -27,6 +28,15 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="baselines\schemaTests\xMsPaths_grammar.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="baselines\grammarTests\required_params_grammar.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="baselines\grammarTests\required_params_grammar.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="baselines\grammarTests\required_params_grammar_requiredOnly.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="baselines\dictionaryTests\quoted_primitives_grammar.py">
@@ -123,6 +133,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\schemaTests\xMsPaths.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\grammarTests\required_params.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\schemaTests\global_path_parameters.json">

--- a/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.json
@@ -1,0 +1,378 @@
+{
+  "Requests": [
+    {
+      "id": {
+        "endpoint": "/customers",
+        "method": "Put"
+      },
+      "method": "Put",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "api"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "customers"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "put_body",
+                "payload": {
+                  "InternalNode": [
+                    {
+                      "name": "",
+                      "propertyType": "Object",
+                      "isRequired": true,
+                      "isReadOnly": false
+                    },
+                    [
+                      {
+                        "LeafNode": {
+                          "name": "name",
+                          "payload": {
+                            "Fuzzable": [
+                              "String",
+                              "fuzzstring",
+                              null,
+                              null
+                            ]
+                          },
+                          "isRequired": false,
+                          "isReadOnly": false
+                        }
+                      },
+                      {
+                        "LeafNode": {
+                          "name": "tags",
+                          "payload": {
+                            "Fuzzable": [
+                              "Object",
+                              "{ \"fuzz\": false }",
+                              null,
+                              null
+                            ]
+                          },
+                          "isRequired": false,
+                          "isReadOnly": false
+                        }
+                      }
+                    ]
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": [
+              {
+                "name": "Content-Type",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Constant": [
+                        "String",
+                        "application/json"
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          "localhost:8888"
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/customers",
+        "method": "Post"
+      },
+      "method": "Post",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "api"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "customers"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "array_query_param",
+                "payload": {
+                  "InternalNode": [
+                    {
+                      "name": "",
+                      "propertyType": "Array",
+                      "isRequired": false,
+                      "isReadOnly": false
+                    },
+                    [
+                      {
+                        "LeafNode": {
+                          "name": "",
+                          "payload": {
+                            "Fuzzable": [
+                              "String",
+                              "fuzzstring",
+                              null,
+                              null
+                            ]
+                          },
+                          "isRequired": false,
+                          "isReadOnly": false
+                        }
+                      }
+                    ]
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "body",
+                "payload": {
+                  "InternalNode": [
+                    {
+                      "name": "",
+                      "propertyType": "Object",
+                      "isRequired": true,
+                      "isReadOnly": false
+                    },
+                    [
+                      {
+                        "LeafNode": {
+                          "name": "name",
+                          "payload": {
+                            "Fuzzable": [
+                              "String",
+                              "fuzzstring",
+                              null,
+                              null
+                            ]
+                          },
+                          "isRequired": true,
+                          "isReadOnly": false
+                        }
+                      },
+                      {
+                        "LeafNode": {
+                          "name": "tags",
+                          "payload": {
+                            "Fuzzable": [
+                              "Object",
+                              "{ \"fuzz\": false }",
+                              null,
+                              null
+                            ]
+                          },
+                          "isRequired": false,
+                          "isReadOnly": false
+                        }
+                      },
+                      {
+                        "InternalNode": [
+                          {
+                            "name": "example_array",
+                            "propertyType": "Array",
+                            "isRequired": true,
+                            "isReadOnly": false
+                          },
+                          [
+                            {
+                              "InternalNode": [
+                                {
+                                  "name": "",
+                                  "propertyType": "Object",
+                                  "isRequired": true,
+                                  "isReadOnly": false
+                                },
+                                [
+                                  {
+                                    "LeafNode": {
+                                      "name": "name",
+                                      "payload": {
+                                        "Fuzzable": [
+                                          "String",
+                                          "fuzzstring",
+                                          null,
+                                          null
+                                        ]
+                                      },
+                                      "isRequired": false,
+                                      "isReadOnly": false
+                                    }
+                                  },
+                                  {
+                                    "LeafNode": {
+                                      "name": "id",
+                                      "payload": {
+                                        "Fuzzable": [
+                                          "Number",
+                                          "1.23",
+                                          null,
+                                          null
+                                        ]
+                                      },
+                                      "isRequired": true,
+                                      "isReadOnly": false
+                                    }
+                                  }
+                                ]
+                              ]
+                            }
+                          ]
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "array_header_param",
+                "payload": {
+                  "InternalNode": [
+                    {
+                      "name": "",
+                      "propertyType": "Array",
+                      "isRequired": false,
+                      "isReadOnly": false
+                    },
+                    [
+                      {
+                        "LeafNode": {
+                          "name": "",
+                          "payload": {
+                            "Fuzzable": [
+                              "String",
+                              "fuzzstring",
+                              null,
+                              null
+                            ]
+                          },
+                          "isRequired": false,
+                          "isReadOnly": false
+                        }
+                      }
+                    ]
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": [
+              {
+                "name": "Content-Type",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Constant": [
+                        "String",
+                        "application/json"
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          "localhost:8888"
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    }
+  ]
+}

--- a/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.py
@@ -1,0 +1,84 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+req_collection = requests.RequestCollection([])
+# Endpoint: /customers, method: Put
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("customers"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/customers"
+)
+req_collection.add_request(request)
+
+# Endpoint: /customers, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("customers"),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("array_query_param="),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("array_header_param: "),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "example_array":
+    [
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "id":"""),
+    primitives.restler_fuzzable_number("1.23"),
+    primitives.restler_static_string("""
+        }
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/customers"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar_requiredonly.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar_requiredonly.py
@@ -1,0 +1,67 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+req_collection = requests.RequestCollection([])
+# Endpoint: /customers, method: Put
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("customers"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/customers"
+)
+req_collection.add_request(request)
+
+# Endpoint: /customers, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("customers"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "example_array":
+    [
+        {,
+            "id":"""),
+    primitives.restler_fuzzable_number("1.23"),
+    primitives.restler_static_string("""
+        }
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/customers"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/swagger/grammarTests/required_params.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/grammarTests/required_params.json
@@ -1,0 +1,119 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "host": "localhost:8888",
+  "info": {
+    "description": "A simple swagger spec that uses required and optional parameters",
+    "title": "Parameters example spec",
+    "version": "1.0"
+  },
+  "definitions": {
+    "ExampleObject": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "id": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "ExampleBody": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object"
+        },
+        "example_array": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExampleObject"
+          }
+        }
+      },
+      "required": [
+        "example_array",
+        "name"
+      ]
+    },
+    "ExampleBody2": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object"
+        }
+      }
+    }
+  },
+  "paths": {
+    "/customers": {
+      "put": {
+        "parameters": [
+          {
+            "name": "put_body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/ExampleBody2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Server not found."
+          }
+        }
+      },
+        "post": {
+          "parameters": [
+            {
+              "in": "header",
+              "name": "array_header_param",
+              "required": false,
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "in": "query",
+              "name": "array_query_param",
+              "required": false,
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "body",
+              "in": "body",
+              "schema": {
+                "$ref": "#/definitions/ExampleBody"
+              }
+            }
+          ],
+          "examples": {},
+          "responses": {
+            "200": {
+              "description": "Success"
+            },
+            "404": {
+              "description": "Server not found."
+            }
+          }
+        }
+      }
+    },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -306,8 +306,8 @@ module private Parameters =
                                     Some { name = declaredParameter.Name
                                            payload = LeafNode { LeafProperty.name = ""
                                                                 payload = payload
-                                                                isReadOnly = false
-                                                                isRequired = true }
+                                                                isReadOnly = (parameterIsReadOnly declaredParameter)
+                                                                isRequired = declaredParameter.IsRequired }
                                            serialization = None }
                                 else
                                     let parameterGrammarElement =
@@ -601,6 +601,7 @@ module private Parameters =
             openApiParameter.Name <- bodyName
             openApiParameter.Schema <- bodySchema.Value
             openApiParameter.Kind <- OpenApiParameterKind.Body
+            openApiParameter.IsRequired <- true
             getParameters (openApiParameter |> stn) exampleConfig dataFuzzing trackParameters jsonPropertyMaxDepth
         else
             // No body

--- a/src/compiler/Restler.Compiler/SwaggerVisitors.fs
+++ b/src/compiler/Restler.Compiler/SwaggerVisitors.fs
@@ -410,7 +410,7 @@ module SwaggerVisitors =
                     let innerProperty = { InnerProperty.name = propertyName
                                           payload = None
                                           propertyType = Property
-                                          isRequired = true
+                                          isRequired = property.IsRequired
                                           isReadOnly = (propertyIsReadOnly property) }
                     InternalNode (innerProperty, stn tree)
                     |> cont
@@ -419,7 +419,7 @@ module SwaggerVisitors =
                 let innerArrayProperty =
                     {   InnerProperty.name = propertyName
                         payload = None; propertyType = Array
-                        isRequired = true
+                        isRequired = property.IsRequired
                         isReadOnly = (propertyIsReadOnly property) }
 
                 let arrayWithElements =
@@ -459,7 +459,7 @@ module SwaggerVisitors =
                             let innerProperty = { InnerProperty.name = propertyName
                                                   payload = None
                                                   propertyType = Property // indicates presence of nested properties
-                                                  isRequired = true
+                                                  isRequired = property.IsRequired
                                                   isReadOnly = (propertyIsReadOnly property) }
                             InternalNode (innerProperty, stn tree)
                             |> cont
@@ -557,8 +557,8 @@ module SwaggerVisitors =
                         {
                             LeafProperty.name = ""
                             payload = payload.Value
-                            isRequired = true
-                            isReadOnly = false }
+                            isRequired = isRequired
+                            isReadOnly = isReadOnly }
 
                     LeafNode leafProperty
             if foundCycle then
@@ -740,8 +740,8 @@ module SwaggerVisitors =
                         let grammarElement =
                             LeafNode ({ LeafProperty.name = ""
                                         payload = leafPayload
-                                        isRequired = true
-                                        isReadOnly = false })
+                                        isRequired = isRequired
+                                        isReadOnly = isReadOnly })
 
                         schemaCache.add schema parents grammarElement exampleValue.IsSome
                         grammarElement |> cont
@@ -757,8 +757,8 @@ module SwaggerVisitors =
                             let innerProperty = { InnerProperty.name = ""
                                                   payload = None
                                                   propertyType = propertyType
-                                                  isRequired = true
-                                                  isReadOnly = false }
+                                                  isRequired = isRequired
+                                                  isReadOnly = isReadOnly }
                             InternalNode (innerProperty, Seq.empty)
                         schemaCache.add schema parents grammarElement exampleValue.IsSome
                         grammarElement |> cont
@@ -767,8 +767,8 @@ module SwaggerVisitors =
                     let innerProperty = { InnerProperty.name = ""
                                           payload = None
                                           propertyType = if schema.IsArray then Array else Object
-                                          isRequired = true
-                                          isReadOnly = false }
+                                          isRequired = isRequired
+                                          isReadOnly = isReadOnly }
                     // At the time this schema is added to the cache, the internalNodes above have not been traversed.
                     // Make sure they have been traversed first, for cycle detection.
                     let internalNodes = internalNodes |> Seq.toList


### PR DESCRIPTION
Prior to this change, the 'isRequired' flag was always set to 'true' for internal nodes
(arrays and objects with properties).  With the upcoming change to test
combinations of nested parameters, make these match the spec in grammar.json.

Note: there are no changes to grammar.py as part of this change - it should
still include all parameters.

Added baseline test for grammar.json and grammar.py.