### PR TITLE
Fix example value quoting issue when 'exactCopy' is true

### DIFF
--- a/docs/user-guide/CompilerConfig.md
+++ b/docs/user-guide/CompilerConfig.md
@@ -98,10 +98,7 @@ The currently supported settings are:
 ```
 
 - ```filePath``` is the path to the file containing metadata about example parameter payloads
-- ```exactCopy``` specifies whether the example values should be merged with the schema and dictionary
-(for example, this will discard parameters that are not present in the spec), or
-used exactly as specified (for example, this will not substitute any values from the dictionary).
-```exactCopy``` is ```false``` by default.
+- ```exactCopy``` specifies whether the example values should be merged with the schema and dictionary.  ```exactCopy``` is ```false``` by default.  When set to ```true```, constants from the example will be taken and override any other possible value (for example, custom payloads from the dictionary will not be used).  Note: parameters that are not in the specification but appear in the example are ignored.
 
 * *UseAllExamplePayloads* When set to ```true```, all available example payloads are used (currently, both
 the ones referenced in the specification and the ones

--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -477,4 +477,35 @@ module Examples =
 
             Assert.True(grammar.Contains("primitives.restler_fuzzable_number(\"1.23\", examples=[\"1.67\"]),"))
 
+        /// Test that 'exactCopy' does not add extra quotes
+        [<Fact>]
+        let ``exactCopy values are correct`` () =
+            let grammarOutputDirectoryPath = ctx.testRootDirPath
+            let config = { Restler.Config.SampleConfig with
+                             IncludeOptionalParameters = true
+                             GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
+                             ResolveBodyDependencies = false
+                             UseBodyExamples = Some true
+                             UseQueryExamples = Some true
+                             DataFuzzing = true
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\exactCopy\array_example.json"))]
+                         }
+
+            let exampleConfigFile = {
+                filePath = Path.Combine(Environment.CurrentDirectory, @"swagger\exactCopy\examples.json")
+                exactCopy = true
+            }
+
+            let testConfig = { config with ExampleConfigFiles = Some [ {exampleConfigFile with exactCopy = false }] }
+            Restler.Workflow.generateRestlerGrammar None testConfig
+
+            let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
+            let grammar = File.ReadAllText(grammarFilePath)
+            Assert.True(grammar.Contains("primitives.restler_static_string(\"2020-02-02\"),"))
+            /// Also test to make sure that 'exactCopy : true' filters out the parameters that are not declared in the spec
+            Assert.False(grammar.Contains("ddd"))
+
+
+
+
         interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -21,6 +21,16 @@
     <Content Include="swagger\example_config_file.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\exactCopy\array_example.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\exactCopy\examples.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="swagger\exactCopy\make_order_post.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+
     <Content Include="baselines\dependencyTests\path_annotation_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/swagger/exactCopy/array_example.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/exactCopy/array_example.json
@@ -1,0 +1,165 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "host": "localhost:8888",
+  "info": {
+    "description": "A simple swagger spec that uses examples",
+    "title": "Parameter examples",
+    "version": "1.0"
+  },
+  "definitions": {
+    "Order": {
+        "properties": {
+            "id": {
+                "description": "The unique identifier of an order",
+                "type": "integer"
+            },
+            "eta": {
+                "description": "The date the order will be ready",
+                "type": "string"
+            },
+          "status": {
+            "description": "The order status",
+            "type": "string"
+          },
+          "order_items": {
+            "type": "array",
+            "items": {
+              "type":  "string"
+            }
+          }
+        }
+    },
+    "GroceryList": {
+      "properties": {
+        "storeId": {
+          "description": "The unique identifier of the store",
+          "type": "integer"
+        },
+        "rush": {
+          "description": "Is it a rush order",
+          "type": "boolean"
+        },
+        "bagType": {
+          "description": "The type of bags to use",
+          "type": "string"
+        },
+        "item_descriptions": {
+          "description": "The type of bags to use",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "item_feedback": {
+          "description": "The type of bags to use",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "useDoubleBags": {
+          "description": "Whether to use double bags",
+          "type": "boolean"
+        },
+        "bannedBrands": {
+          "description": "do not use these brands",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GroceryListItem": {
+        "properties": {
+            "name": {
+                "description": "The name of the item",
+                "type": "string"
+            },
+            "code": {
+                "description": "The code of the item",
+                "type": "integer"
+            },
+            "storeId": {
+                "description": "The unique identifier of the store",
+                "type": "integer"
+            },
+            "expirationMaxDate": {
+                "description": "The maximum date that this item should expire",
+                "type": "string"
+            }
+        }
+    }
+},
+
+  "paths": {
+    "/stores/{storeId}/order": {
+      "post": {
+        "operationId": "make_an_order",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "in": "query",
+            "name": "api-version",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "expiration",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "in": "query",
+            "name": "arrayQueryParameter",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "in": "query",
+            "name": "arrayQueryParameter2",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orderDetails",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GroceryList"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "404": {
+            "description": "Store not found."
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/exactCopy/examples.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/exactCopy/examples.json
@@ -1,0 +1,9 @@
+{
+    "paths": {
+        "/stores/{storeId}/order": {
+            "post": {
+                "0": ".\\make_order_post.json"
+            }
+        }
+    }
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/exactCopy/make_order_post.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/exactCopy/make_order_post.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "storeId": "23456",
+    "arrayQueryParameter": [],
+    "arrayQueryParameter2": [ "a", "b", "c" ],
+    "arrayQueryParameter3": [ "ddd", "eee", "fff" ],
+    "api-version": "2020-02-02",
+    "expiration": 10,
+    "orderDetails": {
+      "storeId": "98765",
+      "rush": "True",
+      "bagType": "paperplain",
+      "item_descriptions": [
+      ],
+      "item_feedback": [
+        "great",
+        "awesome"
+      ]
+    }
+  },
+  "responses": {
+  }
+}

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -301,7 +301,8 @@ module private Parameters =
                                                 PrimitiveType.Object
                                             | _ ->
                                                 PrimitiveType.String
-                                        Constant (primitiveType, payloadValue.ToString(Newtonsoft.Json.Formatting.None))
+                                        let formattedPayloadValue = GenerateGrammarElements.formatJTokenProperty primitiveType payloadValue
+                                        Constant (primitiveType, formattedPayloadValue)
 
                                     Some { name = declaredParameter.Name
                                            payload = LeafNode { LeafProperty.name = ""
@@ -324,37 +325,7 @@ module private Parameters =
                 )
             |> Seq.toList
 
-        let exampleParametersNotFromSpec =
-            if examplePayload.exactCopy then
-                examplePayload.parameterExamples
-                |> List.filter (fun exampleParameter ->
-                                    exampleParameter.parameterName <> bodyName &&
-                                    parameterList |> Seq.tryFind (fun dp -> dp.Name = exampleParameter.parameterName) = None)
-                |> List.map (fun p ->
-
-                                    printfn "Warning: example parameter not found in spec: %s" p.parameterName
-                                    let payload =
-                                        match p.payload with
-                                        | PayloadFormat.JToken payloadValue ->
-                                            let primitiveType =
-                                                match payloadValue.Type with
-                                                | JTokenType.Array
-                                                | JTokenType.Object ->
-                                                    PrimitiveType.Object
-                                                | _ ->
-                                                    PrimitiveType.String
-                                            Constant (primitiveType, payloadValue.ToString(Newtonsoft.Json.Formatting.None))
-
-                                    { name = p.parameterName
-                                      payload = LeafNode { LeafProperty.name = ""
-                                                           payload = payload
-                                                           isReadOnly = false
-                                                           isRequired = true }
-                                      serialization = None })
-            else
-                // Only use the spec examples
-                []
-        exampleParametersFromSpec @ exampleParametersNotFromSpec
+        exampleParametersFromSpec
 
     // Gets the first example found from the open API parameter:
     // The priority is:


### PR DESCRIPTION
For ```exactCopy': true```, the example value needs to be formatted via the helper function, which handles removing quotes based on type.

Also, when this option is enabled, removed the behavior that adds parameters which are not declared in the spec.  This can only be implemented if the format of the example file is extended to specify the corresponding parameter kind (path,header, body, query).