### PR TITLE
Allow specifying the basepath in the engine settings.

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -102,6 +102,11 @@ Example: `management.web.com`
 
 (Note: do NOT include https:// or slashes here!)
 
+### basepath: string (default None)
+Set to override the basepath that is specified in the grammar.
+
+Example: `/api/v2`
+
 ### include_user_agent: bool (default True)
 Set to false to disable sending user agent with requests
 

--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -568,6 +568,22 @@ class Request(object):
                 pass
         return -1
 
+    def get_basepath_index(self):
+        """ Gets the index of the basepath custom payload line, if it exists in the grammar.
+
+        @return: The index of the basepath parameter or -1 if not found
+        @rtype : Int
+
+        """
+        for i, line in enumerate(self._definition):
+            try:
+                if line[0] == "restler_basepath":
+                    return i
+            except:
+                # ignore line parsing exceptions
+                pass
+        return -1
+
     def update_host(self):
         """ Updates the Host field for every request with the one specified in Settings
 
@@ -585,6 +601,24 @@ class Request(object):
             if header_idx < 0:
                 raise InvalidGrammarException
             self._definition.insert(header_idx, new_host_line)
+
+    def update_basepath(self):
+        """ Updates the basepath custom payload for every request with the one specified in Settings
+
+        @return: None
+        @rtype : None
+
+        """
+        basepath_idx = self.get_basepath_index()
+        if basepath_idx >= 0:
+            basepath = self._definition[basepath_idx][1]
+            if Settings().basepath is not None:
+                basepath = Settings().basepath
+            self._definition[basepath_idx] = primitives.restler_static_string(basepath)
+        else:
+            # No basepath custom payload in the grammar - this is possible for older grammar versions.
+            # Do nothing
+            pass
 
     def header_start_index(self):
         """ Gets the index of the first header line in the definition
@@ -1297,6 +1331,17 @@ class RequestCollection(object):
         """
         for req in self._requests:
             req.update_host()
+
+
+    def update_basepaths(self):
+        """ Updates the basepaths in each request of the grammar file
+
+        @return: None
+        @rtype : None
+
+        """
+        for req in self._requests:
+            req.update_basepath()
 
     def get_host_from_grammar(self):
         """ Gets the hostname from the grammar

--- a/restler/engine/primitives.py
+++ b/restler/engine/primitives.py
@@ -44,6 +44,7 @@ CUSTOM_PAYLOAD_HEADER = "restler_custom_payload_header"
 CUSTOM_PAYLOAD_QUERY = "restler_custom_payload_query"
 CUSTOM_PAYLOAD_UUID4_SUFFIX = "restler_custom_payload_uuid4_suffix"
 REFRESHABLE_AUTHENTICATION_TOKEN = "restler_refreshable_authentication_token"
+BASEPATH = "restler_basepath"
 SHADOW_VALUES = "shadow_values"
 
 # Optional argument passed to grammar function definition functions
@@ -126,6 +127,7 @@ class CandidateValuesPool(object):
             CUSTOM_PAYLOAD_QUERY,
             CUSTOM_PAYLOAD_UUID4_SUFFIX,
             REFRESHABLE_AUTHENTICATION_TOKEN,
+            BASEPATH,
             SHADOW_VALUES
         ]
         self.supported_primitive_dict_types = [
@@ -847,3 +849,25 @@ def restler_refreshable_authentication_token(*args, **kwargs):
     examples = None
     param_name = None
     return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+
+def restler_basepath(*args, **kwargs):
+    """ The basepath.
+
+    @param args: The argument with which the primitive is defined in the block
+                    of the request to which it belongs to. This is a custom
+                    payload which means that the user should have provided its
+                    exact value (to be rendered with).
+    @type  args: Tuple
+    @param kwargs: Optional keyword arguments.
+    @type  kwargs: Dict
+
+    @return: A tuple of the primitive's name and its default value or its tag
+                both passed as arguments via the restler grammar.
+    @rtype : Tuple
+
+    """
+    basepath_value = args[0]
+    quoted = False
+    examples = None
+    param_name = None
+    return sys._getframe().f_code.co_name, basepath_value, quoted, examples, param_name

--- a/restler/restler.py
+++ b/restler/restler.py
@@ -461,6 +461,11 @@ if __name__ == '__main__':
             )
             sys.exit(-1)
 
+    try:
+        req_collection.update_basepaths()
+    except requests.InvalidGrammarException:
+        sys.exit(-1)
+
     # Filter and get the requests to be used for fuzzing
     fuzzing_requests = preprocessing.create_fuzzing_req_collection(args.path_regex)
 

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -399,6 +399,8 @@ class RestlerSettings(object):
         self._grammar_schema = SettingsArg('grammar_schema', str, None, user_args)
         ## Set to override the Host that's specified in the grammar
         self._host = SettingsArg('host', str, None, user_args)
+        ## Set to override the basepath that's specified in the grammar
+        self._basepath = SettingsArg('basepath', str, None, user_args)
         ##  Ignore request dependencies
         self._ignore_dependencies = SettingsArg('ignore_dependencies', bool, False, user_args)
         ## Ignore server-side feedback
@@ -531,6 +533,10 @@ class RestlerSettings(object):
     @property
     def host(self):
         return self._host.val
+
+    @property
+    def basepath(self):
+        return self._basepath.val
 
     @property
     def ignore_dependencies(self):

--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -72,6 +72,7 @@ module CodeGenerator =
 
                     method = OperationMethod.Get
                     path = pathPayload
+                    basePath = ""
                     queryParameters = [(ParameterPayloadSource.Examples, ParameterList [{ name = "page"; payload = q1; serialization = None}
                                                                                         { name = "payload"; payload = q2; serialization = None}])]
                     bodyParameters =  [ParameterPayloadSource.Examples, (ParameterList [{ name = "thebody"; payload = b1; serialization = None}]) ]

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/header_deps_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/header_deps_grammar.py
@@ -31,13 +31,13 @@ def parse_serviceuserpost(data, **kwargs):
 
         try:
             temp_7262 = str(headers["user-id"])
-            
+
         except Exception as error:
             # This is not an error, since some properties are not always returned
             pass
 
         pass
-        
+
     # If no dynamic objects were extracted, throw.
     if not (temp_7262):
         raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
@@ -50,8 +50,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /service/user, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),
@@ -61,7 +60,7 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-    
+
     {
         'post_send':
         {
@@ -81,8 +80,7 @@ req_collection.add_request(request)
 # Endpoint: /service/user, method: Get
 request = requests.Request([
     primitives.restler_static_string("GET "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),
@@ -104,8 +102,7 @@ req_collection.add_request(request)
 # Endpoint: /service/user, method: Put
 request = requests.Request([
     primitives.restler_static_string("PUT "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),
@@ -127,8 +124,7 @@ req_collection.add_request(request)
 # Endpoint: /service/user, method: Delete
 request = requests.Request([
     primitives.restler_static_string("DELETE "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/header_response_writer_annotation_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/header_response_writer_annotation_grammar.py
@@ -31,13 +31,13 @@ def parse_serviceuserpost(data, **kwargs):
 
         try:
             temp_7262 = str(headers["Location"])
-            
+
         except Exception as error:
             # This is not an error, since some properties are not always returned
             pass
 
         pass
-        
+
     # If no dynamic objects were extracted, throw.
     if not (temp_7262):
         raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
@@ -50,8 +50,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /service/user, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),
@@ -61,7 +60,7 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-    
+
     {
         'post_send':
         {
@@ -81,8 +80,7 @@ req_collection.add_request(request)
 # Endpoint: /service/user/{userId}, method: Get
 request = requests.Request([
     primitives.restler_static_string("GET "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),
@@ -103,8 +101,7 @@ req_collection.add_request(request)
 # Endpoint: /service/user/{userId}, method: Put
 request = requests.Request([
     primitives.restler_static_string("PUT "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),
@@ -125,8 +122,7 @@ req_collection.add_request(request)
 # Endpoint: /service/user/{userId}, method: Delete
 request = requests.Request([
     primitives.restler_static_string("DELETE "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/header_response_writer_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/header_response_writer_grammar.py
@@ -31,13 +31,13 @@ def parse_serviceuserpost(data, **kwargs):
 
         try:
             temp_7262 = str(headers["userId"])
-            
+
         except Exception as error:
             # This is not an error, since some properties are not always returned
             pass
 
         pass
-        
+
     # If no dynamic objects were extracted, throw.
     if not (temp_7262):
         raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
@@ -50,8 +50,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /service/user, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),
@@ -61,7 +60,7 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-    
+
     {
         'post_send':
         {
@@ -81,8 +80,7 @@ req_collection.add_request(request)
 # Endpoint: /service/user/{userId}, method: Get
 request = requests.Request([
     primitives.restler_static_string("GET "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),
@@ -103,8 +101,7 @@ req_collection.add_request(request)
 # Endpoint: /service/user/{userId}, method: Put
 request = requests.Request([
     primitives.restler_static_string("PUT "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),
@@ -125,8 +122,7 @@ req_collection.add_request(request)
 # Endpoint: /service/user/{userId}, method: Delete
 request = requests.Request([
     primitives.restler_static_string("DELETE "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("service"),
     primitives.restler_static_string("/"),

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/ordering_test_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/ordering_test_grammar.py
@@ -13,8 +13,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /products, method: Get
 request = requests.Request([
     primitives.restler_static_string("GET "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("products"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
@@ -22,7 +21,7 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-    
+
     {
 
         'pre_send':
@@ -43,8 +42,7 @@ req_collection.add_request(request)
 # Endpoint: /services, method: Get
 request = requests.Request([
     primitives.restler_static_string("GET "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("services"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
@@ -52,12 +50,12 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-    
+
     {
 
         'post_send':
         {
-            
+
             'dependencies':
             [
                 __ordering____services_managementTools.writer()
@@ -74,8 +72,7 @@ req_collection.add_request(request)
 # Endpoint: /managementTools, method: Get
 request = requests.Request([
     primitives.restler_static_string("GET "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("managementTools"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
@@ -83,7 +80,7 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-    
+
     {
 
         'pre_send':
@@ -97,7 +94,7 @@ request = requests.Request([
 
         'post_send':
         {
-            
+
             'dependencies':
             [
                 __ordering____managementTools_products.writer()

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_annotation_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_annotation_grammar.py
@@ -36,7 +36,7 @@ def parse_storespost(data, **kwargs):
 
         try:
             temp_7262 = str(data["delivery"]["metadata"])
-            
+
         except Exception as error:
             # This is not an error, since some properties are not always returned
             pass
@@ -44,7 +44,7 @@ def parse_storespost(data, **kwargs):
 
         try:
             temp_8173 = str(data["id"])
-            
+
         except Exception as error:
             # This is not an error, since some properties are not always returned
             pass
@@ -52,7 +52,7 @@ def parse_storespost(data, **kwargs):
 
         try:
             temp_7680 = str(data["metadata"])
-            
+
         except Exception as error:
             # This is not an error, since some properties are not always returned
             pass
@@ -75,8 +75,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /stores, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("stores"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
@@ -84,7 +83,7 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-    
+
     {
         'post_send':
         {
@@ -106,8 +105,7 @@ req_collection.add_request(request)
 # Endpoint: /stores/{storeId}/order, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("stores"),
     primitives.restler_static_string("/"),

--- a/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_in_dictionary_payload_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dependencyTests/path_in_dictionary_payload_grammar.py
@@ -30,7 +30,7 @@ def parse_storespost(data, **kwargs):
 
         try:
             temp_7262 = str(data["id"])
-            
+
         except Exception as error:
             # This is not an error, since some properties are not always returned
             pass
@@ -49,8 +49,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /stores, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("stores"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
@@ -58,7 +57,7 @@ request = requests.Request([
     primitives.restler_static_string("Host: localhost:8888\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-    
+
     {
         'post_send':
         {
@@ -78,8 +77,7 @@ req_collection.add_request(request)
 # Endpoint: /stores/{storeId}/order, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("stores"),
     primitives.restler_static_string("/"),

--- a/src/compiler/Restler.Compiler.Test/baselines/dictionaryTests/quoted_primitives_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dictionaryTests/quoted_primitives_grammar.py
@@ -49,8 +49,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /stores, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("stores"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
@@ -60,6 +59,7 @@ request = requests.Request([
     primitives.restler_static_string("\r\n"),
     
     {
+
         'post_send':
         {
             'parser': parse_storespost,
@@ -68,6 +68,7 @@ request = requests.Request([
                 _stores_post_id.writer()
             ]
         }
+
     },
 
 ],
@@ -78,8 +79,7 @@ req_collection.add_request(request)
 # Endpoint: /stores/{storeId}, method: Put
 request = requests.Request([
     primitives.restler_static_string("PUT "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("stores"),
     primitives.restler_static_string("/"),
@@ -120,8 +120,7 @@ req_collection.add_request(request)
 # Endpoint: /stores/{storeId}/order, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("stores"),
     primitives.restler_static_string("/"),

--- a/src/compiler/Restler.Compiler.Test/baselines/exampleTests/array_example_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/exampleTests/array_example_grammar.py
@@ -49,8 +49,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /stores, method: Get
 request = requests.Request([
     primitives.restler_static_string("GET "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("stores"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
@@ -67,8 +66,7 @@ req_collection.add_request(request)
 # Endpoint: /stores/{storeId}/order, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("stores"),
     primitives.restler_static_string("/"),
@@ -123,6 +121,7 @@ request = requests.Request([
     primitives.restler_static_string("\r\n"),
     
     {
+
         'post_send':
         {
             'parser': parse_storesstoreIdorderpost,
@@ -131,6 +130,7 @@ request = requests.Request([
                 _stores__storeId__order_post_id.writer()
             ]
         }
+
     },
 
 ],
@@ -141,8 +141,7 @@ req_collection.add_request(request)
 # Endpoint: /stores/{storeId}/order/{orderId}, method: Get
 request = requests.Request([
     primitives.restler_static_string("GET "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("stores"),
     primitives.restler_static_string("/"),

--- a/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.json
@@ -6,13 +6,8 @@
         "method": "Put"
       },
       "method": "Put",
+      "basePath": "/api",
       "path": [
-        {
-          "Constant": [
-            "String",
-            "api"
-          ]
-        },
         {
           "Constant": [
             "String",
@@ -135,13 +130,8 @@
         "method": "Post"
       },
       "method": "Post",
+      "basePath": "/api",
       "path": [
-        {
-          "Constant": [
-            "String",
-            "api"
-          ]
-        },
         {
           "Constant": [
             "String",

--- a/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.py
@@ -9,8 +9,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /customers, method: Put
 request = requests.Request([
     primitives.restler_static_string("PUT "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("customers"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
@@ -39,8 +38,7 @@ req_collection.add_request(request)
 # Endpoint: /customers, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("customers"),
     primitives.restler_static_string("?"),

--- a/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar_requiredonly.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar_requiredonly.py
@@ -9,8 +9,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /customers, method: Put
 request = requests.Request([
     primitives.restler_static_string("PUT "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("customers"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),
@@ -33,8 +32,7 @@ req_collection.add_request(request)
 # Endpoint: /customers, method: Post
 request = requests.Request([
     primitives.restler_static_string("POST "),
-    primitives.restler_static_string("/"),
-    primitives.restler_static_string("api"),
+    primitives.restler_basepath("/api"),
     primitives.restler_static_string("/"),
     primitives.restler_static_string("customers"),
     primitives.restler_static_string(" HTTP/1.1\r\n"),

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.py
@@ -13,6 +13,7 @@ req_collection = requests.RequestCollection([])
 # Endpoint: /{resourceName}?type=folder, method: Put
 request = requests.Request([
     primitives.restler_static_string("PUT "),
+    primitives.restler_basepath(""),
     primitives.restler_static_string("/"),
     primitives.restler_custom_payload_uuid4_suffix("resourceName", writer=__resourceName__type_folder_put_resourceName_path.writer()),
     primitives.restler_static_string("?"),
@@ -25,11 +26,11 @@ request = requests.Request([
     primitives.restler_static_string("\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-    
+
     {
         'post_send':
         {
-            
+
             'dependencies':
             [
                 __resourceName__type_folder_put_resourceName_path.writer()
@@ -45,6 +46,7 @@ req_collection.add_request(request)
 # Endpoint: /{resourceName}?type=file, method: Put
 request = requests.Request([
     primitives.restler_static_string("PUT "),
+    primitives.restler_basepath(""),
     primitives.restler_static_string("/"),
     primitives.restler_custom_payload_uuid4_suffix("resourceName", writer=__resourceName__type_file_put_resourceName_path.writer()),
     primitives.restler_static_string("?"),
@@ -57,11 +59,11 @@ request = requests.Request([
     primitives.restler_static_string("\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-    
+
     {
         'post_send':
         {
-            
+
             'dependencies':
             [
                 __resourceName__type_file_put_resourceName_path.writer()
@@ -77,6 +79,7 @@ req_collection.add_request(request)
 # Endpoint: /{resourceName}?type=file&operation={operationId}, method: Get
 request = requests.Request([
     primitives.restler_static_string("GET "),
+    primitives.restler_basepath(""),
     primitives.restler_static_string("/"),
     primitives.restler_static_string(__resourceName__type_file_put_resourceName_path.reader(), quoted=False),
     primitives.restler_static_string("?"),
@@ -102,6 +105,7 @@ req_collection.add_request(request)
 # Endpoint: /{resourceName}/{itemName}, method: Get
 request = requests.Request([
     primitives.restler_static_string("GET "),
+    primitives.restler_basepath(""),
     primitives.restler_static_string("/"),
     primitives.restler_static_string(__resourceName__type_file_put_resourceName_path.reader(), quoted=False),
     primitives.restler_static_string("/"),
@@ -123,6 +127,7 @@ req_collection.add_request(request)
 # Endpoint: /{resourceName}/{itemName}, method: Delete
 request = requests.Request([
     primitives.restler_static_string("DELETE "),
+    primitives.restler_basepath(""),
     primitives.restler_static_string("/"),
     primitives.restler_static_string(__resourceName__type_file_put_resourceName_path.reader(), quoted=False),
     primitives.restler_static_string("/"),

--- a/src/compiler/Restler.Compiler/CodeGenerator.fs
+++ b/src/compiler/Restler.Compiler/CodeGenerator.fs
@@ -47,6 +47,7 @@ module Types =
         /// (Payload name, dynamic object writer name)
         | Restler_custom_payload_uuid4_suffix of string * string option
         | Restler_refreshable_authentication_token of string
+        | Restler_basepath of string
         | Shadow_values of string
         | Response_parser of string
 
@@ -430,6 +431,8 @@ let generatePythonFromRequestElement includeOptionalParameters (requestId:Reques
     match e with
     | Method m ->
         [Restler_static_string_constant (sprintf "%s%s" (m.ToString().ToUpper()) SPACE)]
+    | RequestElement.BasePath bp ->
+        [ Restler_basepath bp ]
     | RequestElement.Path parts ->
         let queryStartIndex =
             match requestId.xMsPath with
@@ -715,6 +718,7 @@ let generatePythonFromRequest (request:Request) includeOptionalParameters mergeS
 
     let requestElements = [
         Method request.method
+        BasePath request.basePath
         Path request.path
         QueryParameters (getParameterListPayload request.queryParameters)
         HttpVersion request.httpVersion
@@ -1167,6 +1171,8 @@ let getRequests(requests:Request list) includeOptionalParameters =
                 sprintf "primitives.restler_custom_payload_query(\"%s\")" q
             | Restler_refreshable_authentication_token tok ->
                 sprintf "primitives.restler_refreshable_authentication_token(\"%s\")" tok
+            | Restler_basepath bp ->
+                sprintf "primitives.restler_basepath(\"%s\")" bp
             | Response_parser s -> s
             | p ->
                 raise (UnsupportedType (sprintf "Primitive not yet implemented: %A" p))

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -714,7 +714,7 @@ let generateRequestPrimitives (requestId:RequestId)
                                (dependencyData:RequestDependencyData option)
                                (requestParameters:RequestParameters)
                                (dependencies:Dictionary<string, List<ProducerConsumerDependency>>)
-                               basePath
+                               (basePath:string)
                                (host:string)
                                (resolveQueryDependencies:bool)
                                (resolveBodyDependencies:bool)
@@ -742,9 +742,11 @@ let generateRequestPrimitives (requestId:RequestId)
             |> Map.ofSeq
         | _ -> raise (UnsupportedType "Only a list of query parameters is supported.")
 
+
     let path =
-        (basePath + requestId.endpoint).Split([|'/'|], StringSplitOptions.RemoveEmptyEntries)
-        |> Array.choose (fun p ->
+        let pathParts =
+            requestId.endpoint.Split([|'/'|], StringSplitOptions.RemoveEmptyEntries)
+            |> Array.choose (fun p ->
                             if Parameters.isPathParameter p then
                                 let consumerResourceName = Parameters.getPathParameterName p
                                 let declaredParameter =
@@ -775,7 +777,8 @@ let generateRequestPrimitives (requestId:RequestId)
                             else
                                 Some (Constant (PrimitiveType.String, p))
                       )
-        |> Array.toList
+            |> Array.toList
+        pathParts
 
     let replaceCustomPayloads customPayloadType customPayloadParameterNames (requestParameter:RequestParameter) =
         if customPayloadParameterNames |> Seq.contains requestParameter.name then
@@ -1016,6 +1019,7 @@ let generateRequestPrimitives (requestId:RequestId)
     {
         id = requestId
         Request.method = method
+        Request.basePath = basePath
         Request.path = path
         queryParameters = requestQueryParameters
         headerParameters = requestHeaderParameters @

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -379,6 +379,7 @@ type RequestDependencyData =
 /// The parts of a request
 type RequestElement =
     | Method of OperationMethod
+    | BasePath of string
     | Path of FuzzingPayload list
     | QueryParameters of RequestParametersPayload
     | HeaderParameters of RequestParametersPayload
@@ -409,6 +410,9 @@ type Request =
 
         /// The request method, e.g. GET
         method : OperationMethod
+
+        /// The basepath, or an empty string if not specified.
+        basePath : string
 
         path : FuzzingPayload list
 


### PR DESCRIPTION
Modified the grammar to contain a new custom payload entry
corresponding to the basepath (special keyword ```__basepath__```).

When ```basepath``` is specified in the engine settings, the engine replaces this
element with the constant specified in the settings.

If the engine settings do not specify the base path, the one from the
specification is used (via the custom payload in the generated dictionary).