### PR TITLE
Support writer variables in variable grammar primitives.

### DIFF
--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -166,6 +166,7 @@ def replace_auth_token(data, replace_str):
             data = data.replace(latest_shadow_token_value.strip('\r\n'), replace_str)
     return data
 
+
 def resolve_dynamic_primitives(values, candidate_values_pool):
     """ Dynamic primitives (i.e., uuid4) must be filled with a new value
         each time the request is rendered.
@@ -194,10 +195,17 @@ def resolve_dynamic_primitives(values, candidate_values_pool):
         and values[i][0] == primitives.restler_fuzzable_uuid4:
             val = f'{uuid.uuid4()}'
             quoted = values[i][1]
+            writer_variable = values[i][2]
+
             if quoted:
                 values[i] = f'"{val}"'
             else:
                 values[i] = val
+            ## Check if a writer is present.  If so, assign the value generated above
+            ## to the dynamic object variable.
+            if writer_variable is not None:
+                dependencies.set_variable(writer_variable, values[i])
+
         elif isinstance(values[i], tuple)\
         and values[i][0] == primitives.CUSTOM_PAYLOAD_UUID4_SUFFIX:
             current_uuid_type_name = values[i][1]

--- a/restler/engine/primitives.py
+++ b/restler/engine/primitives.py
@@ -404,7 +404,8 @@ def restler_static_string(*args, **kwargs):
         quoted = kwargs[QUOTED_ARG]
     examples = None
     param_name = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 
 def restler_fuzzable_string(*args, **kwargs):
@@ -433,7 +434,10 @@ def restler_fuzzable_string(*args, **kwargs):
     param_name = None
     if PARAM_NAME_ARG in kwargs:
         param_name = kwargs[PARAM_NAME_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 def restler_fuzzable_int(*args, **kwargs):
     """ Integer primitive.
@@ -461,7 +465,11 @@ def restler_fuzzable_int(*args, **kwargs):
     param_name = None
     if PARAM_NAME_ARG in kwargs:
         param_name = kwargs[PARAM_NAME_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 
 def restler_fuzzable_bool(*args, **kwargs):
@@ -490,7 +498,10 @@ def restler_fuzzable_bool(*args, **kwargs):
     param_name = None
     if PARAM_NAME_ARG in kwargs:
         param_name = kwargs[PARAM_NAME_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 
 def restler_fuzzable_number(*args, **kwargs):
@@ -519,7 +530,10 @@ def restler_fuzzable_number(*args, **kwargs):
     param_name = None
     if PARAM_NAME_ARG in kwargs:
         param_name = kwargs[PARAM_NAME_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 
 def restler_fuzzable_delim(*args, **kwargs):
@@ -548,7 +562,8 @@ def restler_fuzzable_delim(*args, **kwargs):
     param_name = None
     if PARAM_NAME_ARG in kwargs:
         param_name = kwargs[PARAM_NAME_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 
 def restler_fuzzable_group(*args, **kwargs):
@@ -582,7 +597,10 @@ def restler_fuzzable_group(*args, **kwargs):
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None
-    return sys._getframe().f_code.co_name, field_name, enum_vals, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, enum_vals, quoted, examples, param_name, writer_variable
 
 
 def restler_fuzzable_uuid4(*args, **kwargs):
@@ -611,7 +629,10 @@ def restler_fuzzable_uuid4(*args, **kwargs):
     param_name = None
     if PARAM_NAME_ARG in kwargs:
         param_name = kwargs[PARAM_NAME_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 
 def restler_fuzzable_datetime(*args, **kwargs) :
@@ -640,7 +661,10 @@ def restler_fuzzable_datetime(*args, **kwargs) :
     param_name = None
     if PARAM_NAME_ARG in kwargs:
         param_name = kwargs[PARAM_NAME_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 def restler_fuzzable_date(*args, **kwargs) :
     """ date primitive
@@ -669,7 +693,10 @@ def restler_fuzzable_date(*args, **kwargs) :
     param_name = None
     if PARAM_NAME_ARG in kwargs:
         param_name = kwargs[PARAM_NAME_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 def restler_fuzzable_object(*args, **kwargs) :
     """ object primitive ({})
@@ -697,7 +724,10 @@ def restler_fuzzable_object(*args, **kwargs) :
     param_name = None
     if PARAM_NAME_ARG in kwargs:
         param_name = kwargs[PARAM_NAME_ARG]
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 def restler_multipart_formdata(*args, **kwargs):
     """ Multipart/formdata primitive
@@ -722,7 +752,8 @@ def restler_multipart_formdata(*args, **kwargs):
         quoted = kwargs[QUOTED_ARG]
     examples = None
     param_name = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 
 def restler_custom_payload(*args, **kwargs):
@@ -747,7 +778,10 @@ def restler_custom_payload(*args, **kwargs):
         quoted = kwargs[QUOTED_ARG]
     examples = None
     param_name = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 
 def restler_custom_payload_header(*args, **kwargs):
@@ -772,7 +806,10 @@ def restler_custom_payload_header(*args, **kwargs):
         quoted = kwargs[QUOTED_ARG]
     examples = None
     param_name = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 
 def restler_custom_payload_query(*args, **kwargs):
@@ -797,7 +834,10 @@ def restler_custom_payload_query(*args, **kwargs):
         quoted = kwargs[QUOTED_ARG]
     examples = None
     param_name = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 def restler_custom_payload_uuid4_suffix(*args, **kwargs):
     """ Custom payload primitive with uuid suffix.
@@ -848,7 +888,8 @@ def restler_refreshable_authentication_token(*args, **kwargs):
         quoted = kwargs[QUOTED_ARG]
     examples = None
     param_name = None
-    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name
+    writer_variable = None
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
 
 def restler_basepath(*args, **kwargs):
     """ The basepath.
@@ -870,4 +911,5 @@ def restler_basepath(*args, **kwargs):
     quoted = False
     examples = None
     param_name = None
-    return sys._getframe().f_code.co_name, basepath_value, quoted, examples, param_name
+    writer_variable = None
+    return sys._getframe().f_code.co_name, basepath_value, quoted, examples, param_name, writer_variable

--- a/restler/unit_tests/log_baseline_test_files/dynamic_obj_dict.json
+++ b/restler/unit_tests/log_baseline_test_files/dynamic_obj_dict.json
@@ -1,0 +1,14 @@
+{
+    "restler_custom_payload_uuid4_suffix": {
+        "cityName": "Seattle"
+    },
+    "restler_custom_payload": {
+        "cityName": "Seattle"
+    },
+    "restler_custom_payload_query": {
+        "cityName": "Seattle"
+    },
+    "restler_custom_payload_header": {
+        "cityName": "Seattle"
+    }
+}

--- a/restler/unit_tests/log_baseline_test_files/test_dynamic_obj_writer.py
+++ b/restler/unit_tests/log_baseline_test_files/test_dynamic_obj_writer.py
@@ -1,0 +1,79 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import print_function
+import json
+
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_city_put_name = dependencies.DynamicVariable(
+    "_city_put_name"
+)
+
+req_collection = requests.RequestCollection([])
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("city"),
+    primitives.restler_static_string("/"),
+    primitives.restler_custom_payload_uuid4_suffix("cityName", writer=_city_put_name.writer()),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"properties":'),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"population":'),
+    primitives.restler_fuzzable_int('10000', quoted=True), #, writer=_city_put_population_name.writer()),
+    primitives.restler_static_string(', "area": "5000",'),
+    primitives.restler_fuzzable_string('strtest', quoted=True),#, writer=_city_put_area_name.writer()),
+    primitives.restler_static_string(':'),
+    primitives.restler_fuzzable_bool('true', quoted=True),
+    primitives.restler_static_string(',"subproperties":'),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"subtest":'),
+    primitives.restler_fuzzable_bool("true", quoted=False),#, writer=_city_put_subtest_name.writer()),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'dependencies':
+            [
+                _city_put_name.writer(),
+            ]
+        }
+    },
+
+],
+requestId="/city/{cityName}"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("city"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_city_put_name.reader()),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n")
+],
+requestId="/city/{cityName}"
+)
+req_collection.add_request(request)
+
+


### PR DESCRIPTION
After this change, producer-consumer dependencies may be defined in the grammar
with input variables for any fuzzable or custom payload primitive (not constants).

Closes #448.