### PR TITLE
Support input dependencies based on annotations for any variable type.

### DIFF
--- a/restler/engine/fuzzing_parameters/request_schema_parser.py
+++ b/restler/engine/fuzzing_parameters/request_schema_parser.py
@@ -181,8 +181,8 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
         is_dynamic_object = False
 
         if 'Fuzzable' in payload:
-            content_type = payload['Fuzzable'][0]
-            content_value = payload['Fuzzable'][1]
+            content_type = payload['Fuzzable']['primitiveType']
+            content_value = payload['Fuzzable']['defaultValue']
             fuzzable = True
         elif 'Constant' in payload:
             content_type = payload['Constant'][0]

--- a/restler/unit_tests/log_baseline_test_files/test_grammar.json
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar.json
@@ -136,12 +136,11 @@
                             "LeafNode": {
                               "name": "population",
                               "payload": {
-                                "Fuzzable": [
-                                  "Int",
-                                  "1000",
-                                  null,
-                                  "population"
-                                ]
+                                "Fuzzable": {
+                                  "primitiveType": "Int",
+                                  "defaultValue": "1000",
+                                  "parameterName": "population"
+                                }
                               },
                               "isRequired": false,
                               "isReadOnly": false
@@ -164,10 +163,11 @@
                             "LeafNode": {
                               "name": "strtest",
                               "payload": {
-                                "Fuzzable": [
-                                  "String",
-                                  "true"
-                                ]
+                                "Fuzzable": {
+                                  "primitiveType": "String",
+                                  "defaultValue": "true",
+                                  "parameterName": "population"
+                                }
                               },
                               "isRequired": true,
                               "isReadOnly": false
@@ -247,8 +247,8 @@
                     "LeafNode": {
                       "name": "",
                       "payload": {
-                        "Fuzzable": [
-                          {
+                        "Fuzzable": {
+                          "primitiveType": {
                             "Enum": [
                               "group",
                               "String",
@@ -260,8 +260,8 @@
                               null
                             ]
                           },
-                          "A"
-                        ]
+                          "defaultValue": "A"
+                        }
                       }
                     }
                   }
@@ -482,8 +482,8 @@
                             "LeafNode": {
                               "name": "group",
                               "payload": {
-                                "Fuzzable": [
-                                  {
+                                "Fuzzable": {
+                                  "primitiveType": {
                                     "Enum": [
                                       "group",
                                       "String",
@@ -495,8 +495,8 @@
                                       null
                                     ]
                                   },
-                                  "A"
-                                ]
+                                  "defaultValue": "A"
+                                }
                               }
                             }
                           }
@@ -1524,11 +1524,11 @@
                             "LeafNode": {
                               "name": "testbool",
                               "payload": {
-                                "Fuzzable": [
-                                  "Bool",
-                                  "testval",
-                                  false
-                                ]
+                                "Fuzzable": {
+                                  "primitiveType": "Bool",
+                                  "defaultValue": "testval",
+                                  "exampleValue": "false"
+                                }
                               },
                               "isRequired": true,
                               "isReadOnly": false
@@ -2150,10 +2150,10 @@
                     "LeafNode": {
                       "name": "",
                       "payload": {
-                        "Fuzzable": [
-                          "DateTime",
-                          "2020-1-1"
-                        ]
+                        "Fuzzable": {
+                          "primitiveType": "DateTime",
+                          "defaultValue": "2020-1-1"
+                        }
                       },
                       "isRequired": true,
                       "isReadOnly": false
@@ -2185,10 +2185,10 @@
                             "LeafNode": {
                               "name": "datetest",
                               "payload": {
-                                "Fuzzable": [
-                                  "DateTime",
-                                  "2020-1-1"
-                                ]
+                                "Fuzzable": {
+                                  "primitiveType": "DateTime",
+                                  "defaultValue": "2020-1-1"
+                                }
                               },
                               "isRequired": false,
                               "isReadOnly": false

--- a/restler/unit_tests/log_baseline_test_files/test_grammar_body.json
+++ b/restler/unit_tests/log_baseline_test_files/test_grammar_body.json
@@ -114,10 +114,10 @@
                                       "LeafNode": {
                                         "name": "population",
                                         "payload": {
-                                          "Fuzzable": [
-                                            "Int",
-                                            "1000"
-                                          ]
+                                          "Fuzzable": {
+                                            "primitiveType": "Int",
+                                            "defaultValue": "1000"
+                                          }
                                         },
                                         "isRequired": false,
                                         "isReadOnly": false
@@ -140,10 +140,10 @@
                                       "LeafNode": {
                                         "name": "strtest",
                                         "payload": {
-                                          "Fuzzable": [
-                                            "String",
-                                            "true"
-                                          ]
+                                          "Fuzzable": {
+                                            "primitiveType": "String",
+                                            "defaultValue": "true"
+                                          }
                                         },
                                         "isRequired": true,
                                         "isReadOnly": false
@@ -171,10 +171,10 @@
                                                   "LeafNode": {
                                                     "name": "subtest",
                                                     "payload": {
-                                                      "Fuzzable": [
-                                                        "Bool",
-                                                        "true"
-                                                      ]
+                                                      "Fuzzable": {
+                                                        "primitiveType": "Bool",
+                                                        "defaultValue": "true"
+                                                      }
                                                     },
                                                     "isRequired": false,
                                                     "isReadOnly": false
@@ -265,8 +265,10 @@
                     "LeafNode": {
                       "name": "",
                       "payload": {
-                        "Fuzzable": [
-                          {
+
+                        "Fuzzable": {
+                          "primitiveType":
+                           {
                             "Enum": [
                               "group",
                               "String",
@@ -278,8 +280,8 @@
                               null
                             ]
                           },
-                          "A"
-                        ]
+                          "defaultValue": "A"
+                        }
                       }
                     }
                   }
@@ -508,7 +510,8 @@
                                   "LeafNode": {
                                     "name": "group",
                                     "payload": {
-                                      "Fuzzable": [
+                                      "Fuzzable": {
+                                        "primitiveType":
                                         {
                                           "Enum": [
                                             "group",
@@ -521,8 +524,8 @@
                                             null
                                           ]
                                         },
-                                        "A"
-                                      ]
+                                        "defaultValue": "A"
+                                      }
                                     }
                                   }
                                 }

--- a/src/compiler/Restler.Compiler.Test/DependencyTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DependencyTests.fs
@@ -324,7 +324,7 @@ module Dependencies =
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\input_producer_spec.json"))]
-                             CustomDictionaryFilePath = None
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\input_producer_dict.json"))
                              AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\input_producer_annotations.json"))
                              AllowGetProducers = true
                          }
@@ -336,6 +336,20 @@ module Dependencies =
 
             Assert.True(grammar.Contains("""restler_custom_payload_uuid4_suffix("fileId", writer=_file__fileId__post_fileId_path.writer())"""))
             Assert.True(grammar.Contains("""restler_static_string(_file__fileId__post_fileId_path.reader(), quoted=False)"""))
+
+            // Validate (tag, label) annotation.  tag - body producer (jsonpath), label: path parameter.
+            Assert.True(grammar.Contains("""primitives.restler_custom_payload("tag", quoted=True, writer=_archive_post_tag.writer())"""))
+            Assert.True(grammar.Contains("""restler_static_string(_archive_post_tag.reader(), quoted=True)"""))
+
+            // Validate (name, name) annotation.  name - body producer (POST) and consumer (PUT).
+            Assert.True(grammar.Contains("""primitives.restler_fuzzable_object("{ \"fuzz\": false }", writer=_archive_post_name.writer())"""))
+            Assert.True(grammar.Contains("""primitives.restler_static_string(_archive_post_name.reader(), quoted=False)"""))
+
+            // Validate (hash, sig) annotation.  hash - header producer (POST), sig - header consumer (PUT)
+            Assert.True(grammar.Contains("""primitives.restler_custom_payload_query("hash", writer=_archive_post_hash_query.writer())"""))
+            Assert.True(grammar.Contains("""primitives.restler_static_string(_archive_post_hash_query.reader(), quoted=False)"""))
+
+
 
 
         /// Test that the entire body should be able to be replaced with a custom payload

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -76,6 +76,9 @@
     <Content Include="swagger\dependencyTests\input_producer_spec.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\dependencyTests\input_producer_dict.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\dependencyTests\input_producer_annotations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.json
@@ -43,12 +43,10 @@
                         "LeafNode": {
                           "name": "name",
                           "payload": {
-                            "Fuzzable": [
-                              "String",
-                              "fuzzstring",
-                              null,
-                              null
-                            ]
+                            "Fuzzable": {
+                              "primitiveType": "String",
+                              "defaultValue": "fuzzstring"
+                            }
                           },
                           "isRequired": false,
                           "isReadOnly": false
@@ -58,12 +56,10 @@
                         "LeafNode": {
                           "name": "tags",
                           "payload": {
-                            "Fuzzable": [
-                              "Object",
-                              "{ \"fuzz\": false }",
-                              null,
-                              null
-                            ]
+                            "Fuzzable": {
+                              "primitiveType": "Object",
+                              "defaultValue": "{ \"fuzz\": false }"
+                            }
                           },
                           "isRequired": false,
                           "isReadOnly": false
@@ -159,12 +155,10 @@
                         "LeafNode": {
                           "name": "",
                           "payload": {
-                            "Fuzzable": [
-                              "String",
-                              "fuzzstring",
-                              null,
-                              null
-                            ]
+                            "Fuzzable": {
+                              "primitiveType": "String",
+                              "defaultValue": "fuzzstring"
+                            }
                           },
                           "isRequired": false,
                           "isReadOnly": false
@@ -198,12 +192,10 @@
                         "LeafNode": {
                           "name": "name",
                           "payload": {
-                            "Fuzzable": [
-                              "String",
-                              "fuzzstring",
-                              null,
-                              null
-                            ]
+                            "Fuzzable": {
+                              "primitiveType": "String",
+                              "defaultValue": "fuzzstring"
+                            }
                           },
                           "isRequired": true,
                           "isReadOnly": false
@@ -213,12 +205,10 @@
                         "LeafNode": {
                           "name": "tags",
                           "payload": {
-                            "Fuzzable": [
-                              "Object",
-                              "{ \"fuzz\": false }",
-                              null,
-                              null
-                            ]
+                            "Fuzzable": {
+                              "primitiveType": "Object",
+                              "defaultValue": "{ \"fuzz\": false }"
+                            }
                           },
                           "isRequired": false,
                           "isReadOnly": false
@@ -246,12 +236,10 @@
                                     "LeafNode": {
                                       "name": "name",
                                       "payload": {
-                                        "Fuzzable": [
-                                          "String",
-                                          "fuzzstring",
-                                          null,
-                                          null
-                                        ]
+                                        "Fuzzable": {
+                                          "primitiveType": "String",
+                                          "defaultValue": "fuzzstring"
+                                        }
                                       },
                                       "isRequired": false,
                                       "isReadOnly": false
@@ -261,12 +249,10 @@
                                     "LeafNode": {
                                       "name": "id",
                                       "payload": {
-                                        "Fuzzable": [
-                                          "Number",
-                                          "1.23",
-                                          null,
-                                          null
-                                        ]
+                                        "Fuzzable": {
+                                          "primitiveType": "Number",
+                                          "defaultValue": "1.23"
+                                        }
                                       },
                                       "isRequired": true,
                                       "isReadOnly": false
@@ -306,12 +292,10 @@
                         "LeafNode": {
                           "name": "",
                           "payload": {
-                            "Fuzzable": [
-                              "String",
-                              "fuzzstring",
-                              null,
-                              null
-                            ]
+                            "Fuzzable": {
+                              "primitiveType": "String",
+                              "defaultValue": "fuzzstring"
+                            }
                           },
                           "isRequired": false,
                           "isReadOnly": false

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
@@ -70,8 +70,8 @@
                   "LeafNode": {
                     "name": "",
                     "payload": {
-                      "Fuzzable": [
-                        {
+                      "Fuzzable": {
+                        "primitiveType": {
                           "Enum": [
                             "api-version",
                             "String",
@@ -81,10 +81,8 @@
                             null
                           ]
                         },
-                        "2020-03-01",
-                        null,
-                        null
-                      ]
+                        "defaultValue": "2020-03-01"
+                      }
                     },
                     "isRequired": true,
                     "isReadOnly": false
@@ -215,8 +213,8 @@
                   "LeafNode": {
                     "name": "",
                     "payload": {
-                      "Fuzzable": [
-                        {
+                      "Fuzzable": {
+                        "primitiveType": {
                           "Enum": [
                             "api-version",
                             "String",
@@ -226,10 +224,8 @@
                             null
                           ]
                         },
-                        "2020-03-01",
-                        null,
-                        null
-                      ]
+                        "defaultValue": "2020-03-01"
+                      }
                     },
                     "isRequired": true,
                     "isReadOnly": false
@@ -381,8 +377,8 @@
                   "LeafNode": {
                     "name": "",
                     "payload": {
-                      "Fuzzable": [
-                        {
+                      "Fuzzable": {
+                        "primitiveType": {
                           "Enum": [
                             "api-version",
                             "String",
@@ -392,10 +388,8 @@
                             null
                           ]
                         },
-                        "2020-03-01",
-                        null,
-                        null
-                      ]
+                        "defaultValue": "2020-03-01"
+                      }
                     },
                     "isRequired": true,
                     "isReadOnly": false
@@ -443,12 +437,10 @@
           }
         },
         {
-          "Fuzzable": [
-            "String",
-            "fuzzstring",
-            null,
-            null
-          ]
+          "Fuzzable": {
+            "primitiveType": "String",
+            "defaultValue": "fuzzstring"
+          }
         }
       ],
       "queryParameters": [
@@ -478,8 +470,8 @@
                   "LeafNode": {
                     "name": "",
                     "payload": {
-                      "Fuzzable": [
-                        {
+                      "Fuzzable": {
+                        "primitiveType": {
                           "Enum": [
                             "api-version",
                             "String",
@@ -489,10 +481,8 @@
                             null
                           ]
                         },
-                        "2020-03-01",
-                        null,
-                        null
-                      ]
+                        "defaultValue": "2020-03-01"
+                      }
                     },
                     "isRequired": true,
                     "isReadOnly": false
@@ -540,12 +530,10 @@
           }
         },
         {
-          "Fuzzable": [
-            "String",
-            "fuzzstring",
-            null,
-            null
-          ]
+          "Fuzzable": {
+            "primitiveType": "String",
+            "defaultValue": "fuzzstring"
+          }
         }
       ],
       "queryParameters": [
@@ -575,8 +563,8 @@
                   "LeafNode": {
                     "name": "",
                     "payload": {
-                      "Fuzzable": [
-                        {
+                      "Fuzzable": {
+                        "primitiveType": {
                           "Enum": [
                             "api-version",
                             "String",
@@ -586,10 +574,8 @@
                             null
                           ]
                         },
-                        "2020-03-01",
-                        null,
-                        null
-                      ]
+                        "defaultValue": "2020-03-01"
+                      }
                     },
                     "isRequired": true,
                     "isReadOnly": false

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/input_producer_annotations.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/input_producer_annotations.json
@@ -5,6 +5,30 @@
       "producer_method": "POST",
       "producer_resource_name": "fileId",
       "consumer_param": "fileId"
+    },
+    {
+      "producer_endpoint": "/archive",
+      "producer_method": "POST",
+      "producer_resource_name": "hash",
+      "consumer_param": "sig"
+    },
+    {
+      "producer_endpoint": "/archive",
+      "producer_method": "POST",
+      "producer_resource_name": "/tag",
+      "consumer_param": "label"
+    },
+    {
+      "producer_endpoint": "/archive",
+      "producer_method": "POST",
+      "producer_resource_name": "/tag",
+      "consumer_param": "/tag"
+    },
+    {
+      "producer_endpoint": "/archive",
+      "producer_method": "POST",
+      "producer_resource_name": "/name",
+      "consumer_param": "/name"
     }
   ]
 }

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/input_producer_dict.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/input_producer_dict.json
@@ -1,0 +1,9 @@
+{
+  "restler_custom_payload": {
+    "sig": [ "12345" ],
+    "tag": ["important"]
+  },
+  "restler_custom_payload_query": {
+    "hash": [ "56789" ]
+  }
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/input_producer_spec.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/input_producer_spec.json
@@ -13,10 +13,98 @@
     "fileId":{
         "type": "String",
         "description":  "the file id"
-
+    },
+    "Archive": {
+      "properties": {
+        "name": {
+          "type": "object"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
     }
   },
   "paths": {
+    "/archive/{archiveId}/{label}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "archiveId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "label",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/archive": {
+      "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "hash",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "in": "body",
+            "name": "bodyParam",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Archive"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/archive/{archiveId}": {
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "archiveId",
+            "required": true,
+            "type": "String"
+          },
+          {
+            "in": "query",
+            "name": "sig",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "in": "body",
+            "name": "bodyParam",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Archive"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/file/{fileId}": {
       "post": {
         "parameters": [

--- a/src/compiler/Restler.Compiler/ApiResourceTypes.fs
+++ b/src/compiler/Restler.Compiler/ApiResourceTypes.fs
@@ -372,7 +372,10 @@ type Producer =
     /// Currently, only assigning such values from the dictionary is supported.
     /// The dictionary payload is an option type because it is only present when
     /// the initial payload is being generated.
-    | InputParameter of InputOnlyProducer * DictionaryPayload option
+    /// (producer, dictionary payload, isWriter)
+    /// When 'isWriter' is true, this is a writer variable that should be generated
+    /// with the original payload.
+    | InputParameter of InputOnlyProducer * DictionaryPayload option * bool
 
     | OrderingConstraintParameter of OrderingConstraintProducer
 

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -166,6 +166,26 @@ type CustomPayload =
         dynamicObject: DynamicObject option
     }
 
+type FuzzablePayload =
+    {
+        /// The primitive type of the payload, as declared in the specification
+        primitiveType : PrimitiveType
+
+        /// The default value of the payload
+        defaultValue : string
+
+        /// The example value specified in the spec, if any
+        exampleValue : string option
+
+        /// The parameter name, if available.
+        parameterName : string option
+
+        /// The associated dynamic object, whose value should be
+        /// assigned to the value generated from this payload.
+        /// For example, an input value from a request body property.
+        dynamicObject: DynamicObject option
+    }
+
 /// The payload for a property specified in as a request parameter
 type FuzzingPayload =
     /// Example: (Int "1")
@@ -173,7 +193,7 @@ type FuzzingPayload =
 
     /// (data type, default value, example value, parameter name)
     /// Example: (Int "1", "2")
-    | Fuzzable of PrimitiveType * string * string option * string option
+    | Fuzzable of FuzzablePayload
 
     /// The custom payload, as specified in the fuzzing dictionary
     | Custom of CustomPayload


### PR DESCRIPTION
Before this change, only 'restler_custom_payload_uuid4_suffix' could have
an associated input-only producer.

Now, any parameter that can be annotated may be associated with an
input-only producer.

Testing:
- Manual testing: modified demo_server to have a writer.
- Added unit test