### PR TITLE
Moved _raise_dict_err from render_iter to init_fuzzable_values

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -674,6 +674,14 @@ class Request(object):
             yield self
 
     def init_fuzzable_values(self, req_definition, candidate_values_pool, preprocessing=False):
+        def _raise_dict_err(type, tag):
+            logger.write_to_main(
+                f"Error for request {self.method} {self.endpoint_no_dynamic_objects}.\n"
+                f"{type} exception: {tag} not found.\n"
+                "Make sure you are using the dictionary created during compilation.",
+                print_to_console=True
+            )
+            raise InvalidDictionaryException
 
         fuzzable = []
         writer_variables=[]
@@ -848,15 +856,6 @@ class Request(object):
         @rtype : (Str, Function Pointer, List[Str])
 
         """
-        def _raise_dict_err(type, tag):
-            logger.write_to_main(
-                f"Error for request {self.method} {self.endpoint_no_dynamic_objects}.\n"
-                f"{type} exception: {tag} not found.\n"
-                "Make sure you are using the dictionary created during compilation.",
-                print_to_console=True
-            )
-            raise InvalidDictionaryException
-
         def _handle_exception(type, tag, err):
             logger.write_to_main(
                 f"Exception when rendering request {self.method} {self.endpoint_no_dynamic_objects}.\n"


### PR DESCRIPTION
Summary of the Pull Request
Moved _raise_dict_err from render_iter to init_fuzzable_values.  The code that calls _raise_dict_err was previously moved from render_iter, but the nested function definition was never moved along with it.

PR Checklist
[x] Applies to work item: #463 
[x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz)[](https://github.com/microsoft/restler-fuzzer/blob/main/docs/contributor-guide/PullRequestTemplate.md#info-on-pull-request)[](https://github.com/microsoft/restler-fuzzer/blob/main/docs/contributor-guide/PullRequestTemplate.md#validation-steps-performed) and sign.
[] Tests added/passed.
[] Requires documentation to be updated
[] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach. Issue number where discussion took place: #xxx
Info on Pull Request
What does this include?

Validation Steps Performed
Passed unit tests