### PR TITLE
Enable fuzzing the last request without re-creating the whole sequence.

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -262,7 +262,7 @@ When set, polls for async resource creation before continuing
 Set to True to ignore socked data decoding failures
 See: https://github.com/microsoft/restler-fuzzer/issues/164
 
-## Per resource settings:
+## Per resource settings
 Certain settings can be applied to specific endpoints.
 These settings a defined in a per_resource_settings dict.
 For example:
@@ -277,6 +277,79 @@ For example:
 The above snippet will set the producer timing delay to 5 and
 activate create-once for the specified endpoint.
 Per resource settings override any global settings.
+
+## Sequence exploration settings
+The following settings can be applied to control how RESTler
+executes request sequences.
+
+__create_prefix_once__
+For requests that have dependencies on pre-requisite resources,
+RESTler executes the entire sequence of requests required to fuzz
+the current request every time it fuzzes the request,
+except for if the request type has a ```GET``` or ```HEAD``` method.
+This default maximizes reproducibility.  ```GET``` and ```HEAD``` methods
+are assumed to have no side effects on the resources created by the API,
+so pre-requisite resources are not re-created when fuzzing them.
+
+All requests prior to the current request being fuzzed (the _sequence prefix_) can either be re-executed every time, or saved for testing all combinations of the current request.  This can be controlled on a per-method or per-endpoint basis, as follows.
+
+1. Execute the entire sequence, except for
+requests with `GET` methods.
+
+```json
+  "sequence_exploration_settings": {
+    "create_prefix_once": [
+      {
+          "methods": ["GET"],
+          "endpoints": "*",
+          "reset_after_success": false
+      }
+    ]
+  }
+```
+
+2.  Always execute the entire sequence for every combination.
+Providing an empty list overrides the default behavior as described earlier.
+
+```json
+  "sequence_exploration_settings": {
+    "create_prefix_once": [
+     ]
+  }
+```
+
+3. Do not re-execute the entire sequence for a specific resource.
+```json
+  "sequence_exploration_settings": {
+    "create_prefix_once": [
+      {
+          "methods": ["GET", "PUT", "PATCH"],
+          "endpoints": ["/customer/{customerId}"],
+      }
+    ]
+  }
+
+```
+
+4. Do not re-execute the entire sequence in all cases, except when a successful request deletes or modifies the pre-requisites set up by the previous requests.
+```json
+  "sequence_exploration_settings": {
+    "create_prefix_once": [
+      {
+          "methods": ["GET", "HEAD"],
+          "endpoints": "*",
+          "reset_after_success": false
+      },
+      {
+        "methods": ["PUT", "POST", "PATCH", "DELETE"],
+        "endpoints": "*",
+        "reset_after_success": true
+      }
+    ]
+}
+
+```
+
 
 ### producer_timing_delay: int (default global_producer_timing_delay)
 The per resource producer timing delay, in seconds.
@@ -312,7 +385,7 @@ instead of the default dictionary.
     "per_resource_settings": {
         "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/{recordType}/{relativeRecordSetName}": {
             "producer_timing_delay": 1,
-            "create_once": 1
+            "create_once": 1,
             "custom_dictionary": "c:\\restler\\custom_dict1.json"
         },
         "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}" {

--- a/restler/engine/core/driver.py
+++ b/restler/engine/core/driver.py
@@ -282,6 +282,8 @@ def render_one(seq_to_render, ith, checkers, generation, global_lock):
         print("Unsupported fuzzing_mode:", Settings().fuzzing_mode)
         assert False
 
+    # Release any saved dynamic objects
+    dependencies.clear_saved_local_dyn_objects()
     return valid_renderings
 
 def render_parallel(seq_collection, fuzzing_pool, checkers, generation, global_lock):
@@ -701,6 +703,7 @@ def generate_sequences(fuzzing_requests, checkers, fuzzing_jobs=1):
                 logger.write_to_main("Timed out...")
                 timeout_reached = True
                 seq_collection_exhausted = True
+
                 # Increase fuzzing generation after timeout because the code
                 # that does it would have never been reached. This is done so
                 # the previous generation's test summary is logged correctly.

--- a/restler/engine/core/status_codes_monitor.py
+++ b/restler/engine/core/status_codes_monitor.py
@@ -179,7 +179,7 @@ class StatusCodesMonitor(object):
             lock.acquire()
 
         seq_length = sequence.length
-        self._requests_count['main_driver'] += seq_length
+        self._requests_count['main_driver'] += sequence.executed_requests_count
         seq_definition = sequence.definition
         seq_hash = sequence.hex_definition
 

--- a/restler/unit_tests/log_baseline_test_files/abc_smoke_test_settings_prefix_cache.json
+++ b/restler/unit_tests/log_baseline_test_files/abc_smoke_test_settings_prefix_cache.json
@@ -1,0 +1,16 @@
+{
+  "sequence_exploration_settings": {
+    "create_prefix_once": [
+      {
+        "methods": [ "GET", "HEAD" ],
+        "endpoints": "*",
+        "reset_after_success": false
+      },
+      {
+        "methods": [ "PUT" ],
+        "endpoints": "*",
+        "reset_after_success": false
+      }
+    ]
+  }
+}

--- a/restler/unit_tests/log_baseline_test_files/abc_smoke_test_testing_log_all_combinations.txt
+++ b/restler/unit_tests/log_baseline_test_files/abc_smoke_test_testing_log_all_combinations.txt
@@ -1,0 +1,560 @@
+2022-02-15 00:06:07.651: Will refresh token: python D:\git\restler-fuzzer\restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
+2022-02-15 00:06:07.715: New value: {'user1':{}, 'user2':{}}
+Authorization: valid_unit_test_token
+Authorization: shadow_unit_test_token
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 1)
+	Request hash: 23db74a21a5b43c1601d160252a5cd1b7ae89805
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+2022-02-15 00:06:07.732: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.733: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+
+Generation-1: Rendering Sequence-2
+
+	Request: 1 (Remaining candidate combinations: 1)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+2022-02-15 00:06:07.752: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.753: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-3: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Remaining candidate combinations: 2)
+	Request hash: 2d217a8041860f0742efe1b22a09893cd0e89ca5
+
+		- restler_static_string: 'GET '
+		- restler_static_string: '/C'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-02-15 00:06:07.789: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.791: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-02-15 00:06:07.793: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.795: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+2022-02-15 00:06:07.797: Sending: 'GET /C HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nExtra-Header: Header1\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 20\r\n\r\n{"A": "A", "B": "B"}'
+
+2022-02-15 00:06:07.798: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"C": {}}'
+
+
+Generation-3: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Remaining candidate combinations: 1)
+	Request hash: 2d217a8041860f0742efe1b22a09893cd0e89ca5
+
+		- restler_static_string: 'GET '
+		- restler_static_string: '/C'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-02-15 00:06:07.818: Sending: 'GET /C HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nExtra-Header: Header2\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 20\r\n\r\n{"A": "A", "B": "B"}'
+
+2022-02-15 00:06:07.820: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"C": {}}'
+
+
+Generation-3: Rendering Sequence-2
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Remaining candidate combinations: 2)
+	Request hash: a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/D/D'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+2022-02-15 00:06:07.847: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.849: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-02-15 00:06:07.851: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.854: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+2022-02-15 00:06:07.857: Sending: 'PUT /D/D HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nExtra-Header: Header1\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 22\r\n\r\n{"A": "A", "B": "B"}\r\n'
+
+2022-02-15 00:06:07.858: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "D"}'
+
+
+Generation-3: Rendering Sequence-2
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Remaining candidate combinations: 1)
+	Request hash: a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/D/D'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+2022-02-15 00:06:07.878: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.881: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-02-15 00:06:07.883: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.885: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+2022-02-15 00:06:07.889: Sending: 'PUT /D/D HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nExtra-Header: Header2\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 22\r\n\r\n{"A": "A", "B": "B"}\r\n'
+
+2022-02-15 00:06:07.890: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "D"}'
+
+
+Generation-4: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Current combination: 1 / 2)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/D/D'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 4 (Remaining candidate combinations: 2)
+	Request hash: fb149c026c182b9719b5b5b37ef0ef3f0950c55a
+
+		- restler_static_string: 'GET '
+		- restler_static_string: '/E'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"D": "'
+		- restler_static_string: '_READER_DELIM_post_d_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-02-15 00:06:07.924: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.926: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-02-15 00:06:07.928: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.929: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+2022-02-15 00:06:07.931: Sending: 'PUT /D/D HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nExtra-Header: Header1\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 22\r\n\r\n{"A": "A", "B": "B"}\r\n'
+
+2022-02-15 00:06:07.933: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "D"}'
+
+2022-02-15 00:06:07.934: Sending: 'GET /E HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nExtra-Header: Header1\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 10\r\n\r\n{"D": "D"}'
+
+2022-02-15 00:06:07.936: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"E": {}}'
+
+
+Generation-4: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Current combination: 1 / 2)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/D/D'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 4 (Remaining candidate combinations: 1)
+	Request hash: fb149c026c182b9719b5b5b37ef0ef3f0950c55a
+
+		- restler_static_string: 'GET '
+		- restler_static_string: '/E'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"D": "'
+		- restler_static_string: '_READER_DELIM_post_d_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-02-15 00:06:07.960: Sending: 'GET /E HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nExtra-Header: Header2\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 10\r\n\r\n{"D": "D"}'
+
+2022-02-15 00:06:07.963: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"E": {}}'
+
+
+Generation-4: Rendering Sequence-2
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Current combination: 2 / 2)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/D/D'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 4 (Remaining candidate combinations: 2)
+	Request hash: fb149c026c182b9719b5b5b37ef0ef3f0950c55a
+
+		- restler_static_string: 'GET '
+		- restler_static_string: '/E'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"D": "'
+		- restler_static_string: '_READER_DELIM_post_d_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-02-15 00:06:07.993: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.994: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-02-15 00:06:07.996: Sending: 'PUT /B/B HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-02-15 00:06:07.998: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "B"}'
+
+2022-02-15 00:06:08.003: Sending: 'PUT /D/D HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nExtra-Header: Header2\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 22\r\n\r\n{"A": "A", "B": "B"}\r\n'
+
+2022-02-15 00:06:08.004: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "D"}'
+
+2022-02-15 00:06:08.006: Sending: 'GET /E HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nExtra-Header: Header1\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 10\r\n\r\n{"D": "D"}'
+
+2022-02-15 00:06:08.008: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"E": {}}'
+
+
+Generation-4: Rendering Sequence-2
+
+	Request: 1 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Current combination: 1 / 1)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/B/B'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 3 (Current combination: 2 / 2)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/D/D'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"A": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '", "B": "'
+		- restler_static_string: '_READER_DELIM_post_b_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+		- restler_static_string: '\r\n'
+
+	Request: 4 (Remaining candidate combinations: 1)
+	Request hash: fb149c026c182b9719b5b5b37ef0ef3f0950c55a
+
+		- restler_static_string: 'GET '
+		- restler_static_string: '/E'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		- restler_static_string: 'Extra-Header: '
+		+ restler_fuzzable_group: [Header1, Header2, ...]
+		- restler_static_string: '\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"D": "'
+		- restler_static_string: '_READER_DELIM_post_d_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-02-15 00:06:08.029: Sending: 'GET /E HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nExtra-Header: Header2\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 10\r\n\r\n{"D": "D"}'
+
+2022-02-15 00:06:08.031: Received: 'HTTP/1.1 200 OK\r\nRestler Test\r\n\r\n{"E": {}}'
+

--- a/restler/unit_tests/log_baseline_test_files/abc_test_grammar_combinations.py
+++ b/restler/unit_tests/log_baseline_test_files/abc_test_grammar_combinations.py
@@ -1,0 +1,215 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This grammar was created manually.
+# There is no corresponding OpenAPI spec.
+# This grammar is identical to abc_test_grammar.py, except
+# additional fuzzable groups are introduced so each request type
+# has multiple combinations.
+from __future__ import print_function
+import json
+
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_post_a = dependencies.DynamicVariable(
+    "_post_a"
+)
+
+_post_b = dependencies.DynamicVariable(
+    "_post_b"
+)
+
+_post_d = dependencies.DynamicVariable(
+    "_post_d"
+)
+
+def parse_A(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_a", temp_123)
+
+def parse_B(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_b", temp_123)
+
+
+def parse_D(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_d", temp_123)
+
+
+req_collection = requests.RequestCollection([])
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/A/A"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_A,
+            'dependencies':
+            [
+                _post_a.writer()
+            ]
+        }
+    },
+
+],
+requestId="/A/{A}"
+)
+req_collection.add_request(request)
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/B/B"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_B,
+            'dependencies':
+            [
+                _post_b.writer()
+            ]
+        }
+    },
+],
+requestId="/B/{B}"
+)
+req_collection.add_request(request)
+
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/C"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_static_string("Extra-Header: "),
+    primitives.restler_fuzzable_group("Extra-Header", ["Header1", "Header2"]),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"A": "'),
+    primitives.restler_static_string(_post_a.reader()),
+    primitives.restler_static_string('", "B": "'),
+    primitives.restler_static_string(_post_b.reader()),
+    primitives.restler_static_string('"'),
+    primitives.restler_static_string("}"),
+],
+requestId="/C"
+)
+req_collection.add_request(request)
+
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/D/D"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_static_string("Extra-Header: "),
+    primitives.restler_fuzzable_group("Extra-Header", ["Header1", "Header2"]),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"A": "'),
+    primitives.restler_static_string(_post_a.reader()),
+    primitives.restler_static_string('", "B": "'),
+    primitives.restler_static_string(_post_b.reader()),
+    primitives.restler_static_string('"'),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_D,
+            'dependencies':
+            [
+                _post_d.writer()
+            ]
+        }
+    },
+
+],
+requestId="/D/{D}"
+)
+req_collection.add_request(request)
+
+
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_static_string("/E"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_static_string("Extra-Header: "),
+    primitives.restler_fuzzable_group("Extra-Header", ["Header1", "Header2"]),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"D": "'),
+    primitives.restler_static_string(_post_d.reader()),
+    primitives.restler_static_string('"'),
+    primitives.restler_static_string("}"),
+],
+requestId="/E"
+)
+req_collection.add_request(request)
+
+

--- a/restler/unit_tests/log_baseline_test_files/always_render_full_seq_settings.json
+++ b/restler/unit_tests/log_baseline_test_files/always_render_full_seq_settings.json
@@ -1,0 +1,6 @@
+{
+  "sequence_exploration_settings": {
+    "create_prefix_once": [
+    ]
+  }
+}

--- a/restler/unit_tests/restler_user_settings.json
+++ b/restler/unit_tests/restler_user_settings.json
@@ -60,6 +60,15 @@
       "custom_dictionary": "c:\\restler\\custom_dict2.json"
     }
   },
+  "sequence_exploration_settings": {
+    "create_prefix_once": [
+      {
+        "methods": [ "GET", "HEAD" ],
+        "endpoints": "*",
+        "reset_after_success": false
+      }
+    ]
+  },
   "checkers": {
     "namespacerule": {
       "mode": "exhaustive"


### PR DESCRIPTION
Added new engine option to support this optimization.

See #469 for more details.

The option is specified as follows:

```
"cache_prefix_sequence_settings": {
    "per_request_settings": [
      {
        "methods": [ "GET", "HEAD" ],
        "endpoints": "*",
        "reset_after_success": false
      }
    ]
  }
```

Testing:
- demo_server manual testing
- added unit test
- real world service testing to confirm all objects are cleaned up at the end
- 
Closes #469