### PR TITLE
Fix GC regression.

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -913,10 +913,10 @@ class Request(object):
                 values = list(values)
                 values = request_utilities.resolve_dynamic_primitives(values, candidate_values_pool)
                 for val_idx, val in enumerate(values):
-                    if writer_variables[val_idx] is not None:
+                    (writer_variable, writer_is_quoted) = writer_variables[val_idx]
+                    if writer_variable is not None:
                         # Save the unquoted value.
                         # It will be quoted again at the time it is used, if needed
-                        (writer_variable, writer_is_quoted) = writer_variables[val_idx]
                         if writer_is_quoted:
                             val = val[1:-1]
                         dependencies.set_variable(writer_variable, val)


### PR DESCRIPTION
The condition did not account for the arguments switching to a tuple.
This regressed in #467 (the previous change).

This was not caught by existing tests because there are no unit tests for the
dynamic objects cache, and this only caused the GC to have to
go through more entries.

Testing: manual testing.