### PR TITLE
Update RESTler version to 8.4.0

### DIFF
--- a/ci_build_pipelines/variables/version-variables.yml
+++ b/ci_build_pipelines/variables/version-variables.yml
@@ -2,7 +2,7 @@ variables:
   - name: version.major
     value: 8
   - name: version.minor
-    value: 3
+    value: 4
   - name: devRevision
     value: 0
   - name: buildPlatform

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -14,7 +14,7 @@ open Microsoft.FSharpLu.Diagnostics.Process
 open Restler.Telemetry
 
 [<Literal>]
-let CurrentVersion = "8.3.0"
+let CurrentVersion = "8.4.0"
 let EngineErrorCode = -2
 
 let exitRestler status =


### PR DESCRIPTION
Update highlights:
- improved docker build (thanks to @rhtenhove)
- dependencies can be specified between input parameters (previously, producers were required to be in the response)
- requests can be fuzzed without re-creating all dependencies for every combination