### PR TITLE
Fix quick start test failure

### DIFF
--- a/demo_server/requirements.txt
+++ b/demo_server/requirements.txt
@@ -1,4 +1,6 @@
 flask==1.1.2
 flask-restplus==0.13.0
 Flask-SQLAlchemy==2.5.1
+itsdangerous==2.0.1
 Werkzeug==0.16.0
+


### PR DESCRIPTION
The tests started failing due to a break in demo_server dependencies.

This change implements the following:
1) Resolve flask import issue - pin dependency to an earlier version.
2) Add more debugging output to the quick start script to be able to
diagnose similar failures from build logs.