### PR TITLE
Perf improvement: re-use connection across multiple requests.

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -91,6 +91,11 @@ that is applied after any request that is marked as a producer.
 This wait time will occur for every request in a sequence except the last request.
 The per-resource producer timing delay (below) will override this value.
 
+### reconnect_on_every_request: bool (default False)
+By default, RESTler re-uses the same connection across different requests,
+re-creating it only on error.  Set to True to create a new connection for
+every request sent.
+
 ### grammar_schema: string (default None)
 The path to the grammar.json file for the API in test.
 This is required when using the examples and payload body checkers.
@@ -227,7 +232,7 @@ A list of strings in the response on which the request should be re-tried may be
 }
 ```
 
-___interval_sec__
+__interval_sec__
 
 The number of seconds to wait between retries (shown below with the default value).
 

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -415,6 +415,8 @@ class RestlerSettings(object):
         self._basepath = SettingsArg('basepath', str, None, user_args)
         ##  Ignore request dependencies
         self._ignore_dependencies = SettingsArg('ignore_dependencies', bool, False, user_args)
+        ##  Re-create the connection for every request sent.
+        self._reconnect_on_every_request = SettingsArg('reconnect_on_every_request', bool, False, user_args)
         ## Ignore server-side feedback
         self._ignore_feedback = SettingsArg('ignore_feedback', bool, False, user_args)
         ## Include user agent in requests sent
@@ -589,6 +591,10 @@ class RestlerSettings(object):
     @property
     def max_request_execution_time(self):
         return self._max_request_execution_time.val
+
+    @property
+    def reconnect_on_every_request(self):
+        return self._reconnect_on_every_request.val
 
     @property
     def max_sequence_length(self):

--- a/restler/unit_tests/restler_user_settings.json
+++ b/restler/unit_tests/restler_user_settings.json
@@ -21,6 +21,7 @@
   "fuzzing_jobs": 2,
   "fuzzing_mode": "directed-smoke-test",
   "garbage_collection_interval": 30,
+  "reconnect_on_every_request": false,
   "ignore_dependencies": true,
   "ignore_feedback": true,
   "include_user_agent": true,


### PR DESCRIPTION
Changes include:
- Implement reconnect logic in all parts of RESTler.
- Improve logging.
- The old behavior (new connection on every request) can be restored with the
```reconnect_on_every_request``` setting in the engine settings.
- Fixes so all parts of RESTler are using the same throttling logic.

Testing:
- Manual testing on large services with throttling.  Confirmed all objects are GCed.
- Manual testing of perf improvement. 
