### PR TITLE
Implement dynamic value generators

### DIFF
--- a/docs/user-guide/FuzzingDictionary.md
+++ b/docs/user-guide/FuzzingDictionary.md
@@ -122,3 +122,9 @@ Note: to specify a double-quote " in a string in a fuzzing dictionary, use `\"`
 #### **Per resource dictionaries**
 
 Usually, it is sufficient to specify a dictionary for the entire API under test, or one dictionary per API specification when several API specifications are tested together.  However, there may be cases when a specific endpoint requires a different custom payload from the rest of the APIs.  An example of this is when a service uses different API versions for different endpoints in the same API: the ```api-version``` parameter needs to be one of several values, but for specific endpoints, so it cannot be specified in one *restler_custom_payload*.  Such cases are handled with a per-resource dictionary for individual endpoints, which takes precedence over the global dictionary.  See [SettingsFile](SettingsFile.md) for how to configure a per-resource dictionary.
+
+#### **Dynamically generating values**
+RESTler also supports dynamically generating values for most of the data types above.  Each primitive or custom
+payload may have a corresponding dynamic value generator.  For more details on how to provide
+dynamically generated values to RESTler,
+see the ```custom_value_generators``` setting in the [SettingsFile](SettingsFile.md)

--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -377,6 +377,36 @@ For instance, any custom payloads
 or fuzzable values for this endpoint will be taken from the specified custom dictionary
 instead of the default dictionary.
 
+### custom_value_generators: string (default None)
+If this setting is set to a valid path with a ```.py``` extension,
+RESTler will try to import the contents of this
+file as a Python module, and will search for a dictionary named ```value_generators```.
+This dictionary must have the same structure as the mutations dictionary,
+but each entry may be initialized with a generator function (example shown below).
+A dynamic value generator overrides the corresponding entry in the custom dictionary, if
+it exists.  For example, if a ```restler_custom_payload``` for ```ip_address``` specifies
+one value in the dictionary, and has a custom value generator, values will be
+dynamically generated up to ```max_combinations``` or until the
+generator has no more values.
+
+Below is an example of a valid Python dictionary that specifies a value generator.
+Note: a template file containing placeholder custom value generators for all of the
+dictionary entries, including custom payloads, is automatically generated
+during compilation and placed into the 'Compile' directory.
+
+```python
+def generate_strings(**kwargs):
+    while True:
+        yield "fuzz"
+        yield str(random.randint(-10, 10))
+
+value_generators = {
+	"restler_fuzzable_string": generate_strings
+}
+```
+
+
+
 ## Example Settings File Format
 ```json
 {

--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -198,7 +198,7 @@ def resolve_dynamic_primitives(values, candidate_values_pool):
         and values[i][0] == primitives.restler_fuzzable_uuid4:
             val = f'{uuid.uuid4()}'
             quoted = values[i][1]
-            writer_variable = values[i][2]
+            (writer_variable, is_quoted) = values[i][2]
 
             if quoted:
                 values[i] = f'"{val}"'
@@ -226,6 +226,24 @@ def resolve_dynamic_primitives(values, candidate_values_pool):
                 values[i] = current_uuid_suffixes[current_uuid_type_name]
             # Check if a writer is present.  If so, assign the value generated above
             # to the dynamic object variable.
+            if writer_variable is not None:
+                dependencies.set_variable(writer_variable, values[i])
+
+        elif isinstance(values[i], tuple)\
+        and isinstance(values[i][0], types.GeneratorType):
+            # Handle the case of a custom value generator.
+            # The value needs to be quoted, and if a writer variable is present, it needs to be
+            # set (similar to restler_fuzzable_uuid4)
+            value_generator = values[i][0]
+            val = str(next(value_generator))
+            quoted = values[i][1]
+            (writer_variable, is_quoted) = values[i][2]
+            if quoted:
+                values[i] = f'"{val}"'
+            else:
+                values[i] = val
+            ## Check if a writer is present.  If so, assign the value generated above
+            ## to the dynamic object variable.
             if writer_variable is not None:
                 dependencies.set_variable(writer_variable, values[i])
 

--- a/restler/engine/core/sequences.py
+++ b/restler/engine/core/sequences.py
@@ -366,7 +366,7 @@ class Sequence(object):
                 prev_request = self.requests[i]
                 prev_rendered_data, prev_parser, tracked_parameters =\
                     prev_request.render_current(candidate_values_pool,
-                    preprocessing=preprocessing)
+                    preprocessing=preprocessing, use_last_cached_rendering=True)
 
                 request.update_tracked_parameters(tracked_parameters)
 

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -441,6 +441,8 @@ class RestlerSettings(object):
         self._save_results_in_fixed_dirname = SettingsArg('save_results_in_fixed_dirname', bool, False, user_args)
         ## Limit restler grammars only to endpoints whose paths contain a given substring
         self._path_regex = SettingsArg('path_regex', str, None, user_args)
+        ## Custom value generator module file path
+        self._custom_value_generators_file_path = SettingsArg('custom_value_generators', str, None, user_args)
         ## Minimum time, in milliseconds, to wait between sending requests
         self._request_throttle_ms = SettingsArg('request_throttle_ms', (int, float), None, user_args, minval=0)
         ## Settings for customizing re-try logic for requests
@@ -611,6 +613,10 @@ class RestlerSettings(object):
     @property
     def path_regex(self):
         return self._path_regex.val
+
+    @property
+    def custom_value_generators_file_path(self):
+        return self._custom_value_generators_file_path.val
 
     @property
     def request_throttle_ms(self):

--- a/restler/unit_tests/log_baseline_test_files/custom_value_gen.py
+++ b/restler/unit_tests/log_baseline_test_files/custom_value_gen.py
@@ -1,0 +1,70 @@
+import typing
+import random
+import time
+import string
+import itertools
+random_seed=0
+print(f"Value generator random seed: {random_seed}")
+random.seed(random_seed)
+
+EXAMPLE_ARG = "examples"
+
+# No count limit
+def gen_restler_fuzzable_string(**kwargs):
+    example_values=None
+    if EXAMPLE_ARG in kwargs:
+        example_values = kwargs[EXAMPLE_ARG]
+
+    if example_values:
+        for exv in example_values:
+            yield exv
+        example_values = itertools.cycle(example_values)
+
+    i = 0
+    while True:
+        i = i + 1
+        size = random.randint(i, i + 10)
+        if example_values:
+            ex = next(example_values)
+            ex_k = random.randint(1, len(ex) - 1)
+            new_values=''.join(random.choices(ex, k=ex_k))
+            yield ex[:ex_k] + new_values + ex[ex_k:]
+
+        yield ''.join(random.choices(string.ascii_letters + string.digits, k=size))
+        yield ''.join(random.choices(string.printable, k=size)).replace("\r\n", "")
+
+
+def get_integers():
+    values = range(0, 5)
+    for k in values:
+        yield k
+
+# Returns 5 values
+def gen_restler_fuzzable_int(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    return get_integers()
+
+# Returns 3 values
+def gen_type(**kwargs):
+
+    yield "int"
+    yield "number"
+    yield "string"
+
+value_generators = {
+	"restler_fuzzable_string": gen_restler_fuzzable_string,
+	"restler_fuzzable_string_unquoted": None,
+	"restler_fuzzable_datetime": None,
+	"restler_fuzzable_datetime_unquoted": None,
+	"restler_fuzzable_date": None,
+	"restler_fuzzable_date_unquoted": None,
+	"restler_fuzzable_uuid4": None,
+	"restler_fuzzable_uuid4_unquoted": None,
+	"restler_fuzzable_int":  gen_restler_fuzzable_int,
+	"restler_custom_payload": {
+		"type": gen_type,
+	},
+}

--- a/restler/unit_tests/log_baseline_test_files/value_gen_dict.json
+++ b/restler/unit_tests/log_baseline_test_files/value_gen_dict.json
@@ -1,0 +1,15 @@
+{
+  "restler_fuzzable_string": [
+    "fuzzstring"
+  ],
+  "restler_fuzzable_int": [
+    "1"
+  ],
+  "restler_fuzzable_number": [
+    "1.1", "2.2", "3.3"
+  ],
+  "restler_custom_payload": {
+    "type": [ "int" ],
+    "result": [ "pass", "fail" ]
+  }
+}

--- a/restler/unit_tests/log_baseline_test_files/value_gen_settings.json
+++ b/restler/unit_tests/log_baseline_test_files/value_gen_settings.json
@@ -1,0 +1,1 @@
+{"custom_value_generators": "D:\\git\\restler-fuzzer\\restler\\unit_tests\\log_baseline_test_files\\custom_value_gen.py", "max_combinations": 6}

--- a/restler/unit_tests/log_baseline_test_files/value_gen_test_grammar.py
+++ b/restler/unit_tests/log_baseline_test_files/value_gen_test_grammar.py
@@ -1,0 +1,96 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This grammar was created manually.
+# There is no corresponding OpenAPI spec.
+
+from __future__ import print_function
+import json
+
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+req_collection = requests.RequestCollection([])
+
+_post_a = dependencies.DynamicVariable(
+    "_post_a"
+)
+
+
+def parse_A(data):
+    temp_123 = None
+
+    try:
+        data = json.loads(data)
+    except Exception as error:
+        raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+
+    try:
+        temp_123 = str(data["name"])
+    except Exception as error:
+        pass
+
+    if temp_123:
+        dependencies.set_variable("_post_a", temp_123)
+
+
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_static_string("/A/A"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Value-generated: "),
+    primitives.restler_fuzzable_string("fuzzstring"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    {
+        'post_send':
+        {
+            'parser': parse_A,
+            'dependencies':
+            [
+                _post_a.writer()
+            ]
+        }
+    },
+
+],
+requestId="/A/{A}"
+)
+req_collection.add_request(request)
+
+
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_static_string("/"),
+    primitives.restler_custom_payload("result"),
+    primitives.restler_static_string("/"),
+    primitives.restler_fuzzable_number("1.1"),
+    primitives.restler_static_string("/A/"),
+    primitives.restler_fuzzable_string("fuzzstring"),
+    primitives.restler_static_string("/B/"),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string("/C/"),
+    primitives.restler_custom_payload("type"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: restler.unit.test.server.com\r\n"),
+    primitives.restler_static_string("Content-Type: application/json\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string('"reader": "'),
+    primitives.restler_static_string(_post_a.reader()),
+    primitives.restler_static_string('"'),
+    primitives.restler_static_string("}"),
+
+],
+requestId="/A/{name}/B/{id}/C/{type}"
+)
+req_collection.add_request(request)
+

--- a/restler/unit_tests/log_baseline_test_files/value_gen_testing_log.txt
+++ b/restler/unit_tests/log_baseline_test_files/value_gen_testing_log.txt
@@ -1,0 +1,1936 @@
+2022-03-10 23:37:23.771: Will refresh token: python D:\git\restler-fuzzer\restler\unit_tests\log_baseline_test_files\unit_test_server_auth.py
+2022-03-10 23:37:23.842: New value: {'user1':{}, 'user2':{}}
+Authorization: valid_unit_test_token
+Authorization: shadow_unit_test_token
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 6)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876B80>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+2022-03-10 23:37:23.897: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: LehlZhfZh\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:23.904: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 5)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876F70>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+2022-03-10 23:37:23.948: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: Yj\r*L+6&S\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:23.955: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 4)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876E50>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+2022-03-10 23:37:24.019: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: gqnOvlFcg9m\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.032: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 3)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118B00D0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+2022-03-10 23:37:24.118: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: z,@|g&\n5&[y\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.126: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 2)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118B0310>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+2022-03-10 23:37:24.189: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: h5PaQ32\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.200: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-1: Rendering Sequence-1
+
+	Request: 1 (Remaining candidate combinations: 1)
+	Request hash: 44414ad093616e18a9e2f845ae9d453eb6e4c8bc
+
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118B0550>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+2022-03-10 23:37:24.280: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: |#C$f(J\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.291: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876C10>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 6)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876DC0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876CA0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876C10>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:24.504: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: LehlZhfZh\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.510: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:24.515: Sending: 'POST /pass/1.1/A/uc/B/0/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:24.521: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876EE0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 5)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876DC0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876E50>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876EE0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:24.575: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: LehlZhfZh\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.581: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:24.587: Sending: 'POST /pass/2.2/A/so/B/1/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:24.593: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 4)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:24.646: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: LehlZhfZh\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.653: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:24.659: Sending: 'POST /pass/3.3/A/vrw6NMSyz/B/2/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:24.666: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE700>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 3)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE0D0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE550>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE700>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:24.728: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: LehlZhfZh\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.734: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:24.740: Sending: 'POST /fail/1.1/A/$0jxn"B^U/B/3/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:24.748: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE940>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 2)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE550>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE700>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE940>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:24.800: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: LehlZhfZh\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.808: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:24.813: Sending: 'POST /fail/2.2/A/b2JVRkdRB/B/4/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:24.819: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-1
+
+	Request: 1 (Current combination: 1 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEB80>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE700>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE940>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEB80>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:24.871: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: LehlZhfZh\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.877: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:24.883: Sending: 'POST /fail/3.3/A/_{Y03w@4?/B/0/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:24.889: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-2
+
+	Request: 1 (Current combination: 2 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BECA0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 6)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEAF0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE550>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BECA0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:24.964: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: Yj\r*L+6&S\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:24.971: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:24.977: Sending: 'POST /pass/1.1/A/l9NfS9y/B/0/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:24.983: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-2
+
+	Request: 1 (Current combination: 2 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEAF0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 5)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BECA0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEF70>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEAF0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.040: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: Yj\r*L+6&S\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.046: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.052: Sending: 'POST /pass/2.2/A/&vl*0?Q/B/1/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.058: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-2
+
+	Request: 1 (Current combination: 2 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876CA0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 4)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876CA0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876DC0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876CA0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.117: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: Yj\r*L+6&S\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.124: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.131: Sending: 'POST /pass/3.3/A/lLm/B/2/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.137: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-2
+
+	Request: 1 (Current combination: 2 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876DC0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 3)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876D30>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876CA0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876DC0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.192: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: Yj\r*L+6&S\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.200: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.206: Sending: 'POST /fail/1.1/A/u\'i/B/3/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.214: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-2
+
+	Request: 1 (Current combination: 2 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEEE0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 2)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEEE0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEEE0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEEE0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.276: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: Yj\r*L+6&S\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.282: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.288: Sending: 'POST /fail/2.2/A/0yfrCX1iGO/B/4/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.294: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-2
+
+	Request: 1 (Current combination: 2 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE670>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEDC0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE0D0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE670>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.348: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: Yj\r*L+6&S\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.354: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.360: Sending: 'POST /fail/3.3/A/y^r14\'T ~{/B/0/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.367: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-3
+
+	Request: 1 (Current combination: 3 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE790>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 6)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE9D0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE940>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE790>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.442: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: gqnOvlFcg9m\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.448: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.454: Sending: 'POST /pass/1.1/A/0/B/0/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.459: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-3
+
+	Request: 1 (Current combination: 3 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE9D0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 5)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE790>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEAF0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE9D0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.517: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: gqnOvlFcg9m\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.525: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.531: Sending: 'POST /pass/2.2/A/\n/B/1/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.537: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-3
+
+	Request: 1 (Current combination: 3 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE5E0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 4)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEAF0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE9D0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE5E0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.592: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: gqnOvlFcg9m\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.599: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.605: Sending: 'POST /pass/3.3/A/OS3NxHmKaju/B/2/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.613: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-3
+
+	Request: 1 (Current combination: 3 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE820>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 3)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEAF0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEB80>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE820>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.673: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: gqnOvlFcg9m\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.679: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.685: Sending: 'POST /fail/1.1/A/;*x!4g\x0bsDSt/B/3/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.691: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-3
+
+	Request: 1 (Current combination: 3 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0310>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 2)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D01F0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0160>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0310>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.746: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: gqnOvlFcg9m\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.753: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.759: Sending: 'POST /fail/2.2/A/T5t1TsZsgI/B/4/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.765: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-3
+
+	Request: 1 (Current combination: 3 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0700>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0160>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0310>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0700>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.823: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: gqnOvlFcg9m\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.830: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.838: Sending: 'POST /fail/3.3/A/Mx<>cbN3x\'/B/0/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.846: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-4
+
+	Request: 1 (Current combination: 4 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0820>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 6)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0670>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D01F0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0820>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:25.924: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: z,@|g&\n5&[y\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:25.931: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:25.937: Sending: 'POST /pass/1.1/A/5Mx/B/0/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:25.944: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-4
+
+	Request: 1 (Current combination: 4 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0670>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 5)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0820>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0AF0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0670>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:26.011: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: z,@|g&\n5&[y\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:26.021: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:26.029: Sending: 'POST /pass/2.2/A/\r"6/B/1/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:26.038: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-4
+
+	Request: 1 (Current combination: 4 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEE50>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 4)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE670>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE9D0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEE50>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:26.139: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: z,@|g&\n5&[y\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:26.149: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:26.161: Sending: 'POST /pass/3.3/A/mnx/B/2/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:26.175: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-4
+
+	Request: 1 (Current combination: 4 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE670>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 3)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEE50>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE670>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:26.289: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: z,@|g&\n5&[y\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:26.302: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:26.315: Sending: 'POST /fail/1.1/A/9Ts/B/3/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:26.323: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-4
+
+	Request: 1 (Current combination: 4 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEE50>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 2)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE670>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEE50>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:26.425: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: z,@|g&\n5&[y\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:26.431: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:26.438: Sending: 'POST /fail/2.2/A/WSnfn9Kklh/B/4/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:26.444: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-4
+
+	Request: 1 (Current combination: 4 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEDC0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEC10>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEDC0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:26.515: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: z,@|g&\n5&[y\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:26.528: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:26.536: Sending: 'POST /fail/3.3/A/?\\2Q.kNp#\x0c/B/0/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:26.543: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-5
+
+	Request: 1 (Current combination: 5 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876DC0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 6)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876F70>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876E50>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876DC0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:26.659: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: h5PaQ32\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:26.672: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:26.684: Sending: 'POST /pass/1.1/A/MgCw/B/0/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:26.697: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-5
+
+	Request: 1 (Current combination: 5 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876C10>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 5)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876DC0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876F70>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876C10>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:26.813: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: h5PaQ32\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:26.826: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:26.839: Sending: 'POST /pass/2.2/A/?aXM/B/1/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:26.852: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-5
+
+	Request: 1 (Current combination: 5 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876D30>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 4)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876C10>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876DC0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876D30>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:26.926: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: h5PaQ32\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:26.932: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:26.938: Sending: 'POST /pass/3.3/A/zQ2E4tEEPmL/B/2/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:26.944: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-5
+
+	Request: 1 (Current combination: 5 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0C10>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 3)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D00D0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D01F0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0C10>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:26.997: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: h5PaQ32\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:27.004: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:27.010: Sending: 'POST /fail/1.1/A/ly\n`>3ep;[W/B/3/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:27.017: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-5
+
+	Request: 1 (Current combination: 5 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0790>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 2)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D01F0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0C10>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0790>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:27.076: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: h5PaQ32\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:27.082: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:27.088: Sending: 'POST /fail/2.2/A/ef1cnca0uj/B/4/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:27.095: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-5
+
+	Request: 1 (Current combination: 5 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0550>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0C10>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0790>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0550>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:27.154: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: h5PaQ32\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:27.160: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:27.166: Sending: 'POST /fail/3.3/A/e$\nO{OV&=./B/0/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:27.172: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-6
+
+	Request: 1 (Current combination: 6 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0040>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 6)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D05E0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D01F0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0040>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:27.242: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: |#C$f(J\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:27.247: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:27.253: Sending: 'POST /pass/1.1/A/U4/B/0/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:27.259: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-6
+
+	Request: 1 (Current combination: 6 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D05E0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 5)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0040>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D0700>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118D05E0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:27.309: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: |#C$f(J\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:27.315: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:27.323: Sending: 'POST /pass/2.2/A/kR/B/1/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:27.329: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-6
+
+	Request: 1 (Current combination: 6 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876CA0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 4)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876D30>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876E50>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA11876CA0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:27.382: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: |#C$f(J\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:27.388: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:27.395: Sending: 'POST /pass/3.3/A/z808Lo1b2Ts/B/2/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:27.401: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-6
+
+	Request: 1 (Current combination: 6 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 3)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE430>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:27.462: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: |#C$f(J\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:27.470: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:27.476: Sending: 'POST /fail/1.1/A/VxNq?:CCg~n/B/3/C/int HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:27.482: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-6
+
+	Request: 1 (Current combination: 6 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE4C0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 2)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE1F0>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEA60>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE4C0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:27.538: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: |#C$f(J\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:27.549: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:27.556: Sending: 'POST /fail/2.2/A/dczE1SPj/B/4/C/number HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:27.564: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+
+
+Generation-2: Rendering Sequence-6
+
+	Request: 1 (Current combination: 6 / 6)
+		- restler_static_string: 'PUT '
+		- restler_static_string: '/A/A'
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Value-generated: '
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE5E0>
+		- restler_static_string: '\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+
+	Request: 2 (Remaining candidate combinations: 1)
+	Request hash: 7a15d09ce9ad6f1adbed63be98c58d88ffe8a153
+
+		- restler_static_string: 'POST '
+		- restler_static_string: '/'
+		+ restler_custom_payload: [pass, fail, ...]
+		- restler_static_string: '/'
+		+ restler_fuzzable_number: [1.1, 2.2, ...]
+		- restler_static_string: '/A/'
+		- restler_fuzzable_string: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BEA60>
+		- restler_static_string: '/B/'
+		- restler_fuzzable_int: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE4C0>
+		- restler_static_string: '/C/'
+		- restler_custom_payload: <function CandidateValuesPool.get_candidate_values.<locals>.get_custom_value_generator.<locals>.value_generator_wrapper at 0x000001CA118BE5E0>
+		- restler_static_string: ' HTTP/1.1\r\n'
+		- restler_static_string: 'Accept: application/json\r\n'
+		- restler_static_string: 'Host: unittest\r\n'
+		- restler_static_string: 'Content-Type: application/json\r\n'
+		+ restler_refreshable_authentication_token: [token_refresh_cmd, token_refresh_interval, ...]
+		- restler_static_string: '\r\n'
+		- restler_static_string: '{'
+		- restler_static_string: '"reader": "'
+		- restler_static_string: '_READER_DELIM_post_a_READER_DELIM'
+		- restler_static_string: '"'
+		- restler_static_string: '}'
+
+2022-03-10 23:37:27.625: Sending: 'PUT /A/A HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nValue-generated: |#C$f(J\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 0\r\n\r\n'
+
+2022-03-10 23:37:27.632: Received: 'HTTP/1.1 201 Created\r\nRestler Test\r\n\r\n{"name": "A"}'
+
+2022-03-10 23:37:27.639: Sending: 'POST /fail/3.3/A/\x0bFZC4Lf3/B/0/C/string HTTP/1.1\r\nAccept: application/json\r\nHost: unittest\r\nContent-Type: application/json\r\nAuthorization: valid_unit_test_token\r\nContent-Length: 15\r\n\r\n{"reader": "A"}'
+
+2022-03-10 23:37:27.645: Received: 'HTTP/1.1 405 Method Not Allowed\r\nRestler Test\r\n\r\n{"error": "Method, POST, not supported"}'
+

--- a/restler/unit_tests/restler_user_settings.json
+++ b/restler/unit_tests/restler_user_settings.json
@@ -50,6 +50,7 @@
   "add_fuzzable_dates": true,
   "token_refresh_interval": 60,
   "wait_for_async_resource_creation": false,
+  "custom_value_generators": "c:\\restler\\Compile\\custom_value_generators.py",
   "per_resource_settings": {
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/{recordType}/{relativeRecordSetName}": {
       "producer_timing_delay": 1,

--- a/restler/utils/import_utilities.py
+++ b/restler/utils/import_utilities.py
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""  Primitive types supported by restler. """
+from __future__ import print_function
+import sys
+import os
+import time
+import datetime
+import uuid
+import itertools
+import importlib
+import importlib.util
+import types
+import shutil
+
+def load_module(name, module_file_path):
+    spec = importlib.util.spec_from_file_location(name, module_file_path)
+    module_to_load = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module_to_load)
+
+def import_attr(module_file_path, attr_name):
+    file_name = os.path.basename(module_file_path)
+    module_name = file_name.replace(".py", "")
+
+    # Import the object
+    sys.path.append(os.path.dirname(module_file_path))
+    imported_module = importlib.import_module(module_name)
+    imported_attr = getattr(imported_module, attr_name)
+
+    return imported_attr
+

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -10,6 +10,7 @@ import threading
 import time
 import statistics
 import json
+import types
 from collections import OrderedDict
 from shutil import copyfile
 from collections import namedtuple
@@ -854,17 +855,10 @@ def format_request_block(request_id, request_block, candidate_values_pool):
     elif primitive == "restler_multipart_formdata":
         values = ['_OMITTED_BINARY_DATA_']
         default_val = '_OMITTED_BINARY_DATA_'
-    # Handle custom payload header and query
-    elif (primitive == "restler_custom_payload_header" or\
-          primitive == "restler_custom_payload_query"):
-        current_fuzzable_tag = field_name
-        values = candidate_values_pool.get_candidate_values(primitive, request_id=request_id, tag=current_fuzzable_tag, quoted=quoted)
-        if not isinstance(values, list):
-            values = [values]
-        if len(values) == 1:
-            default_val = values[0]
     # Handle custom payload
-    elif primitive == "restler_custom_payload":
+    elif primitive == "restler_custom_payload" or\
+         primitive == "restler_custom_payload_header" or\
+         primitive == "restler_custom_payload_query":
         current_fuzzable_tag = field_name
         values = candidate_values_pool.get_candidate_values(primitive, request_id=request_id, tag=current_fuzzable_tag, quoted=quoted)
         if not isinstance(values, list):
@@ -879,6 +873,8 @@ def format_request_block(request_id, request_block, candidate_values_pool):
     # Handle all the rest
     else:
         values = candidate_values_pool.get_fuzzable_values(primitive, default_val, request_id, quoted=quoted, examples=examples)
+        if primitives.is_value_generator(values):
+            values = [values]
     return primitive, values, default_val
 
 

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -52,6 +52,9 @@
     <Content Include="baselines\dictionaryTests\quoted_primitives_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="baselines\dictionaryTests\customPayloadDict_ValueGeneratorTemplate.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="baselines\exampleTests\array_example_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/baselines/dictionaryTests/customPayloadDict_ValueGeneratorTemplate.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dictionaryTests/customPayloadDict_ValueGeneratorTemplate.py
@@ -1,0 +1,211 @@
+import typing
+import random
+import time
+import string
+import itertools
+random_seed=time.time()
+print(f"Value generator random seed: {random_seed}")
+random.seed(random_seed)
+
+EXAMPLE_ARG = "examples"
+
+
+def gen_restler_fuzzable_string(**kwargs):
+    example_values=None
+    if EXAMPLE_ARG in kwargs:
+        example_values = kwargs[EXAMPLE_ARG]
+
+    if example_values:
+        for exv in example_values:
+            yield exv
+        example_values = itertools.cycle(example_values)
+
+    i = 0
+    while True:
+        i = i + 1
+        size = random.randint(i, i + 10)
+        if example_values:
+            ex = next(example_values)
+            ex_k = random.randint(1, len(ex) - 1)
+            new_values=''.join(random.choices(ex, k=ex_k))
+            yield ex[:ex_k] + new_values + ex[ex_k:]
+
+        yield ''.join(random.choices(string.ascii_letters + string.digits, k=size))
+        yield ''.join(random.choices(string.printable, k=size)).replace("\r\n", "")
+
+def placeholder_value_generator():
+    while True:
+        yield str(random.randint(-10, 10))
+        yield ''.join(random.choices(string.ascii_letters + string.digits, k=1))
+    
+
+def gen_restler_fuzzable_string_unquoted(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_fuzzable_datetime(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_fuzzable_datetime_unquoted(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_fuzzable_date(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_fuzzable_date_unquoted(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_fuzzable_uuid4(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_fuzzable_uuid4_unquoted(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_fuzzable_int(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_custom_payload__storeProperties_tags(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_custom_payload_code(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_custom_payload_count2(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_custom_payload_message(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_custom_payload_unquoted__storeProperties_tags(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_custom_payload_unquoted_count2(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+
+
+def gen_restler_custom_payload_unquoted_message(**kwargs):
+    example_value=None
+    if EXAMPLE_ARG in kwargs:
+        example_value = kwargs[EXAMPLE_ARG]
+
+    # Add logic here to generate values
+    return placeholder_value_generator()
+    
+value_generators = {
+	"restler_fuzzable_string": gen_restler_fuzzable_string,
+	"restler_fuzzable_string_unquoted": None,
+	"restler_fuzzable_datetime": None,
+	"restler_fuzzable_datetime_unquoted": None,
+	"restler_fuzzable_date": None,
+	"restler_fuzzable_date_unquoted": None,
+	"restler_fuzzable_uuid4": None,
+	"restler_fuzzable_uuid4_unquoted": None,
+	"restler_fuzzable_int": None,
+	"restler_custom_payload": {
+		"/storeProperties/tags": None,
+		"code": None,
+		"count2": None,
+		"message": None,
+	},
+	"restler_custom_payload_unquoted": {
+		"/storeProperties/tags": None,
+		"count2": None,
+		"message": None,
+	},
+}

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -464,6 +464,13 @@ type GrammarDefinition =
 module DynamicObjectNaming =
     let ReplaceTargets = [|"/"; "."; "__"; "{"; "}"; "$"; "-" |]
 
+    /// Returns the string with all characters that are invalid in
+    /// a Python function replaced with 'delimiter'
+    let generatePythonFunctionNameFromString (str:string) delimiter =
+        str.Split(ReplaceTargets, System.StringSplitOptions.None)
+        |> seq
+        |> String.concat delimiter
+
     let generateOrderingConstraintVariableName (sourceRequestId:RequestId) (targetRequestId:RequestId) delimiter =
 
         let sourceEndpointParts = sourceRequestId.endpoint.Split(ReplaceTargets, System.StringSplitOptions.None)

--- a/src/compiler/Restler.Compiler/Workflow.fs
+++ b/src/compiler/Restler.Compiler/Workflow.fs
@@ -20,6 +20,7 @@ module Constants =
     let DependenciesDebugFileName = "dependencies_debug.json"
     let DefaultExampleMetadataFileName = "examples.json"
     let DefaultEngineSettingsFileName = "engine_settings.json"
+    let CustomValueGeneratorTemplateFileName = "custom_value_gen_template.py"
 
 let generatePython grammarOutputDirectoryPath config grammar =
     let codeFile = Path.Combine(grammarOutputDirectoryPath, Constants.DefaultRestlerGrammarFileName)
@@ -209,6 +210,12 @@ let generateGrammarFromSwagger grammarOutputDirectoryPath (swaggerDoc, specMetad
         Microsoft.FSharpLu.Json.Compact.serializeToFile newDictionaryFilePath newDict
     writeDictionary Constants.NewDictionaryFileName newDictionary
 
+    // Also generate a template for input value generator based on the dictionary.
+    let newDictJson = Microsoft.FSharpLu.Json.Compact.serialize newDictionary
+    let customValueGeneratorTemplateFilePath = System.IO.Path.Combine(grammarOutputDirectoryPath, Constants.CustomValueGeneratorTemplateFileName)
+    let templateLines = Restler.CodeGenerator.Python.generateCustomValueGenTemplate newDictJson
+    Microsoft.FSharpLu.File.writeLines customValueGeneratorTemplateFilePath templateLines
+
     // Write the per-resource dictionaries.
     perResourceDictionaries
     |> Map.toSeq
@@ -275,5 +282,4 @@ let generateRestlerGrammar swaggerDoc (config:Config) =
     logTimingInfo "Generating python grammar..."
     generatePython grammarOutputDirectoryPath config grammar
     logTimingInfo "Done generating python grammar."
-
     printfn "Workflow completed.  See %s for REST-ler grammar." grammarOutputDirectoryPath


### PR DESCRIPTION
This change enables values to be generated dynamically for fuzzable
and custom primitives in RESTler.

For every combination (up to 'max_combinations'), if a custom generator
is available for a fuzzable or custom primitive, RESTler will use it to
generate a new value instead of using values from the static dictionary.

The user can add value generators in python corresponding to fuzzable and
custom primitives (see documentation for the list of supported primitives).
RESTler fetches the generators from a dictionary with the same structure
as the custom values dictionary.  The generator dictionary must be defined in a
python file and specified in the engine settings (see documentation).
A template file with placeholders for all possible generators corresponding
to the dictionary is generated when compiling the spec.

**Implementation notes:**
When RESTler generates sequences of requests, the prefix of the sequence
(all requests up to the last one) contains requests that have been
previously successfully executed.  In order to send the request with
the same set of values in the presence of dynamic generators, the
fuzzable values previously sent are cached and simply plugged in
when a sequence is being re-rendered.

There was some complexity required in integrating with 'render_iter',
which to date has been stateless - if skip=N was specified, it simply
re-generated all the combinations in order to get to N.
1) The same value needs to be used for re-rendering sequences.
This is solved as noted above, by saving the previously rendered values.

2) Since it's not clear how generated values should be combined with others for a given schema and
primitive type, a simple solution was chosen to fetch a new value any time it is needed.
This ensures that all the static values will be combined as usual up to 'max_combinations',
and the necessary generated values will be plugged in as needed.
For example, if there are two fuzzable strings in the request,
and 3 'restler_fuzzable_string' values in the static dictionary,
a total of 9 combinations will be generated.
If these same 3 values are returned in a value generator instead,
only 3 combinations will be tested ((v1,v1), (v2,v2), and (v3, v3)).

3) Before testing, RESTler iterates to see how many total combinations there are.
The state of any cached values, including the value generators, must be reset after this initial count to make sure all of the values intended to be tested are used.

Because requests are deep copied when saving rendered sequences,
special logic needed to be added to exclude the generators and associated data from being copied.

Testing:
- Manual testing with demo_server
- New compiler baseline test for the generated dictionary
- Engine unit test to confirm sequence re-rendering works
correctly with the same values when values are dynamically generated,
the number of combinations is correct with vs. without value generators (including in main.txt), both in smoke test and 'test-all-combinations' modes.