### PR TITLE
Include messages in F# exceptions.

### DIFF
--- a/src/compiler/Restler.Compiler/CodeGenerator.fs
+++ b/src/compiler/Restler.Compiler/CodeGenerator.fs
@@ -13,8 +13,10 @@ let TAB = @"    "
 let RETURN = @"\r\n"
 let SPACE = @" "
 
+type UnsupportedType (msg:string) =
+    inherit Exception(msg)
+
 exception UnsupportedAccessPath
-exception UnsupportedType of string
 
 module Types =
     type RequestPrimitiveTypeData =

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -22,7 +22,8 @@ open Restler.Utilities.Logging
 open Restler.Utilities.Operators
 open Restler.XMsPaths
 
-exception UnsupportedParameterSerialization of string
+type UnsupportedParameterSerialization (msg:string) =
+    inherit Exception(msg)
 
 module Types =
     /// A configuration associated with a single Swagger document

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -14,7 +14,9 @@ open Restler.ApiResourceTypes
 open Restler.DependencyAnalysisTypes
 open Restler.Annotations
 
-exception UnsupportedType of string
+type UnsupportedType (msg:string) =
+    inherit Exception(msg)
+
 exception InvalidSwaggerEndpoint
 
 /// Determines whether a producer is valid for a given consumer.

--- a/src/compiler/Restler.Compiler/Dictionary.fs
+++ b/src/compiler/Restler.Compiler/Dictionary.fs
@@ -8,7 +8,8 @@ open Restler.ApiResourceTypes
 open Restler.Utilities.Operators
 open Restler.AccessPaths
 
-exception InvalidMutationsDictionaryFormat of string
+type InvalidMutationsDictionaryFormat (msg:string) =
+    inherit System.Exception(msg)
 
 type MutationsDictionary =
     {

--- a/src/compiler/Restler.Compiler/Swagger.fs
+++ b/src/compiler/Restler.Compiler/Swagger.fs
@@ -6,9 +6,12 @@ module Restler.Swagger
 open Microsoft.FSharpLu.File
 open NSwag
 
-exception UnexpectedSwaggerParameter of string
-exception UnsupportedParameterSchema of string
-exception ParameterTypeNotFound of string
+type UnexpectedSwaggerParameter (msg:string) =
+    inherit System.Exception(msg)
+type UnsupportedParameterSchema (msg:string) =
+    inherit System.Exception(msg)
+type ParameterTypeNotFound (msg:string) =
+    inherit System.Exception(msg)
 
 let at x = Async.AwaitTask(x)
 

--- a/src/compiler/Restler.Compiler/SwaggerVisitors.fs
+++ b/src/compiler/Restler.Compiler/SwaggerVisitors.fs
@@ -10,11 +10,17 @@ open Restler.Utilities.Operators
 open Newtonsoft.Json.Linq
 open NJsonSchema
 
-exception UnsupportedType of string
-exception NullArraySchema of string
-exception UnsupportedArrayExample of string
-exception UnsupportedRecursiveExample of string
+type UnsupportedType (msg:string) =
+    inherit Exception(msg)
 
+type NullArraySchema (msg:string) =
+    inherit Exception(msg)
+
+type UnsupportedArrayExample (msg:string) =
+    inherit Exception(msg)
+
+type UnsupportedRecursiveExample (msg:string) =
+    inherit Exception(msg)
 
 module SchemaUtilities =
 


### PR DESCRIPTION
Modify the custom exception types to inherit from System.Exception so the message is reported
in call stacks for unhandled exceptions.