### PR TITLE
Fix default argument for python path

### DIFF
--- a/build-restler.py
+++ b/build-restler.py
@@ -201,8 +201,8 @@ if __name__ == '__main__':
                         help='The build configuration',
                         type=str, default='release', required=False)
     parser.add_argument('--python_path',
-                        help='The path or python command to use for compilation. (Default: python)',
-                        type=str, default='python', required=False)
+                        help='The path or python command to use for compilation. (Default: python command that initiated this script)',
+                        type=str, default=sys.executable, required=False)
     parser.add_argument('--compile_type',
                         help='all: driver/compiler & engine as python files\n'
                         'engine: engine only, as python files\n'


### PR DESCRIPTION
The `build-restler.py` script fails when not using the default `python`-executable.  
E.g.  
```console
$ python3 ./build-restler.py --dest_dir $PWD/restler_bin
[...]
Testing compilation of Python files...
Copying all python files...
Build failed!
Exit code: 1
Removing engine compilation build directory...
```

Currently the only way to resolve this is by manually setting the correct `--python_path python3`, which is error-prone.

This PR resolves the issue by setting the default of `--python_path` to the used executable to initiate the script.

If for whatever reason people wish to use a different `--python_path` for initiating the build script and compilation internally, they can still overwrite this default as before.