### PR TITLE
Fix out of memory for large OpenAPI spec.

### DIFF
--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -1871,12 +1871,14 @@ let writeDependencies dependenciesFilePath dependencies (unresolvedOnly:bool) =
                    )
         |> Map.ofSeq
 
-    Microsoft.FSharpLu.Json.Compact.serializeToFile dependenciesFilePath grouped
+    Restler.Utilities.Stream.serializeToFile dependenciesFilePath grouped
 
 let writeDependenciesDebug dependenciesFilePath dependencies =
+    Restler.Utilities.Stream.serializeToFile dependenciesFilePath dependencies
 
-    Microsoft.FSharpLu.Json.Compact.serializeToFile dependenciesFilePath dependencies
-    // The below statement is present as an assertion, to check for deserialization issues for
-    // specific grammars.
-    Microsoft.FSharpLu.Json.Compact.deserializeFile<ProducerConsumerDependency list> dependenciesFilePath
+    // The below statement is present as an assertion, to check for deserialization issues
+#if TEST_GRAMMAR
+    use f = System.IO.File.OpenRead(dependenciesFilePath)
+    Microsoft.FSharpLu.Json.Compact.deserializeStream<ProducerConsumerDependency list> f
     |> ignore
+#endif

--- a/src/compiler/Restler.Compiler/Utilities.fs
+++ b/src/compiler/Restler.Compiler/Utilities.fs
@@ -93,3 +93,10 @@ module Stream =
                 ()
             else
                 base.Write(s, offset, count)
+
+    let serializeToFile filePath data = 
+        use fs = new FileStreamWithoutPreamble(filePath, System.IO.FileMode.Create)
+        Microsoft.FSharpLu.Json.Compact.serializeToStream fs data
+        fs.Flush()
+        fs.Dispose()
+

--- a/src/compiler/Restler.Compiler/Workflow.fs
+++ b/src/compiler/Restler.Compiler/Workflow.fs
@@ -186,17 +186,15 @@ let generateGrammarFromSwagger grammarOutputDirectoryPath (swaggerDoc, specMetad
                         userSpecifiedExamples
 
     let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, Constants.DefaultJsonGrammarFileName)
+    Restler.Utilities.Stream.serializeToFile grammarFilePath grammar
 
-    use fs = new Restler.Utilities.Stream.FileStreamWithoutPreamble(grammarFilePath, IO.FileMode.Create)
-    Microsoft.FSharpLu.Json.Compact.serializeToStream fs grammar
-    fs.Flush()
-    fs.Dispose()
     // The below statement is present as an assertion, to check for deserialization issues for
     // specific grammars.
-
-    let ignoreStream = new System.IO.MemoryStream()
-    Microsoft.FSharpLu.Json.Compact.deserializeStream<GrammarDefinition>(ignoreStream)
+#if TEST_GRAMMAR
+    use f = System.IO.File.OpenRead(grammarFilePath)
+    Microsoft.FSharpLu.Json.Compact.deserializeStream<GrammarDefinition> f
     |> ignore
+#endif
 
     // If examples were discovered, create a new examples file
     if config.DiscoverExamples then


### PR DESCRIPTION
The stream-based serialization was not implemented for every output file.
This change modifies all output files that may be large to be written
via serializing To/FromStream.

Testing: manual testing on the specification that found the issue -
https://github.com/microsoftgraph/msgraph-metadata/tree/master/openapi/v1.0