### PR TITLE
Cover additional case with x-ms-path query parameters.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths.json
@@ -40,6 +40,12 @@
             "name": "resourceName",
             "type": "string",
             "required": true
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "type": "string",
+            "required": true
           }
         ],
         "responses": {

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -650,15 +650,22 @@ module private XMsPaths =
                                      (endpointQueryPart:string) =
         // Filter any query parameters that are part of a path
         // declared in x-ms-paths
+        // param1=customer&param2={id}
+        // Note: some specifications declare 'param1' and 'param2' in query parameters, while others declare 'id'.
+        // The code below filters out all of them, so they do not appear twice in the grammar.
         let endpointQueryParameterNames =
             endpointQueryPart.Split("&")
             |> Array.choose (fun x ->
                                  let splitParam = x.Split("=", StringSplitOptions.RemoveEmptyEntries)
                                  match splitParam with
                                  | [|name ; paramValue|] ->
+
                                     if paramValue.StartsWith("{") then
                                         Some (Parameters.getPathParameterName paramValue)
-                                    else None
+                                    else
+                                        Some name
+                                 | [|name|] ->
+                                    Some name
                                  | _ -> None
                              )
 


### PR DESCRIPTION
In some specifications, the query parameter names that are part of the path
are declared.  For example, for the endpoint /customer&operation=create, the
'operation' is declared as a query parameter.  This was not previously handled -
RESTler now filters these out of the query parameters it appends after the path.