### PR TITLE
Fix examples config for x-ms-paths.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -173,7 +173,10 @@
     <Content Include="swagger\schemaTests\xMsPaths_annotations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="swagger\dictionaryTests\customPayloadSwagger.json">
+	  <Content Include="swagger\schemaTests\xMsPaths_examples.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\dictionaryTests\customPayloadSwagger.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\dictionaryTests\customPayloadDict.json">

--- a/src/compiler/Restler.Compiler.Test/SchemaTests.fs
+++ b/src/compiler/Restler.Compiler.Test/SchemaTests.fs
@@ -44,6 +44,7 @@ module ApiSpecSchema =
             let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\xMsPaths.json")
             let dictionaryFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\xMsPaths_dict.json")
             let annotationsFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\xMsPaths_annotations.json")
+            let exampleConfigFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\xMsPaths_examples.json")
             let config = { Restler.Config.SampleConfig with
                              IncludeOptionalParameters = true
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
@@ -52,6 +53,8 @@ module ApiSpecSchema =
                              SwaggerSpecFilePath = Some [specFilePath]
                              CustomDictionaryFilePath = Some dictionaryFilePath
                              AnnotationFilePath = Some annotationsFilePath
+                             ExampleConfigFilePath = Some exampleConfigFilePath
+                             UseHeaderExamples = Some true
                          }
             Restler.Workflow.generateRestlerGrammar None config
 

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
@@ -61,6 +61,45 @@
       ],
       "headerParameters": [
         [
+          "Examples",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Constant": [
+                        "String",
+                        "2020-03-02"
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              },
+              {
+                "name": "resource-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Constant": [
+                        "String",
+                        "1.2.3.4"
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
           "Schema",
           {
             "ParameterList": [
@@ -82,6 +121,22 @@
                           ]
                         },
                         "defaultValue": "2020-03-01"
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              },
+              {
+                "name": "resource-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
                       }
                     },
                     "isRequired": true,
@@ -225,6 +280,22 @@
                           ]
                         },
                         "defaultValue": "2020-03-01"
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              },
+              {
+                "name": "resource-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
                       }
                     },
                     "isRequired": true,

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.py
@@ -22,20 +22,25 @@ request = requests.Request([
     primitives.restler_static_string("Accept: application/json\r\n"),
     primitives.restler_static_string("Host: \r\n"),
     primitives.restler_static_string("api-version: "),
-    primitives.restler_fuzzable_group("api-version", ['2020-03-01']  ,quoted=False),
+    primitives.restler_static_string("2020-03-02"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("resource-version: "),
+    primitives.restler_static_string("1.2.3.4"),
     primitives.restler_static_string("\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-
+    
     {
+
         'post_send':
         {
-
+            
             'dependencies':
             [
                 __resourceName__type_folder_put_resourceName_path.writer()
             ]
         }
+
     },
 
 ],
@@ -57,18 +62,23 @@ request = requests.Request([
     primitives.restler_static_string("api-version: "),
     primitives.restler_fuzzable_group("api-version", ['2020-03-01']  ,quoted=False),
     primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("resource-version: "),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string("\r\n"),
     primitives.restler_refreshable_authentication_token("authentication_token_tag"),
     primitives.restler_static_string("\r\n"),
-
+    
     {
+
         'post_send':
         {
-
+            
             'dependencies':
             [
                 __resourceName__type_file_put_resourceName_path.writer()
             ]
         }
+
     },
 
 ],

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths.json
@@ -46,6 +46,12 @@
             "name": "type",
             "type": "string",
             "required": true
+          },
+          {
+            "in": "header",
+            "name": "resource-version",
+            "type": "string",
+            "required": true
           }
         ],
         "responses": {
@@ -65,6 +71,12 @@
           {
             "in": "path",
             "name": "resourceName",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "header",
+            "name": "resource-version",
             "type": "string",
             "required": true
           }

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths_examples.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths_examples.json
@@ -1,0 +1,14 @@
+{
+  "paths": {
+    "/{resourceName}?type=folder": {
+      "put": {
+        "1": {
+          "parameters": {
+            "api-version":  "2020-03-02",
+            "resource-version": "1.2.3.4"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -1093,7 +1093,14 @@ let generateRequestGrammar (swaggerDocs:Types.ApiSpecFuzzingConfig list)
                         let useExamples =
                             usePathExamples || useBodyExamples || useQueryExamples || useHeaderExamples
                         if useExamples || config.DiscoverExamples then
-                            let exampleRequestPayloads = getExampleConfig (ep,m.Key) m.Value config.DiscoverExamples
+                            // The original endpoint must be used to find the example
+                            let exampleConfigEndpoint =
+                                match xMsPath with
+                                | None -> ep
+                                | Some xMsPath -> xMsPath.getEndpoint()
+                            let exampleRequestPayloads = getExampleConfig (exampleConfigEndpoint,m.Key)
+                                                                          m.Value
+                                                                          config.DiscoverExamples
                                                                           config.ExamplesDirectory
                                                                           userSpecifiedExamples
                                                                           (config.UseAllExamplePayloads |> Option.defaultValue false)


### PR DESCRIPTION
Examples were not being found for paths in x-ms-paths format.  This bug was present
since the original implementation of x-ms-paths.

Testing: extended x-ms-path unit test to cover examples.