### PR TITLE
Fix annotation matching logic to check the endpoint and method.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -197,10 +197,16 @@
     <Content Include="swagger\DependencyTests\header_deps.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="swagger\DependencyTests\ordering_test.json">
+    <Content Include="swagger\DependencyTests\simple_crud_api.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="swagger\DependencyTests\ordering_test_annotations.json">
+	  <Content Include="swagger\DependencyTests\simple_crud_api_annotations.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\DependencyTests\ordering_test.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\DependencyTests\ordering_test_annotations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\DependencyTests\header_deps_annotations.json">

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/simple_crud_api.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/simple_crud_api.json
@@ -1,0 +1,72 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "host": "localhost:8888",
+  "info": {
+    "description": "Small example for per-request type annotations.",
+    "title": "The title.",
+    "version": "1.0.0"
+  },
+  "definitions": {
+    "Product": {
+      "properties": {
+        "version": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "paths": {
+    "/products": {
+      "post": {
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+
+          }
+        }
+      }
+    },
+    "/services": {
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "product-ver",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "product-ver",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+
+    }
+
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/simple_crud_api_annotations.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/simple_crud_api_annotations.json
@@ -1,0 +1,12 @@
+{
+  "x-restler-global-annotations": [
+    {
+      "producer_endpoint": "/products",
+      "producer_method": "POST",
+      "producer_resource_name": "version",
+      "consumer_endpoint": "/services",
+      "consumer_method": "PUT",
+      "consumer_param": "product-ver"
+    }
+  ]
+}

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -776,7 +776,12 @@ let findAnnotation globalAnnotations
                    (resourceName:string)
                    (resourceAccessPath:AccessPath) =
 
-    let annotationMatches consumerParameter resourceName resourceAccessPath exceptConsumers =
+    let annotationMatches consumerId consumerParameter resourceName resourceAccessPath exceptConsumers =
+        let consumerIdMatches =
+            match consumerId with
+            | None -> true
+            | Some consumerId ->
+                consumerId = requestId
         let consumerParameterMatches =
             match consumerParameter with
             | None -> false
@@ -790,11 +795,11 @@ let findAnnotation globalAnnotations
             | None -> true
             | Some exceptConsumers ->
                 not (exceptConsumers |> Seq.exists (fun ec -> ec = requestId))
-        consumerParameterMatches && requestIdMatches
+        consumerIdMatches && consumerParameterMatches && requestIdMatches
 
     let globalAnnotation =
         match globalAnnotations
-              |> Seq.filter (fun a -> annotationMatches a.consumerParameter resourceName resourceAccessPath a.exceptConsumerId
+              |> Seq.filter (fun a -> annotationMatches a.consumerId a.consumerParameter resourceName resourceAccessPath a.exceptConsumerId
                              ) with
         | g when g |> Seq.isEmpty -> None
         | g ->
@@ -809,7 +814,7 @@ let findAnnotation globalAnnotations
 
     let localAnnotation =
         match localAnnotations
-              |> Seq.filter (fun a -> annotationMatches a.consumerParameter resourceName resourceAccessPath a.exceptConsumerId
+              |> Seq.filter (fun a -> annotationMatches a.consumerId a.consumerParameter resourceName resourceAccessPath a.exceptConsumerId
                              ) with
         | g when g |> Seq.isEmpty -> None
         | g ->


### PR DESCRIPTION
Annotations were assigned globally even when a specific ```consumer_endpoint``` and ```consumer_method``` was specified.

Testing: added unit test.