### PR TITLE
Include all parameters in an example if specified.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -56,11 +56,12 @@ module CodeGenerator =
                 [
                     Method OperationMethod.Get
                     Path pathPayload
-                    QueryParameters (ParameterList [{ name = "page" ; payload = q1 ; serialization = None }
+                    QueryParameters (ParameterPayloadSource.Schema,
+                                     ParameterList [{ name = "page" ; payload = q1 ; serialization = None }
                                                     { name = "payload"; payload = q2; serialization = None} ])
-                    Body (ParameterList  [{ name = "theBody" ; payload = b1 ; serialization = None}])
+                    Body (ParameterPayloadSource.Schema,(ParameterList  [{ name = "theBody" ; payload = b1 ; serialization = None}]))
                     RequestElement.HttpVersion "1.1"
-                    HeaderParameters (ParameterList [])
+                    HeaderParameters (ParameterPayloadSource.Schema,ParameterList [])
                     Headers [("Accept", "application/json")
                              ("Host", "fromSwagger")
                              ("Content-Type", "application/json")]
@@ -103,7 +104,7 @@ module CodeGenerator =
             let l2 = LeafNode p2
             let par = InternalNode (r, [l1 ; l2])
 
-            let result = Restler.CodeGenerator.Python.generatePythonParameter true ParameterKind.Body { name = "theBody"; payload = par; serialization = None }
+            let result = Restler.CodeGenerator.Python.generatePythonParameter true ParameterPayloadSource.Schema ParameterKind.Body { name = "theBody"; payload = par; serialization = None }
 
             let hasRegion = result |> Seq.tryFind (fun s -> s = (Restler_static_string_constant "\"region\":"))
             Assert.True(hasRegion.IsSome, "region not found")

--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -506,6 +506,30 @@ module Examples =
             Assert.False(grammar.Contains("ddd"))
 
 
+        /// Test that when optional parameters are excluded, they are still present if added with an example payload.
+        [<Fact>]
+        let ``examples with optional parameters`` () =
+            let grammarOutputDirectoryPath = ctx.testRootDirPath
+            let config = { Restler.Config.SampleConfig with
+                             IncludeOptionalParameters = false
+                             GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
+                             ResolveBodyDependencies = false
+                             UseQueryExamples = Some true
+                             DataFuzzing = true
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\exampleTests\optional_params.json"))]
+                         }
 
+            let exampleConfigFile = {
+                filePath = Path.Combine(Environment.CurrentDirectory, @"swagger\exampleTests\optional_params_example.json")
+                exactCopy = false
+            }
+
+            let testConfig = { config with ExampleConfigFiles = Some [ {exampleConfigFile with exactCopy = false }] }
+            Restler.Workflow.generateRestlerGrammar None testConfig
+
+            let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
+            let grammar = File.ReadAllText(grammarFilePath)
+            Assert.True(grammar.Contains("required-param"))
+            Assert.True(grammar.Contains("optional-param"))
 
         interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -230,7 +230,13 @@
     <Content Include="swagger\DependencyTests\nested_objects_naming.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="swagger\get_path_dependencies.json">
+	  <Content Include="swagger\ExampleTests\optional_params.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\ExampleTests\optional_params_example.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\get_path_dependencies.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\put_createorupdate.json">

--- a/src/compiler/Restler.Compiler.Test/swagger/exampleTests/optional_params.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/exampleTests/optional_params.json
@@ -1,0 +1,40 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "host": "localhost:8888",
+  "info": {
+    "description": "Simple API with required and optional parameters.",
+    "title": "The title.",
+    "version": "1.0.0"
+  },
+  "definitions": {
+  },
+  "paths": {
+    "/products": {
+      "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "required-param",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "optional-param",
+            "type": "string",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/exampleTests/optional_params_example.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/exampleTests/optional_params_example.json
@@ -1,0 +1,14 @@
+{
+  "paths": {
+    "/products": {
+      "post": {
+        "1": {
+          "parameters": {
+            "required-param": "a",
+            "optional-param": "b"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -401,9 +401,9 @@ type RequestElement =
     | Method of OperationMethod
     | BasePath of string
     | Path of FuzzingPayload list
-    | QueryParameters of RequestParametersPayload
-    | HeaderParameters of RequestParametersPayload
-    | Body of RequestParametersPayload
+    | QueryParameters of ParameterPayloadSource * RequestParametersPayload
+    | HeaderParameters of ParameterPayloadSource * RequestParametersPayload
+    | Body of ParameterPayloadSource * RequestParametersPayload
     | Token of string
     | RefreshableToken
     | Headers of (string * string) list


### PR DESCRIPTION
Previously, if filtering optional parameters was specified, they were filtered out of the example.
However, examples should be used as-is.  
For example, the user may fix a case where the specification incorrectly marks a parameter as optional
by adding an example file (in cases where the specification cannot be fixed right away).

Testing: added unit test.