### PR TITLE
Fix incorrectly compiled x-ms-paths empty path.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
@@ -2,6 +2,108 @@
   "Requests": [
     {
       "id": {
+        "endpoint": "/?operation=list",
+        "xMsPath": {
+          "pathPart": "/",
+          "queryPart": "operation=list"
+        },
+        "method": "Put"
+      },
+      "method": "Put",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "?"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            ""
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "operation=list"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": {
+                          "Enum": [
+                            "api-version",
+                            "String",
+                            [
+                              "2020-03-01"
+                            ],
+                            null
+                          ]
+                        },
+                        "defaultValue": "2020-03-01"
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
         "endpoint": "/{resourceName}?type=folder",
         "xMsPath": {
           "pathPart": "/{resourceName}",

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.py
@@ -10,6 +10,27 @@ __resourceName__type_folder_put_resourceName_path = dependencies.DynamicVariable
 
 __resourceName__type_file_put_resourceName_path = dependencies.DynamicVariable("__resourceName__type_file_put_resourceName_path")
 req_collection = requests.RequestCollection([])
+# Endpoint: /?operation=list, method: Put
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("operation=list"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("api-version: "),
+    primitives.restler_fuzzable_group("api-version", ['2020-03-01']  ,quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/?operation=list"
+)
+req_collection.add_request(request)
+
 # Endpoint: /{resourceName}?type=folder, method: Put
 request = requests.Request([
     primitives.restler_static_string("PUT "),

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/xMsPaths.json
@@ -29,6 +29,20 @@
   ],
   "paths": {},
   "x-ms-paths": {
+    "/?operation=list": {
+      "put": {
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/{resourceName}?type=folder": {
       "put": {
         "parameters": [
@@ -112,7 +126,7 @@
             "required": true
           },
           {
-            $ref: "#/parameters/ApiVersionParameter"
+            "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {

--- a/src/compiler/Restler.Compiler/CodeGenerator.fs
+++ b/src/compiler/Restler.Compiler/CodeGenerator.fs
@@ -467,8 +467,8 @@ let generatePythonFromRequestElement includeOptionalParameters (requestId:Reques
                     ]
                 )
         // Handle the case of '/'
-        if x |> List.isEmpty then
-            [ Restler_static_string_constant "/" ]
+        if x |> List.isEmpty || queryStartIndex = 0 then
+            [ Restler_static_string_constant "/" ] @ x
         else
             x
     | HeaderParameters (parameterSource, hp) ->


### PR DESCRIPTION
The starting slash was missing.  This bug was already fixed for regular paths, but
needed to be handled separately for x-ms-paths.

Testing: added unit test.