### PR TITLE
Fix exactCopy example with __body__

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -58,7 +58,10 @@
     <Content Include="baselines\exampleTests\array_example_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="baselines\dependencyTests\path_in_dictionary_payload_grammar.py">
+	  <Content Include="baselines\exampleTests\body_param_exactCopy_grammar.py">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="baselines\dependencyTests\path_in_dictionary_payload_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="baselines\dependencyTests\header_response_writer_grammar.py">
@@ -234,6 +237,12 @@
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
 	  <Content Include="swagger\ExampleTests\optional_params_example.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\ExampleTests\body_param.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\ExampleTests\body_param_example.json">
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
 	  <Content Include="swagger\get_path_dependencies.json">

--- a/src/compiler/Restler.Compiler.Test/baselines/exampleTests/body_param_exactCopy_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/exampleTests/body_param_exactCopy_grammar.py
@@ -1,0 +1,29 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+req_collection = requests.RequestCollection([])
+# Endpoint: /products, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("products"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("<xml><label>banana</label></xml>"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/products"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/swagger/exampleTests/body_param.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/exampleTests/body_param.json
@@ -1,0 +1,51 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "host": "localhost:8888",
+  "info": {
+    "description": "Simple API with required and optional parameters.",
+    "title": "The title.",
+    "version": "1.0.0"
+  },
+  "definitions": {
+    "Product": {
+      "xml": {
+        "name": "Product"
+      },
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "expiration": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    }
+  },
+  "paths": {
+    "/products": {
+      "post": {
+        "parameters": [
+          {
+            "name": "orderDetails",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          }
+
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/exampleTests/body_param_example.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/exampleTests/body_param_example.json
@@ -1,0 +1,13 @@
+{
+  "paths": {
+    "/products": {
+      "post": {
+        "1": {
+          "parameters": {
+            "__body__": "<xml><label>banana</label></xml>"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -296,12 +296,19 @@ module private Parameters =
                                 if examplePayload.exactCopy then
                                     let payload =
                                         let primitiveType =
-                                            match payloadValue.Type with
-                                            | JTokenType.Array
-                                            | JTokenType.Object ->
+                                            // If the example is for the body, it should
+                                            // be treated as an object.  This covers cases when
+                                            // the example is for a content type other than json, so it
+                                            // needs to be provided as a string in the example file.
+                                            if declaredParameter.Kind = OpenApiParameterKind.Body then
                                                 PrimitiveType.Object
-                                            | _ ->
-                                                PrimitiveType.String
+                                            else
+                                                match payloadValue.Type with
+                                                | JTokenType.Array
+                                                | JTokenType.Object ->
+                                                    PrimitiveType.Object
+                                                | _ ->
+                                                    PrimitiveType.String
                                         let formattedPayloadValue = GenerateGrammarElements.formatJTokenProperty primitiveType payloadValue
                                         Constant (primitiveType, formattedPayloadValue)
 

--- a/src/compiler/Restler.Compiler/SwaggerVisitors.fs
+++ b/src/compiler/Restler.Compiler/SwaggerVisitors.fs
@@ -355,7 +355,9 @@ module SwaggerVisitors =
             | PrimitiveType.String
             | PrimitiveType.DateTime
             | PrimitiveType.Enum (_, PrimitiveType.String, _, _)
-            | PrimitiveType.Uuid ->
+            | PrimitiveType.Uuid
+            // Special case: non-Json bodies (e.g. text, xml) should not be quoted
+            | PrimitiveType.Object when (rawValue.[0] = ''' || rawValue.[0] =  '"') ->
                 // Remove the start and end quotes, which are preserved with 'Formatting.None'.
                 if rawValue.Length > 1 then
                     match rawValue.[0], rawValue.[rawValue.Length-1] with


### PR DESCRIPTION
The body was being put in quotes -
it needs to be treated like an object instead of a string constant.

Testing: added unit test.