### PR TITLE
Resolve the schema specified in additionalProperties.

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -148,7 +148,10 @@
     <Content Include="swagger\dictionaryTests\dict.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="swagger\schemaTests\swagger_escape_characters.json">
+    <Content Include="swagger\schemaTests\additionalProperties.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+	<Content Include="swagger\schemaTests\swagger_escape_characters.json">
 	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</Content>
     <Content Include="swagger\schemaTests\requiredHeader.yml">

--- a/src/compiler/Restler.Compiler.Test/SchemaTests.fs
+++ b/src/compiler/Restler.Compiler.Test/SchemaTests.fs
@@ -153,4 +153,21 @@ module ApiSpecSchema =
                     Assert.True(grammar.Contains(objectName))
                     Assert.False(grammar.Contains(nextObjectName))
 
+        [<Fact>]
+        let ``additionalProperties schema`` () =
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\additionalProperties.yml")
+            let config = { Restler.Config.SampleConfig with
+                                IncludeOptionalParameters = true
+                                GrammarOutputDirectoryPath = Some ctx.testRootDirPath
+                                ResolveBodyDependencies = true
+                                ResolveQueryDependencies = true
+                                SwaggerSpecFilePath = Some [specFilePath]
+                         }
+            Restler.Workflow.generateRestlerGrammar None config
+            let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
+            let grammar = File.ReadAllText(grammarOutputFilePath)
+            let expectedProperties = ["supiRanges"; "groupId"; "start"; "end"]
+            for ep in expectedProperties do
+                Assert.True(grammar.Contains(sprintf "\"%s\":" ep))
+
         interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/additionalProperties.yml
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/additionalProperties.yml
@@ -1,0 +1,71 @@
+openapi: 3.0.3
+info:
+  title: example api
+  version: 1.2.3
+paths:
+  "/test_additionalProperties":
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/UdrInfo'
+              minProperties: 1
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    SupiRange:
+      example:
+        start: start
+        pattern: pattern
+        end: end
+      properties:
+        start:
+          pattern: ^[0-9]+$
+          type: string
+        end:
+          pattern: ^[0-9]+$
+          type: string
+        pattern:
+          type: string
+      type: object
+    UdrInfo:
+      example:
+        supportedDataSets:
+        - null
+        - null
+        groupId: groupId
+        externalGroupIdentifiersRanges:
+        - start: start
+          pattern: pattern
+          end: end
+        - start: start
+          pattern: pattern
+          end: end
+        supiRanges:
+        - start: start
+          pattern: pattern
+          end: end
+        - start: start
+          pattern: pattern
+          end: end
+        gpsiRanges:
+        - start: start
+          pattern: pattern
+          end: end
+        - start: start
+          pattern: pattern
+          end: end
+      properties:
+        groupId:
+          type: string
+        supiRanges:
+          items:
+            $ref: '#/components/schemas/SupiRange'
+          minItems: 1
+          type: array
+      type: object


### PR DESCRIPTION
This update generates the body payload with all of the available properties specified explicitly in the additional properties schema, if present.

This unblocks the incorrect payload generated as described in #330.