### PR TITLE
More robust python grammar generation from the engine

### DIFF
--- a/restler/engine/core/preprocessing.py
+++ b/restler/engine/core/preprocessing.py
@@ -72,7 +72,10 @@ def create_fuzzing_req_collection(path_regex):
 
     return fuzz_reqs
 
-def _set_schemas(examples: RequestExamples, body_schema: BodySchema, query_schema: QueryList, headers_schema: HeaderList, method: str, endpoint: str):
+
+def _set_method_endpoint_schemas(examples: RequestExamples, body_schema: BodySchema, query_schema: QueryList,
+                 headers_schema: HeaderList, method: str, endpoint: str,
+                 req_collection=None):
     """ Assigns a specified RequestExamples object to the matching
     request in the RequestCollection
 
@@ -80,6 +83,9 @@ def _set_schemas(examples: RequestExamples, body_schema: BodySchema, query_schem
     @param body_schema: The BodySchema object to set
     @param method: The request's method
     @param endpoint: The request's endpoint
+    @param req_collection: The request collection to which the json schema corresponds.
+                           If None, use the global request collection.
+    @type  req_collection: RequestCollection
 
     @return: None
 
@@ -87,11 +93,11 @@ def _set_schemas(examples: RequestExamples, body_schema: BodySchema, query_schem
     def _print_req_not_found():
         logger.write_to_main(
             "Request from grammar does not exist in the Request Collection!\n"
-            f"{method} {endpoint}\n",\
+            f"{method} {endpoint}\n",
             print_to_console=True
         )
 
-    request_collection = GrammarRequestCollection().request_id_collection
+    request_collection = GrammarRequestCollection().request_id_collection if req_collection is None else req_collection
 
     hex_def = str_to_hex_def(endpoint)
     # Find the request's endpoint in the request collection
@@ -120,12 +126,16 @@ def _set_schemas(examples: RequestExamples, body_schema: BodySchema, query_schem
         # Failed to find request in the request collection
         _print_req_not_found()
 
-def parse_grammar_schema(schema_json):
+def parse_grammar_schema(schema_json, req_collection=None):
     """ Parses the grammar.json file for examples and body schemas and sets the
     examples for each matching request in the RequestCollection
 
     @param schema_json: The json schema to parse for examples
     @type  schema_json: Json
+
+    @param req_collection: The request collection to which the json schema corresponds.
+                           If None, use the global request collection.
+    @type  req_json: RequestCollection
 
     @return: False if there was an exception while parsing the examples
     @rtype : Bool
@@ -166,7 +176,8 @@ def parse_grammar_schema(schema_json):
 
             if request_examples or body_schema or \
                 (headers_schema is not None) or (query_schema is not None):
-                _set_schemas(request_examples, body_schema, query_schema, headers_schema, method, endpoint)
+                _set_method_endpoint_schemas(request_examples, body_schema, query_schema, headers_schema, method,
+                                             endpoint, req_collection=req_collection)
 
         return True
     except ValueError as err:

--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -1157,7 +1157,7 @@ class Request(object):
 
         # Get the required header blocks that should always be present
         # These special headers are not fuzzed, and should not be replaced
-        skipped_headers_str = ["Accept", "Host", "Content-Type"]
+        skipped_headers_str = ["Accept", "Host"]
         required_header_blocks = []
         append_header = False
         for line in old_request.definition[header_start_index : header_end_index]:

--- a/restler/engine/fuzzing_parameters/body_schema.py
+++ b/restler/engine/fuzzing_parameters/body_schema.py
@@ -121,6 +121,15 @@ class BodySchema():
         """
         return self._schema.get_blocks(self._config)
 
+    def get_original_blocks(self, config) -> list:
+        """ Returns the request blocks exactly as they were
+            defined in the original grammar.
+
+        @return: The request blocks for this schema
+        @rtype : List[str]
+        """
+        return self._schema.get_original_blocks(config)
+
     def get_signature(self) -> str:
         """ Returns the signature of this schema
 

--- a/restler/engine/fuzzing_parameters/fuzzing_config.py
+++ b/restler/engine/fuzzing_parameters/fuzzing_config.py
@@ -25,6 +25,7 @@ class FuzzingConfig(object):
         self.max_combination = 100
         self.merge_fuzzable_values = False
         self.max_depth = sys.maxsize
+        self.filter_fn = None
         # Traversal depth state
         self.depth = 0
 
@@ -86,6 +87,7 @@ class FuzzingConfig(object):
         new_config.max_combination = self.max_combination
         new_config.merge_fuzzable_values = self.merge_fuzzable_values
         new_config.max_depth = self.max_depth
+        new_config.filter_fn = self.filter_fn
 
         return new_config
 

--- a/restler/engine/fuzzing_parameters/fuzzing_utils.py
+++ b/restler/engine/fuzzing_parameters/fuzzing_utils.py
@@ -7,7 +7,6 @@ import itertools
 import json
 
 import engine.primitives as primitives
-from engine.core.requests import Request
 
 def get_product_exhaust(sets, bound):
     """ Return the product of the input sets exhaustively

--- a/restler/engine/primitives.py
+++ b/restler/engine/primitives.py
@@ -259,7 +259,7 @@ class CandidateValuesPool(object):
 
         return current_primitives
 
-    def get_candidate_values(self, primitive_name, request_id=None, tag=None, quoted=False, examples=None):
+    def get_candidate_values(self, primitive_name, request_id=None, tag=None, quoted=False, examples=[]):
         """ Return feasible values for a given primitive.
 
         @param primitive_name: The primitive whose feasible values we wish to fetch.
@@ -343,7 +343,7 @@ class CandidateValuesPool(object):
         except KeyError:
             raise CandidateValueException
 
-    def get_fuzzable_values(self, primitive_type, default_value, request_id=None, quoted=False, examples=None):
+    def get_fuzzable_values(self, primitive_type, default_value, request_id=None, quoted=False, examples=[]):
         """ Return list of fuzzable values with a default value (specified)
         in the front of the list.
 
@@ -492,7 +492,7 @@ def restler_fuzzable_string(*args, **kwargs):
     quoted = False
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
-    examples=None
+    examples=[]
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None
@@ -523,7 +523,7 @@ def restler_fuzzable_int(*args, **kwargs):
     quoted = False
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
-    examples=None
+    examples=[]
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None
@@ -556,7 +556,7 @@ def restler_fuzzable_bool(*args, **kwargs):
     quoted = False
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
-    examples=None
+    examples=[]
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None
@@ -588,7 +588,7 @@ def restler_fuzzable_number(*args, **kwargs):
     quoted = False
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
-    examples=None
+    examples=[]
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None
@@ -620,7 +620,7 @@ def restler_fuzzable_delim(*args, **kwargs):
     quoted = False
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
-    examples=None
+    examples=[]
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None
@@ -657,7 +657,7 @@ def restler_fuzzable_group(*args, **kwargs):
     quoted = False
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
-    examples=None
+    examples=[]
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None
@@ -687,7 +687,7 @@ def restler_fuzzable_uuid4(*args, **kwargs):
     quoted = False
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
-    examples=None
+    examples=[]
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None
@@ -719,7 +719,7 @@ def restler_fuzzable_datetime(*args, **kwargs) :
     quoted = False
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
-    examples=None
+    examples=[]
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None
@@ -751,7 +751,7 @@ def restler_fuzzable_date(*args, **kwargs) :
     quoted = False
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
-    examples=None
+    examples=[]
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None
@@ -782,7 +782,7 @@ def restler_fuzzable_object(*args, **kwargs) :
     quoted = False
     if QUOTED_ARG in kwargs:
         quoted = kwargs[QUOTED_ARG]
-    examples=None
+    examples=[]
     if EXAMPLES_ARG in kwargs:
         examples = kwargs[EXAMPLES_ARG]
     param_name = None

--- a/restler/unit_tests/grammar_schema_test_files/README.txt
+++ b/restler/unit_tests/grammar_schema_test_files/README.txt
@@ -1,0 +1,6 @@
+This directory contains the Swagger files that are used to generate the grammars
+as well as the grammars themselves.
+
+If the grammar definition in the RESTler compiler is updated, 
+the grammars in this directory should be re-generated from the Swagger
+files using the new version of the compiler.

--- a/restler/unit_tests/grammar_schema_test_files/simple_swagger_all_param_types.json
+++ b/restler/unit_tests/grammar_schema_test_files/simple_swagger_all_param_types.json
@@ -1,0 +1,114 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple Swagger with all parameter types",
+    "version": "1"
+  },
+  "paths": {
+    "/customer": {
+      "post": {
+        "operationId": "post_customer",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "schema-version",
+            "type": "string",
+            "in": "header",
+            "required": false
+          },
+          {
+            "name": "body",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Customer"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Customer"
+            }
+          }
+        }
+      }
+    },
+    "/customer/{customerId}": {
+      "get": {
+        "operationId": "post_customer",
+        "parameters": [
+          {
+            "name": "customerId",
+            "type": "string",
+            "in": "path",
+            "required": true
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "schema-version",
+            "type": "string",
+            "in": "header",
+            "required": false
+          },
+          {
+            "name": "view-option",
+            "type": "string",
+            "enum": [
+              "detailed",
+              "minimal"
+            ],
+            "in": "header",
+            "required": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Customer"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Customer": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "Person": {
+          "$ref": "#/definitions/Person"
+        }
+      }
+    },
+    "Person": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/restler/unit_tests/grammar_schema_test_files/simple_swagger_all_param_types_grammar.json
+++ b/restler/unit_tests/grammar_schema_test_files/simple_swagger_all_param_types_grammar.json
@@ -1,0 +1,344 @@
+{
+  "Requests": [
+    {
+      "id": {
+        "endpoint": "/customer",
+        "method": "Post"
+      },
+      "method": "Post",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "customer"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "body",
+                "payload": {
+                  "InternalNode": [
+                    {
+                      "name": "",
+                      "propertyType": "Object",
+                      "isRequired": true,
+                      "isReadOnly": false
+                    },
+                    [
+                      {
+                        "LeafNode": {
+                          "name": "id",
+                          "payload": {
+                            "Fuzzable": {
+                              "primitiveType": "String",
+                              "defaultValue": "fuzzstring"
+                            }
+                          },
+                          "isRequired": false,
+                          "isReadOnly": false
+                        }
+                      },
+                      {
+                        "InternalNode": [
+                          {
+                            "name": "Person",
+                            "propertyType": "Property",
+                            "isRequired": false,
+                            "isReadOnly": false
+                          },
+                          [
+                            {
+                              "InternalNode": [
+                                {
+                                  "name": "",
+                                  "propertyType": "Object",
+                                  "isRequired": false,
+                                  "isReadOnly": false
+                                },
+                                [
+                                  {
+                                    "LeafNode": {
+                                      "name": "name",
+                                      "payload": {
+                                        "Fuzzable": {
+                                          "primitiveType": "String",
+                                          "defaultValue": "fuzzstring"
+                                        }
+                                      },
+                                      "isRequired": true,
+                                      "isReadOnly": false
+                                    }
+                                  },
+                                  {
+                                    "LeafNode": {
+                                      "name": "address",
+                                      "payload": {
+                                        "Fuzzable": {
+                                          "primitiveType": "String",
+                                          "defaultValue": "fuzzstring"
+                                        }
+                                      },
+                                      "isRequired": false,
+                                      "isReadOnly": false
+                                    }
+                                  }
+                                ]
+                              ]
+                            }
+                          ]
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "schema-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": false,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": [
+              {
+                "name": "Content-Type",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Constant": [
+                        "String",
+                        "application/json"
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          null
+        ]
+      ],
+      "httpVersion": "1.1",
+      "dependencyData": {
+        "responseParser": {
+          "writerVariables": [
+            {
+              "requestId": {
+                "endpoint": "/customer",
+                "method": "Post"
+              },
+              "accessPathParts": {
+                "path": [
+                  "id"
+                ]
+              },
+              "primitiveType": "String",
+              "kind": "BodyResponseProperty"
+            }
+          ],
+          "headerWriterVariables": []
+        },
+        "inputWriterVariables": [],
+        "orderingConstraintWriterVariables": [],
+        "orderingConstraintReaderVariables": []
+      },
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/customer/{customerId}",
+        "method": "Get"
+      },
+      "method": "Get",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "customer"
+          ]
+        },
+        {
+          "DynamicObject": {
+            "primitiveType": "String",
+            "variableName": "_customer_post_id",
+            "isWriter": false
+          }
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "schema-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": false,
+                    "isReadOnly": false
+                  }
+                }
+              },
+              {
+                "name": "view-option",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": {
+                          "Enum": [
+                            "view-option",
+                            "String",
+                            [
+                              "detailed",
+                              "minimal"
+                            ],
+                            null
+                          ]
+                        },
+                        "defaultValue": "detailed"
+                      }
+                    },
+                    "isRequired": false,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          null
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    }
+  ]
+}

--- a/restler/unit_tests/grammar_schema_test_files/simple_swagger_all_param_types_grammar.py
+++ b/restler/unit_tests/grammar_schema_test_files/simple_swagger_all_param_types_grammar.py
@@ -1,0 +1,130 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_customer_post_id = dependencies.DynamicVariable("_customer_post_id")
+
+def parse_customerpost(data, **kwargs):
+    """ Automatically generated response parser """
+    # Declare response variables
+    temp_7262 = None
+
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        try:
+            data = json.loads(data)
+        except Exception as error:
+            raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+        pass
+
+    # Try to extract each dynamic object
+
+        try:
+            temp_7262 = str(data["id"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
+
+
+
+    # If no dynamic objects were extracted, throw.
+    if not (temp_7262):
+        raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
+
+    # Set dynamic variables
+    if temp_7262:
+        dependencies.set_variable("_customer_post_id", temp_7262)
+
+req_collection = requests.RequestCollection([])
+# Endpoint: /customer, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("customer"),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("api-version="),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("schema-version: "),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "id":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "Person":
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "address":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+        }
+    }"""),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+
+        'post_send':
+        {
+            'parser': parse_customerpost,
+            'dependencies':
+            [
+                _customer_post_id.writer()
+            ]
+        }
+
+    },
+
+],
+requestId="/customer"
+)
+req_collection.add_request(request)
+
+# Endpoint: /customer/{customerId}, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("customer"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_customer_post_id.reader(), quoted=False),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("api-version="),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("schema-version: "),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("view-option: "),
+    primitives.restler_fuzzable_group("view-option", ['detailed','minimal']  ,quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/customer/{customerId}"
+)
+req_collection.add_request(request)

--- a/restler/unit_tests/test_grammar_schema_parser.py
+++ b/restler/unit_tests/test_grammar_schema_parser.py
@@ -1,0 +1,180 @@
+import unittest
+import os
+import sys
+import importlib
+import importlib.util
+import json
+
+from engine.fuzzing_parameters.param_combinations import *
+from engine.fuzzing_parameters.fuzzing_config import FuzzingConfig
+
+import restler_settings
+from restler_settings import Settings
+from restler_settings import UninitializedError as UninitializedSettingsError
+from engine.core.preprocessing import parse_grammar_schema
+from engine.core.requests import GrammarRequestCollection
+
+from engine.fuzzing_parameters.parameter_schema import HeaderList
+from engine.fuzzing_parameters.parameter_schema import QueryList
+
+def get_grammar_file_path(grammar_file_name):
+    Test_File_Directory = os.path.join(
+        os.path.dirname(__file__), 'grammar_schema_test_files'
+    )
+    return os.path.join(Test_File_Directory, grammar_file_name)
+
+def get_python_grammar(grammar_name):
+    python_grammar_file_name = f"{grammar_name}.py"
+    grammar_file_path = get_grammar_file_path(python_grammar_file_name)
+
+    sys.path.append(os.path.dirname(grammar_file_path))
+    grammar = importlib.import_module(grammar_name)
+    req_collection = getattr(grammar, "req_collection")
+
+    # The line below is required to avoid key errors on the auth token
+    # TODO: remove this constraint from the code, so the token refresh grammar element
+    # can also be tested here.
+    req_collection.remove_authentication_tokens()
+    return req_collection
+
+def set_grammar_schema(grammar_file_name, request_collection):
+    grammar_file_path = get_grammar_file_path(grammar_file_name)
+    schema_json=''
+    with open(grammar_file_path, 'r') as grammar:
+        schema_json = json.load(grammar)
+    parse_grammar_schema(schema_json, request_collection)
+
+class SchemaParserTest(unittest.TestCase):
+
+    def setup(self):
+        try:
+            self.settings = Settings()
+        except UninitializedSettingsError:
+            self.settings = restler_settings.RestlerSettings({})
+
+    def tearDown(self):
+        restler_settings.RestlerSettings.TEST_DeleteInstance()
+
+    def generate_new_request(self, req, headers_schema, query_schema, body_schema):
+        fuzzing_config = FuzzingConfig()
+
+        query_blocks = query_schema.get_original_blocks(fuzzing_config)
+        new_request = req.substitute_query(query_blocks)
+        self.assertTrue(new_request is not None)
+
+        header_blocks = headers_schema.get_original_blocks(fuzzing_config)
+        new_request = new_request.substitute_headers(header_blocks)
+        self.assertTrue(new_request is not None)
+
+        if body_schema is not None:
+            body_schema.set_config(fuzzing_config) # This line is required for legacy reasons
+            body_blocks = body_schema.get_original_blocks(fuzzing_config)
+            new_request = new_request.substitute_body(body_blocks)
+            self.assertTrue(new_request is not None)
+
+        return new_request
+
+    def check_equivalence(self, original_req, generated_req, req_collection, equal=True):
+        # Fuzzables equal
+        original_fuzzables=list(filter(lambda x : 'restler_fuzzable' in x[0] , original_req.definition))
+        generated_fuzzables=list(filter(lambda x : 'restler_fuzzable' in x[0] , generated_req.definition))
+
+        if equal:
+            self.assertEqual(original_fuzzables, generated_fuzzables)
+        else:
+            self.assertNotEqual(original_fuzzables, generated_fuzzables)
+
+        # TODO: enums equal
+
+        # Payloads equal
+        original_rendered_data,_,_ = next(original_req.render_iter(req_collection.candidate_values_pool))
+        generated_rendered_data,_,_ = next(generated_req.render_iter(req_collection.candidate_values_pool))
+
+        original_rendered_data = original_rendered_data.replace("\r\n", "")
+
+        original_rendered_data = original_rendered_data.replace("\n", "")
+        original_rendered_data = original_rendered_data.replace(" ", "")
+        generated_rendered_data = generated_rendered_data.replace("\r\n", "")
+
+        generated_rendered_data = generated_rendered_data.replace("\n", "")
+        generated_rendered_data = generated_rendered_data.replace(" ", "")
+        if equal:
+            self.assertEqual(original_rendered_data, generated_rendered_data)
+        else:
+            self.assertNotEqual(original_rendered_data, generated_rendered_data)
+        return original_rendered_data, generated_rendered_data
+
+    def test_simple_request(self):
+        # This test checks that the json schema has the expected properties, and
+        # the request payload is correctly generated from this schema.
+        def check_body_schema_properties(req):
+            self.assertTrue(req.body_schema is not None)
+            schema_members = req.body_schema.schema.members
+            self.assertTrue(len(schema_members) == 2)
+            self.assertEqual(schema_members[0].name, "id")
+            self.assertEqual(schema_members[0].value.is_required, False)
+            self.assertEqual(schema_members[0].value.content, "fuzzstring")
+            self.assertEqual(schema_members[1].name, "Person")
+            self.assertEqual(schema_members[1].is_required, False)
+            customer_members = schema_members[1].value.members
+            self.assertTrue(len(customer_members) == 2)
+            self.assertEqual(customer_members[0].name, "name")
+            self.assertEqual(customer_members[0].is_required, True)
+            self.assertEqual(customer_members[0].value.content, "fuzzstring")
+            self.assertEqual(customer_members[1].name, "address")
+            self.assertEqual(customer_members[1].is_required, False)
+            self.assertEqual(customer_members[1].value.content, "fuzzstring")
+
+        def check_query_schema_properties(req):
+            self.assertTrue(req.query_schema is not None)
+            schema_members = req.query_schema.param_list
+            self.assertTrue(len(schema_members) == 1)
+            self.assertEqual(schema_members[0].key, "api-version")
+            self.assertEqual(schema_members[0].is_required, True)
+            self.assertEqual(schema_members[0].content.content, "fuzzstring")
+
+        def check_headers_schema_properties(req, num_headers=None):
+            self.assertTrue(req.headers_schema is not None)
+            header_members = req.headers_schema.param_list
+            if num_headers is not None:
+                self.assertTrue(len(header_members) >= num_headers)
+            self.assertEqual(header_members[0].key, "schema-version")
+            self.assertEqual(header_members[0].is_required, False)
+            self.assertEqual(header_members[0].content.content, "fuzzstring")
+
+        def filter_fuzzables(req_definition):
+            return filter(lambda x : 'restler_fuzzable' in x[0] , req_definition)
+
+        self.setup()
+
+        grammar_name = "simple_swagger_all_param_types_grammar"
+        schema_json_file_name = f"{grammar_name}.json"
+
+        request_collection = get_python_grammar(grammar_name)
+
+        set_grammar_schema(schema_json_file_name, request_collection)
+
+        # 1. Confirm that all of the parameters are present in the schema.
+        for idx, req in enumerate(request_collection):
+            has_body = (idx == 0)
+            num_headers = 2 if has_body else 1
+            if has_body:
+                check_body_schema_properties(req)
+            check_headers_schema_properties(req, num_headers=num_headers)
+            check_query_schema_properties(req)
+
+            # 2. Generate the Python grammar from this schema, and confirm it matches
+            # the expected Python grammar (generated by the RESTler compiler)
+            # Go through and generate the body, query, and headers
+            # then, call 'substitute' on the request.
+            # Then, make sure they match the original request.
+            # This is a "round trip" test for the request.
+            generated_req = self.generate_new_request(req, req.headers_schema, req.query_schema, req.body_schema)
+
+            # Checking for equality is not going to work because of the compiler
+            # feature to "merge" the grammars.  We will have to validate as follows:
+            # 1) The same 'fuzzable' and 'custom payload' and 'enum' entries are there
+            # 2) the generated payload is the same.
+
+            self.check_equivalence(req, generated_req, request_collection)
+


### PR DESCRIPTION
Background: the grammar.json schema parser and python grammar generator were initially developed for the payload body checker.  Over time, other parts of the RESTler engine began to use this parser and python request definition generator code, but it was never thoroughly tested.
This change makes several fixes and enhancements to the schema parser and request definition generator as well as adds a sanity test for a large portion of the existing functionality.

Specific changes include:
- added 'get_original_blocks' function to each param object, which is supposed to generate
exactly the python grammar corresponding to the original json grammar.
The existing 'get_blocks' and 'get_fuzzing_blocks' do not satisfy this requirement.
They are kept for backwards compatibility for the payload body checker.
- fixed several bugs in schema parsing
- added missing elements to the data types
- added the ability to filter schema nodes using a filter function
(this will be used in a subsequent change)

Testing:
- new unit test
- manual real-world testing of Test, test_all_combinations, FuzzLean on several services