### PR TITLE
Upgrade NSwag and NJsonSchema

### DIFF
--- a/src/ResultsAnalyzer/packages.lock.json
+++ b/src/ResultsAnalyzer/packages.lock.json
@@ -98,8 +98,8 @@
       },
       "Namotion.Reflection": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "avIVcrF4fNVBccqup2lZ+EDuF7XF7Em5ttpm/x7kovny+f1ctmiZwuKWsT106jwgBf9LrTf4LlcGBaFt8cRKCg==",
+        "resolved": "2.0.10",
+        "contentHash": "KHndyscosup/AnzMQLzW0g6+z0h2NCmTyW9hnEL/T/ZkiUIQWBA1RadYgUT+dXuMORmQI/BXm+DXYySWwq8h0Q==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0"
         }
@@ -171,40 +171,40 @@
       },
       "NJsonSchema": {
         "type": "Transitive",
-        "resolved": "10.0.27",
-        "contentHash": "PUNgCQFTN/0dzNodToOp1hb1IuENWph4RfRVcOmkhJQKRZvAeLvzz+nzD5ADjcp8MnmFBGkRRE+Mg3TjJd9JIg==",
+        "resolved": "10.7.2",
+        "contentHash": "XBjzX8wM1UwOAYr57s5iMvapxzVg/X3STWTF+F6GJ+F6O20c349CPdclmTxuSbIVFFWTr0v1rRcgOnfDtExyeg==",
         "dependencies": {
-          "Namotion.Reflection": "1.0.7",
+          "Namotion.Reflection": "2.0.10",
           "Newtonsoft.Json": "9.0.1"
         }
       },
       "NJsonSchema.Yaml": {
         "type": "Transitive",
-        "resolved": "10.0.27",
-        "contentHash": "bzNBxtC/0zppU+nsO0h7INLFSpQn5HuDK/cO3+GF9ZpCrOH4sShmn8c1enAouEehv5q/mfemIjE3oAkhg6QcLQ==",
+        "resolved": "10.7.2",
+        "contentHash": "H4eG4tdPEPz5cupgBZ7qkb3xGT14j0Ts9Nx/GHF5s4mhP9YsqDiuM3hPfTEa84oDAp/to9UCdPv8JASHmp0fyA==",
         "dependencies": {
           "Microsoft.CSharp": "4.4.1",
-          "NJsonSchema": "10.0.27",
-          "YamlDotNet.Signed": "5.1.0"
+          "NJsonSchema": "10.7.2",
+          "YamlDotNet": "11.2.1"
         }
       },
       "NSwag.Core": {
         "type": "Transitive",
-        "resolved": "13.1.3",
-        "contentHash": "ON3qbtEgTdM+/AGWUUmAmx58JK4h9vJS6KbMC4MIJVH0M/byBFszpLINFTCr9HbYyypY7A6RfYbQkvI+jpOMQQ==",
+        "resolved": "13.16.1",
+        "contentHash": "xiX+H3Bv6zxrqJExPepO5WQVutkDUMdlUA3NqQ8VguwsYwJlkV05eF8XvmbJn/yGJWUag7vLImuXAoj0/327Bg==",
         "dependencies": {
-          "NJsonSchema": "10.0.27",
+          "NJsonSchema": "10.7.2",
           "Newtonsoft.Json": "9.0.1"
         }
       },
       "NSwag.Core.Yaml": {
         "type": "Transitive",
-        "resolved": "13.1.3",
-        "contentHash": "fms5leiF7FNdU8irwhp4WFwRwh1VXdEVn4f8UI4YhsjgwYgQjtAob27HGyFTWOk4sOw1FZkfAST2RYbSG99gGw==",
+        "resolved": "13.16.1",
+        "contentHash": "d3QwvjuM5pYLJ0IVyRLHJXQCKiSdjIFTI3J8nWHP5L0+XHBpIlkfuOzYvtgsRrdyBuzuKL3Xf4JBtRq42RMJjQ==",
         "dependencies": {
-          "NJsonSchema.Yaml": "10.0.27",
-          "NSwag.Core": "13.1.3",
-          "YamlDotNet.Signed": "5.1.0"
+          "NJsonSchema.Yaml": "10.7.2",
+          "NSwag.Core": "13.16.1",
+          "YamlDotNet": "11.2.1"
         }
       },
       "Pluralize.NET.Core": {
@@ -1117,10 +1117,10 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
-      "YamlDotNet.Signed": {
+      "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "5.1.0",
-        "contentHash": "3iZF8/sDp/AxnA3YZ3gR+8irfd2FiBsqdR9fywzcpeBdaqUDRncqejAv3+jIwwCoHJz3No6JT7u+NzTeVE+5VA=="
+        "resolved": "11.2.1",
+        "contentHash": "tBt8K+korVfrjH9wyDEhiLKxbs8qoLCLIFwvYgkSUuMC9//w3z0cFQ8LQAI/5MCKq+BMil0cfRTRvPeE7eXhQw=="
       },
       "restler.compiler": {
         "type": "Project",
@@ -1129,9 +1129,9 @@
           "Microsoft.ApplicationInsights": "2.14.0",
           "Microsoft.FSharpLu": "0.11.6",
           "Microsoft.FSharpLu.Json": "0.11.6",
-          "NJsonSchema": "10.0.27",
-          "NSwag.Core": "13.1.3",
-          "NSwag.Core.Yaml": "13.1.3",
+          "NJsonSchema": "10.7.2",
+          "NSwag.Core": "13.16.1",
+          "NSwag.Core.Yaml": "13.16.1",
           "Newtonsoft.Json": "13.0.1",
           "Pluralize.NET.Core": "1.0.0"
         }

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -364,11 +364,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.FSharpLu" Version="0.11.6" />
     <PackageReference Include="Microsoft.FSharpLu.Json" Version="0.11.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NJsonSchema" Version="10.0.27" />
-    <PackageReference Include="NSwag.Core" Version="13.1.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+	  <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+	  <PackageReference Include="NJsonSchema" Version="10.7.2" />
+	  <PackageReference Include="NSwag.Core" Version="13.16.1" />
+	  <PackageReference Include="xunit" Version="2.4.1" />
+	  <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/compiler/Restler.Compiler.Test/packages.lock.json
+++ b/src/compiler/Restler.Compiler.Test/packages.lock.json
@@ -44,21 +44,21 @@
       },
       "NJsonSchema": {
         "type": "Direct",
-        "requested": "[10.0.27, )",
-        "resolved": "10.0.27",
-        "contentHash": "PUNgCQFTN/0dzNodToOp1hb1IuENWph4RfRVcOmkhJQKRZvAeLvzz+nzD5ADjcp8MnmFBGkRRE+Mg3TjJd9JIg==",
+        "requested": "[10.7.2, )",
+        "resolved": "10.7.2",
+        "contentHash": "XBjzX8wM1UwOAYr57s5iMvapxzVg/X3STWTF+F6GJ+F6O20c349CPdclmTxuSbIVFFWTr0v1rRcgOnfDtExyeg==",
         "dependencies": {
-          "Namotion.Reflection": "1.0.7",
+          "Namotion.Reflection": "2.0.10",
           "Newtonsoft.Json": "9.0.1"
         }
       },
       "NSwag.Core": {
         "type": "Direct",
-        "requested": "[13.1.3, )",
-        "resolved": "13.1.3",
-        "contentHash": "ON3qbtEgTdM+/AGWUUmAmx58JK4h9vJS6KbMC4MIJVH0M/byBFszpLINFTCr9HbYyypY7A6RfYbQkvI+jpOMQQ==",
+        "requested": "[13.16.1, )",
+        "resolved": "13.16.1",
+        "contentHash": "xiX+H3Bv6zxrqJExPepO5WQVutkDUMdlUA3NqQ8VguwsYwJlkV05eF8XvmbJn/yGJWUag7vLImuXAoj0/327Bg==",
         "dependencies": {
-          "NJsonSchema": "10.0.27",
+          "NJsonSchema": "10.7.2",
           "Newtonsoft.Json": "9.0.1"
         }
       },
@@ -199,8 +199,8 @@
       },
       "Namotion.Reflection": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "avIVcrF4fNVBccqup2lZ+EDuF7XF7Em5ttpm/x7kovny+f1ctmiZwuKWsT106jwgBf9LrTf4LlcGBaFt8cRKCg==",
+        "resolved": "2.0.10",
+        "contentHash": "KHndyscosup/AnzMQLzW0g6+z0h2NCmTyW9hnEL/T/ZkiUIQWBA1RadYgUT+dXuMORmQI/BXm+DXYySWwq8h0Q==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0"
         }
@@ -267,22 +267,22 @@
       },
       "NJsonSchema.Yaml": {
         "type": "Transitive",
-        "resolved": "10.0.27",
-        "contentHash": "bzNBxtC/0zppU+nsO0h7INLFSpQn5HuDK/cO3+GF9ZpCrOH4sShmn8c1enAouEehv5q/mfemIjE3oAkhg6QcLQ==",
+        "resolved": "10.7.2",
+        "contentHash": "H4eG4tdPEPz5cupgBZ7qkb3xGT14j0Ts9Nx/GHF5s4mhP9YsqDiuM3hPfTEa84oDAp/to9UCdPv8JASHmp0fyA==",
         "dependencies": {
           "Microsoft.CSharp": "4.4.1",
-          "NJsonSchema": "10.0.27",
-          "YamlDotNet.Signed": "5.1.0"
+          "NJsonSchema": "10.7.2",
+          "YamlDotNet": "11.2.1"
         }
       },
       "NSwag.Core.Yaml": {
         "type": "Transitive",
-        "resolved": "13.1.3",
-        "contentHash": "fms5leiF7FNdU8irwhp4WFwRwh1VXdEVn4f8UI4YhsjgwYgQjtAob27HGyFTWOk4sOw1FZkfAST2RYbSG99gGw==",
+        "resolved": "13.16.1",
+        "contentHash": "d3QwvjuM5pYLJ0IVyRLHJXQCKiSdjIFTI3J8nWHP5L0+XHBpIlkfuOzYvtgsRrdyBuzuKL3Xf4JBtRq42RMJjQ==",
         "dependencies": {
-          "NJsonSchema.Yaml": "10.0.27",
-          "NSwag.Core": "13.1.3",
-          "YamlDotNet.Signed": "5.1.0"
+          "NJsonSchema.Yaml": "10.7.2",
+          "NSwag.Core": "13.16.1",
+          "YamlDotNet": "11.2.1"
         }
       },
       "Pluralize.NET.Core": {
@@ -1563,10 +1563,10 @@
           "xunit.extensibility.core": "[2.4.1]"
         }
       },
-      "YamlDotNet.Signed": {
+      "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "5.1.0",
-        "contentHash": "3iZF8/sDp/AxnA3YZ3gR+8irfd2FiBsqdR9fywzcpeBdaqUDRncqejAv3+jIwwCoHJz3No6JT7u+NzTeVE+5VA=="
+        "resolved": "11.2.1",
+        "contentHash": "tBt8K+korVfrjH9wyDEhiLKxbs8qoLCLIFwvYgkSUuMC9//w3z0cFQ8LQAI/5MCKq+BMil0cfRTRvPeE7eXhQw=="
       },
       "restler.compiler": {
         "type": "Project",
@@ -1575,9 +1575,9 @@
           "Microsoft.ApplicationInsights": "2.14.0",
           "Microsoft.FSharpLu": "0.11.6",
           "Microsoft.FSharpLu.Json": "0.11.6",
-          "NJsonSchema": "10.0.27",
-          "NSwag.Core": "13.1.3",
-          "NSwag.Core.Yaml": "13.1.3",
+          "NJsonSchema": "10.7.2",
+          "NSwag.Core": "13.16.1",
+          "NSwag.Core.Yaml": "13.16.1",
           "Newtonsoft.Json": "13.0.1",
           "Pluralize.NET.Core": "1.0.0"
         }

--- a/src/compiler/Restler.Compiler/Examples.fs
+++ b/src/compiler/Restler.Compiler/Examples.fs
@@ -229,9 +229,10 @@ let getSpecPayloadExamples (swaggerMethodDefinition:OpenApiOperation) (examplesD
                     else
                         // The examples may be file references or inlined
                         // simply return the object.
-                        if exampleValues.Contains("__referencePath") then
-                            yield exampleValues.["__referencePath"]
-
+                        let refString = "$ref"
+                        if exampleValues.Contains(refString) then
+                            yield exampleValues.[refString]
+ 
                         if exampleValues.Contains("parameters") then
                             yield exampleValues :> obj
             }

--- a/src/compiler/Restler.Compiler/Restler.Compiler.fsproj
+++ b/src/compiler/Restler.Compiler/Restler.Compiler.fsproj
@@ -40,9 +40,9 @@
     <PackageReference Include="Microsoft.FSharpLu" Version="0.11.6" />
     <PackageReference Include="Microsoft.FSharpLu.Json" Version="0.11.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NJsonSchema" Version="10.0.27" />
-    <PackageReference Include="NSwag.Core" Version="13.1.3" />
-    <PackageReference Include="NSwag.Core.Yaml" Version="13.1.3" />
+    <PackageReference Include="NJsonSchema" Version="10.7.2" />
+    <PackageReference Include="NSwag.Core" Version="13.16.1" />
+    <PackageReference Include="NSwag.Core.Yaml" Version="13.16.1" />
     <PackageReference Include="Pluralize.NET.Core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/compiler/Restler.Compiler/packages.lock.json
+++ b/src/compiler/Restler.Compiler/packages.lock.json
@@ -54,33 +54,33 @@
       },
       "NJsonSchema": {
         "type": "Direct",
-        "requested": "[10.0.27, )",
-        "resolved": "10.0.27",
-        "contentHash": "PUNgCQFTN/0dzNodToOp1hb1IuENWph4RfRVcOmkhJQKRZvAeLvzz+nzD5ADjcp8MnmFBGkRRE+Mg3TjJd9JIg==",
+        "requested": "[10.7.2, )",
+        "resolved": "10.7.2",
+        "contentHash": "XBjzX8wM1UwOAYr57s5iMvapxzVg/X3STWTF+F6GJ+F6O20c349CPdclmTxuSbIVFFWTr0v1rRcgOnfDtExyeg==",
         "dependencies": {
-          "Namotion.Reflection": "1.0.7",
+          "Namotion.Reflection": "2.0.10",
           "Newtonsoft.Json": "9.0.1"
         }
       },
       "NSwag.Core": {
         "type": "Direct",
-        "requested": "[13.1.3, )",
-        "resolved": "13.1.3",
-        "contentHash": "ON3qbtEgTdM+/AGWUUmAmx58JK4h9vJS6KbMC4MIJVH0M/byBFszpLINFTCr9HbYyypY7A6RfYbQkvI+jpOMQQ==",
+        "requested": "[13.16.1, )",
+        "resolved": "13.16.1",
+        "contentHash": "xiX+H3Bv6zxrqJExPepO5WQVutkDUMdlUA3NqQ8VguwsYwJlkV05eF8XvmbJn/yGJWUag7vLImuXAoj0/327Bg==",
         "dependencies": {
-          "NJsonSchema": "10.0.27",
+          "NJsonSchema": "10.7.2",
           "Newtonsoft.Json": "9.0.1"
         }
       },
       "NSwag.Core.Yaml": {
         "type": "Direct",
-        "requested": "[13.1.3, )",
-        "resolved": "13.1.3",
-        "contentHash": "fms5leiF7FNdU8irwhp4WFwRwh1VXdEVn4f8UI4YhsjgwYgQjtAob27HGyFTWOk4sOw1FZkfAST2RYbSG99gGw==",
+        "requested": "[13.16.1, )",
+        "resolved": "13.16.1",
+        "contentHash": "d3QwvjuM5pYLJ0IVyRLHJXQCKiSdjIFTI3J8nWHP5L0+XHBpIlkfuOzYvtgsRrdyBuzuKL3Xf4JBtRq42RMJjQ==",
         "dependencies": {
-          "NJsonSchema.Yaml": "10.0.27",
-          "NSwag.Core": "13.1.3",
-          "YamlDotNet.Signed": "5.1.0"
+          "NJsonSchema.Yaml": "10.7.2",
+          "NSwag.Core": "13.16.1",
+          "YamlDotNet": "11.2.1"
         }
       },
       "Pluralize.NET.Core": {
@@ -133,8 +133,8 @@
       },
       "Namotion.Reflection": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "avIVcrF4fNVBccqup2lZ+EDuF7XF7Em5ttpm/x7kovny+f1ctmiZwuKWsT106jwgBf9LrTf4LlcGBaFt8cRKCg==",
+        "resolved": "2.0.10",
+        "contentHash": "KHndyscosup/AnzMQLzW0g6+z0h2NCmTyW9hnEL/T/ZkiUIQWBA1RadYgUT+dXuMORmQI/BXm+DXYySWwq8h0Q==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0"
         }
@@ -201,12 +201,12 @@
       },
       "NJsonSchema.Yaml": {
         "type": "Transitive",
-        "resolved": "10.0.27",
-        "contentHash": "bzNBxtC/0zppU+nsO0h7INLFSpQn5HuDK/cO3+GF9ZpCrOH4sShmn8c1enAouEehv5q/mfemIjE3oAkhg6QcLQ==",
+        "resolved": "10.7.2",
+        "contentHash": "H4eG4tdPEPz5cupgBZ7qkb3xGT14j0Ts9Nx/GHF5s4mhP9YsqDiuM3hPfTEa84oDAp/to9UCdPv8JASHmp0fyA==",
         "dependencies": {
           "Microsoft.CSharp": "4.4.1",
-          "NJsonSchema": "10.0.27",
-          "YamlDotNet.Signed": "5.1.0"
+          "NJsonSchema": "10.7.2",
+          "YamlDotNet": "11.2.1"
         }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
@@ -1114,10 +1114,10 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
-      "YamlDotNet.Signed": {
+      "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "5.1.0",
-        "contentHash": "3iZF8/sDp/AxnA3YZ3gR+8irfd2FiBsqdR9fywzcpeBdaqUDRncqejAv3+jIwwCoHJz3No6JT7u+NzTeVE+5VA=="
+        "resolved": "11.2.1",
+        "contentHash": "tBt8K+korVfrjH9wyDEhiLKxbs8qoLCLIFwvYgkSUuMC9//w3z0cFQ8LQAI/5MCKq+BMil0cfRTRvPeE7eXhQw=="
       }
     }
   }

--- a/src/compiler/Restler.CompilerExe/Restler.CompilerExe.fsproj
+++ b/src/compiler/Restler.CompilerExe/Restler.CompilerExe.fsproj
@@ -6,7 +6,7 @@
     <NoWarn>NU1603</NoWarn>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OtherFlags></OtherFlags>
     <Deterministic>false</Deterministic>
     <Tailcalls>true</Tailcalls>
@@ -21,8 +21,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Restler.Compiler\Restler.Compiler.fsproj" />
     <PackageReference Include="Microsoft.FSharpLu.Json" Version="0.11.6" />
-    <PackageReference Include="NJsonSchema" Version="10.0.27" />
-    <PackageReference Include="NSwag.Core" Version="13.1.3" />
+	  <PackageReference Include="NJsonSchema" Version="10.7.2" />
+	  <PackageReference Include="NSwag.Core" Version="13.16.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.2" />

--- a/src/compiler/Restler.CompilerExe/packages.lock.json
+++ b/src/compiler/Restler.CompilerExe/packages.lock.json
@@ -20,21 +20,21 @@
       },
       "NJsonSchema": {
         "type": "Direct",
-        "requested": "[10.0.27, )",
-        "resolved": "10.0.27",
-        "contentHash": "PUNgCQFTN/0dzNodToOp1hb1IuENWph4RfRVcOmkhJQKRZvAeLvzz+nzD5ADjcp8MnmFBGkRRE+Mg3TjJd9JIg==",
+        "requested": "[10.7.2, )",
+        "resolved": "10.7.2",
+        "contentHash": "XBjzX8wM1UwOAYr57s5iMvapxzVg/X3STWTF+F6GJ+F6O20c349CPdclmTxuSbIVFFWTr0v1rRcgOnfDtExyeg==",
         "dependencies": {
-          "Namotion.Reflection": "1.0.7",
+          "Namotion.Reflection": "2.0.10",
           "Newtonsoft.Json": "9.0.1"
         }
       },
       "NSwag.Core": {
         "type": "Direct",
-        "requested": "[13.1.3, )",
-        "resolved": "13.1.3",
-        "contentHash": "ON3qbtEgTdM+/AGWUUmAmx58JK4h9vJS6KbMC4MIJVH0M/byBFszpLINFTCr9HbYyypY7A6RfYbQkvI+jpOMQQ==",
+        "requested": "[13.16.1, )",
+        "resolved": "13.16.1",
+        "contentHash": "xiX+H3Bv6zxrqJExPepO5WQVutkDUMdlUA3NqQ8VguwsYwJlkV05eF8XvmbJn/yGJWUag7vLImuXAoj0/327Bg==",
         "dependencies": {
-          "NJsonSchema": "10.0.27",
+          "NJsonSchema": "10.7.2",
           "Newtonsoft.Json": "9.0.1"
         }
       },
@@ -108,8 +108,8 @@
       },
       "Namotion.Reflection": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "avIVcrF4fNVBccqup2lZ+EDuF7XF7Em5ttpm/x7kovny+f1ctmiZwuKWsT106jwgBf9LrTf4LlcGBaFt8cRKCg==",
+        "resolved": "2.0.10",
+        "contentHash": "KHndyscosup/AnzMQLzW0g6+z0h2NCmTyW9hnEL/T/ZkiUIQWBA1RadYgUT+dXuMORmQI/BXm+DXYySWwq8h0Q==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0"
         }
@@ -181,22 +181,22 @@
       },
       "NJsonSchema.Yaml": {
         "type": "Transitive",
-        "resolved": "10.0.27",
-        "contentHash": "bzNBxtC/0zppU+nsO0h7INLFSpQn5HuDK/cO3+GF9ZpCrOH4sShmn8c1enAouEehv5q/mfemIjE3oAkhg6QcLQ==",
+        "resolved": "10.7.2",
+        "contentHash": "H4eG4tdPEPz5cupgBZ7qkb3xGT14j0Ts9Nx/GHF5s4mhP9YsqDiuM3hPfTEa84oDAp/to9UCdPv8JASHmp0fyA==",
         "dependencies": {
           "Microsoft.CSharp": "4.4.1",
-          "NJsonSchema": "10.0.27",
-          "YamlDotNet.Signed": "5.1.0"
+          "NJsonSchema": "10.7.2",
+          "YamlDotNet": "11.2.1"
         }
       },
       "NSwag.Core.Yaml": {
         "type": "Transitive",
-        "resolved": "13.1.3",
-        "contentHash": "fms5leiF7FNdU8irwhp4WFwRwh1VXdEVn4f8UI4YhsjgwYgQjtAob27HGyFTWOk4sOw1FZkfAST2RYbSG99gGw==",
+        "resolved": "13.16.1",
+        "contentHash": "d3QwvjuM5pYLJ0IVyRLHJXQCKiSdjIFTI3J8nWHP5L0+XHBpIlkfuOzYvtgsRrdyBuzuKL3Xf4JBtRq42RMJjQ==",
         "dependencies": {
-          "NJsonSchema.Yaml": "10.0.27",
-          "NSwag.Core": "13.1.3",
-          "YamlDotNet.Signed": "5.1.0"
+          "NJsonSchema.Yaml": "10.7.2",
+          "NSwag.Core": "13.16.1",
+          "YamlDotNet": "11.2.1"
         }
       },
       "Pluralize.NET.Core": {
@@ -1109,10 +1109,10 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
-      "YamlDotNet.Signed": {
+      "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "5.1.0",
-        "contentHash": "3iZF8/sDp/AxnA3YZ3gR+8irfd2FiBsqdR9fywzcpeBdaqUDRncqejAv3+jIwwCoHJz3No6JT7u+NzTeVE+5VA=="
+        "resolved": "11.2.1",
+        "contentHash": "tBt8K+korVfrjH9wyDEhiLKxbs8qoLCLIFwvYgkSUuMC9//w3z0cFQ8LQAI/5MCKq+BMil0cfRTRvPeE7eXhQw=="
       },
       "restler.compiler": {
         "type": "Project",
@@ -1121,9 +1121,9 @@
           "Microsoft.ApplicationInsights": "2.14.0",
           "Microsoft.FSharpLu": "0.11.6",
           "Microsoft.FSharpLu.Json": "0.11.6",
-          "NJsonSchema": "10.0.27",
-          "NSwag.Core": "13.1.3",
-          "NSwag.Core.Yaml": "13.1.3",
+          "NJsonSchema": "10.7.2",
+          "NSwag.Core": "13.16.1",
+          "NSwag.Core.Yaml": "13.16.1",
           "Newtonsoft.Json": "13.0.1",
           "Pluralize.NET.Core": "1.0.0"
         }

--- a/src/driver/packages.lock.json
+++ b/src/driver/packages.lock.json
@@ -179,8 +179,8 @@
       },
       "Namotion.Reflection": {
         "type": "Transitive",
-        "resolved": "1.0.7",
-        "contentHash": "avIVcrF4fNVBccqup2lZ+EDuF7XF7Em5ttpm/x7kovny+f1ctmiZwuKWsT106jwgBf9LrTf4LlcGBaFt8cRKCg==",
+        "resolved": "2.0.10",
+        "contentHash": "KHndyscosup/AnzMQLzW0g6+z0h2NCmTyW9hnEL/T/ZkiUIQWBA1RadYgUT+dXuMORmQI/BXm+DXYySWwq8h0Q==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0"
         }
@@ -252,40 +252,40 @@
       },
       "NJsonSchema": {
         "type": "Transitive",
-        "resolved": "10.0.27",
-        "contentHash": "PUNgCQFTN/0dzNodToOp1hb1IuENWph4RfRVcOmkhJQKRZvAeLvzz+nzD5ADjcp8MnmFBGkRRE+Mg3TjJd9JIg==",
+        "resolved": "10.7.2",
+        "contentHash": "XBjzX8wM1UwOAYr57s5iMvapxzVg/X3STWTF+F6GJ+F6O20c349CPdclmTxuSbIVFFWTr0v1rRcgOnfDtExyeg==",
         "dependencies": {
-          "Namotion.Reflection": "1.0.7",
+          "Namotion.Reflection": "2.0.10",
           "Newtonsoft.Json": "9.0.1"
         }
       },
       "NJsonSchema.Yaml": {
         "type": "Transitive",
-        "resolved": "10.0.27",
-        "contentHash": "bzNBxtC/0zppU+nsO0h7INLFSpQn5HuDK/cO3+GF9ZpCrOH4sShmn8c1enAouEehv5q/mfemIjE3oAkhg6QcLQ==",
+        "resolved": "10.7.2",
+        "contentHash": "H4eG4tdPEPz5cupgBZ7qkb3xGT14j0Ts9Nx/GHF5s4mhP9YsqDiuM3hPfTEa84oDAp/to9UCdPv8JASHmp0fyA==",
         "dependencies": {
           "Microsoft.CSharp": "4.4.1",
-          "NJsonSchema": "10.0.27",
-          "YamlDotNet.Signed": "5.1.0"
+          "NJsonSchema": "10.7.2",
+          "YamlDotNet": "11.2.1"
         }
       },
       "NSwag.Core": {
         "type": "Transitive",
-        "resolved": "13.1.3",
-        "contentHash": "ON3qbtEgTdM+/AGWUUmAmx58JK4h9vJS6KbMC4MIJVH0M/byBFszpLINFTCr9HbYyypY7A6RfYbQkvI+jpOMQQ==",
+        "resolved": "13.16.1",
+        "contentHash": "xiX+H3Bv6zxrqJExPepO5WQVutkDUMdlUA3NqQ8VguwsYwJlkV05eF8XvmbJn/yGJWUag7vLImuXAoj0/327Bg==",
         "dependencies": {
-          "NJsonSchema": "10.0.27",
+          "NJsonSchema": "10.7.2",
           "Newtonsoft.Json": "9.0.1"
         }
       },
       "NSwag.Core.Yaml": {
         "type": "Transitive",
-        "resolved": "13.1.3",
-        "contentHash": "fms5leiF7FNdU8irwhp4WFwRwh1VXdEVn4f8UI4YhsjgwYgQjtAob27HGyFTWOk4sOw1FZkfAST2RYbSG99gGw==",
+        "resolved": "13.16.1",
+        "contentHash": "d3QwvjuM5pYLJ0IVyRLHJXQCKiSdjIFTI3J8nWHP5L0+XHBpIlkfuOzYvtgsRrdyBuzuKL3Xf4JBtRq42RMJjQ==",
         "dependencies": {
-          "NJsonSchema.Yaml": "10.0.27",
-          "NSwag.Core": "13.1.3",
-          "YamlDotNet.Signed": "5.1.0"
+          "NJsonSchema.Yaml": "10.7.2",
+          "NSwag.Core": "13.16.1",
+          "YamlDotNet": "11.2.1"
         }
       },
       "Pluralize.NET.Core": {
@@ -1473,10 +1473,10 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
-      "YamlDotNet.Signed": {
+      "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "5.1.0",
-        "contentHash": "3iZF8/sDp/AxnA3YZ3gR+8irfd2FiBsqdR9fywzcpeBdaqUDRncqejAv3+jIwwCoHJz3No6JT7u+NzTeVE+5VA=="
+        "resolved": "11.2.1",
+        "contentHash": "tBt8K+korVfrjH9wyDEhiLKxbs8qoLCLIFwvYgkSUuMC9//w3z0cFQ8LQAI/5MCKq+BMil0cfRTRvPeE7eXhQw=="
       },
       "restler.compiler": {
         "type": "Project",
@@ -1485,9 +1485,9 @@
           "Microsoft.ApplicationInsights": "2.14.0",
           "Microsoft.FSharpLu": "0.11.6",
           "Microsoft.FSharpLu.Json": "0.11.6",
-          "NJsonSchema": "10.0.27",
-          "NSwag.Core": "13.1.3",
-          "NSwag.Core.Yaml": "13.1.3",
+          "NJsonSchema": "10.7.2",
+          "NSwag.Core": "13.16.1",
+          "NSwag.Core.Yaml": "13.16.1",
           "Newtonsoft.Json": "13.0.1",
           "Pluralize.NET.Core": "1.0.0"
         }


### PR DESCRIPTION
Upgrade to the latest version.

This fixes an issue that was present in older versions of YamlDotNet
that caused failures to compile yaml specifications with long
property names (due to a size limit for a referenced property).