### PR TITLE
logging cmd result before call `parse_authentication_tokens`

### DIFF
--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -76,7 +76,7 @@ def execute_token_refresh_cmd(cmd):
 
             _RAW_LOGGING(f"New value: {cmd_result}")
             _, latest_token_value, latest_shadow_token_value = parse_authentication_tokens(cmd_result)
-            _RAW_LOGGING(f"Parse latest token value succeed: {cmd_result}")
+            _RAW_LOGGING(f"Successfully obtained the latest token")
             break
         except subprocess.CalledProcessError:
             error_str = f"Authentication failed when refreshing token:\n\nCommand that failed: \n{cmd}"

--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -74,8 +74,9 @@ def execute_token_refresh_cmd(cmd):
             else:
                 cmd_result = subprocess.getoutput([cmd])
 
-            _, latest_token_value, latest_shadow_token_value = parse_authentication_tokens(cmd_result)
             _RAW_LOGGING(f"New value: {cmd_result}")
+            _, latest_token_value, latest_shadow_token_value = parse_authentication_tokens(cmd_result)
+            _RAW_LOGGING(f"Parse latest token value succeed: {cmd_result}")
             break
         except subprocess.CalledProcessError:
             error_str = f"Authentication failed when refreshing token:\n\nCommand that failed: \n{cmd}"


### PR DESCRIPTION
For debugging purpose, we need to log `cmd_result` before call `parse_authentication_tokens` function. That's because if `parse_authentication_token` throw exception.  It's hard to know what happened. 

` metadata = ast.literal_eval(metadata)` in `parse_authentication_token` is very easy to trigger exception. If get token scripts output unexpected log. For example, in different os platform, some log are output by system not scripts. In this case, it will throw exception. `Error: invalid syntax (<unknown>, line 1)`