### PR TITLE
Add attempted requests to the output summary

### DIFF
--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -676,6 +676,7 @@ let getDataFromTestingSummary taskWorkingDirectory =
                 Microsoft.FSharpLu.Json.Compact.deserializeFile<Engine.TestingSummary> testingSummaryFilePath
 
             Logging.logInfo <| sprintf "Request coverage (successful / total): %s" testingSummary.final_spec_coverage
+            Logging.logInfo <| sprintf "Attempted requests: %s" testingSummary.rendered_requests
 
             let bugBuckets = testingSummary.bug_buckets
                                 |> Seq.map (fun kvp -> kvp.Key, sprintf "%A" kvp.Value)


### PR DESCRIPTION
Closes #574

Added a new line to the output:
```
Request coverage (successful / total): 17 / 24
Attempted requests: 21 / 24
```