### PR TITLE
Test more schema combinations by default to increase coverage

### DIFF
--- a/restler/checkers/body_schema_fuzzer.py
+++ b/restler/checkers/body_schema_fuzzer.py
@@ -11,8 +11,10 @@ import random
 from engine.fuzzing_parameters.fuzzing_utils import *
 from engine.fuzzing_parameters.request_params import *
 
-class BodySchemaStructuralFuzzer():
-    """ Body Schema Fuzzer Base Class """
+from engine.fuzzing_parameters.param_combinations import JsonBodySchemaFuzzerBase
+
+class BodySchemaStructuralFuzzer(JsonBodySchemaFuzzerBase):
+    """ Body Schema Fuzzer Class """
 
     def __init__(self, LOG=print, strategy=''):
         """ Initialize the body schema fuzzer
@@ -24,6 +26,7 @@ class BodySchemaStructuralFuzzer():
         @rtype:  None
 
         """
+        JsonBodySchemaFuzzerBase.__init__(self)
         # setup customized log
         self._log = LOG
 
@@ -136,6 +139,10 @@ class BodySchemaStructuralFuzzer():
 
         """
         return self._strategy.upper() == 'ALL'
+
+    def _apply_shuffle_propagation(self, values_pool):
+        if self._shuffle_propagation:
+            random.Random(self._random_seed).shuffle(values_pool)
 
     def _fuzz_member(self, param_member, fuzzed_value):
         """ Fuzz a ParamMember node

--- a/restler/end_to_end_tests/test_quick_start.py
+++ b/restler/end_to_end_tests/test_quick_start.py
@@ -58,8 +58,9 @@ def test_test_task(restler_working_dir, swagger_path, restler_drop_dir):
         shell=True, capture_output=True
     )
     expected_strings = [
-        'Request coverage (successful / total): 5 / 6',
-        'No bugs were found.' ,
+        'Request coverage (successful / total): 6 / 6',
+        'Attempted requests: 6 / 6',
+        'No bugs were found.',
         'Task Test succeeded.'
     ]
     check_output_errors(output)
@@ -72,7 +73,8 @@ def test_fuzzlean_task(restler_working_dir, swagger_path, restler_drop_dir):
         shell=True, capture_output=True
     )
     expected_strings = [
-        'Request coverage (successful / total): 5 / 6',
+        'Request coverage (successful / total): 6 / 6',
+        'Attempted requests: 6 / 6',
         'Bugs were found!' ,
         'InvalidDynamicObjectChecker_20x: 2',
         'PayloadBodyChecker_500: 2',
@@ -93,6 +95,7 @@ def test_fuzz_task(restler_working_dir, swagger_path, restler_drop_dir):
 
     expected_strings = [
         'Request coverage (successful / total): 6 / 6',
+        'Attempted requests: 6 / 6',
         'Bugs were found!' ,
         'InvalidDynamicObjectChecker_20x: 2',
         'InvalidDynamicObjectChecker_500: 1',

--- a/restler/engine/fuzzing_parameters/fuzzing_config.py
+++ b/restler/engine/fuzzing_parameters/fuzzing_config.py
@@ -26,6 +26,7 @@ class FuzzingConfig(object):
         self.merge_fuzzable_values = False
         self.max_depth = sys.maxsize
         self.filter_fn = None
+        self.use_constant_enum_value = False
         # Traversal depth state
         self.depth = 0
 
@@ -88,6 +89,7 @@ class FuzzingConfig(object):
         new_config.merge_fuzzable_values = self.merge_fuzzable_values
         new_config.max_depth = self.max_depth
         new_config.filter_fn = self.filter_fn
+        new_config.use_constant_enum_value = self.use_constant_enum_value
 
         return new_config
 

--- a/restler/engine/fuzzing_parameters/param_combinations.py
+++ b/restler/engine/fuzzing_parameters/param_combinations.py
@@ -9,13 +9,27 @@ import json
 import engine.primitives as primitives
 import utils.logger as logger
 from restler_settings import Settings
+from engine.fuzzing_parameters.fuzzing_utils import *
+from engine.fuzzing_parameters.request_params import *
 
-def get_param_list_combinations(param_list, max_combinations):
-    """
-    Generator that takes the specified list and returns all combinations of the elements.
+
+def get_param_list_combinations(param_list, max_combinations, choose_n):
+    """ Generator that takes the specified list and returns all combinations of the elements.
     """
     def generate_combinations():
-        for i in range(1, len(param_list) + 2):
+        param_count = len(param_list)
+        if choose_n is None:
+            combination_size_range = range(1, param_count + 2)
+        elif choose_n == "max":
+            combination_size_range = range(param_count + 1, param_count + 2)
+        else:
+            c = int(choose_n)
+            if 0 < c <= param_count:
+                combination_size_range = range(c + 1, c + 2)
+            else:
+                raise Exception(f"Invalid choose_n specified: {choose_n}, there are only {param_count} parameters.")
+
+        for i in combination_size_range:
             num_items = i - 1
             combinations_num_i = itertools.combinations(param_list, num_items)
             for new_param_list in combinations_num_i:
@@ -24,35 +38,60 @@ def get_param_list_combinations(param_list, max_combinations):
 
     return itertools.islice(generate_combinations(), 0, max_combinations)
 
-def get_param_combinations(req, param_combinations_setting, param_list, param_type):
+
+def filter_required(p_list, required_val=True):
+    """ Given a list of parameters, returns a list
+        containing only the required parameters.
     """
-    param_type is either "header" or "query"
-    """
-    def filter_required(p_list, required_val=True):
-        rp=[]
-        for p in p_list:
-            if p.is_required == required_val:
-                rp.append(p)
-        return rp
+    rp = []
+    for p in p_list:
+        if p.is_required == required_val:
+            rp.append(p)
+    return rp
 
 
-    if 'param_kind' in param_combinations_setting:
-        param_kind = param_combinations_setting['param_kind']
-    else:
-        param_kind = "all"
+def get_max_combinations(param_combinations_setting):
     if 'max_combinations' in param_combinations_setting:
         max_combinations = param_combinations_setting['max_combinations']
     else:
         max_combinations = Settings().max_combinations
+    return max_combinations
 
+
+def get_choose_n(param_combinations_setting):
+    if 'choose_n' in param_combinations_setting:
+        return param_combinations_setting['choose_n']
+    else:
+        return None
+
+
+def get_param_kind(param_combinations_setting):
+    if 'param_kind' in param_combinations_setting:
+        param_kind = param_combinations_setting['param_kind']
+    else:
+        param_kind = "all"
+    return param_kind
+
+
+def get_param_combinations(req, param_combinations_setting, param_list, param_type):
+    """
+    param_type is either "header" or "query"
+    """
+    if param_type not in ["header", "query"]:
+        raise Exception(f"Invalid param_type: {param_type}.  Specify 'header' or 'query'.")
+
+    param_kind = get_param_kind(param_combinations_setting)
+
+    max_combinations = get_max_combinations(param_combinations_setting)
+    choose_n = get_choose_n(param_combinations_setting)
     if param_kind == "all":
         # Send combinations of all available parameters.
-        for x in get_param_list_combinations(param_list, max_combinations):
+        for x in get_param_list_combinations(param_list, max_combinations, choose_n):
             yield x
     elif param_kind == "required":
         # Only send required parameter combinations, and omit optional parameters.
         required_params_list = filter_required(param_list)
-        for x in get_param_list_combinations(required_params_list, max_combinations):
+        for x in get_param_list_combinations(required_params_list, max_combinations, choose_n):
             yield x
     elif param_kind == "optional":
         # Send required parameters, and additionally send combinations
@@ -60,7 +99,7 @@ def get_param_combinations(req, param_combinations_setting, param_list, param_ty
         required_params_list = filter_required(param_list)
         optional_params_list = filter_required(param_list, required_val=False)
 
-        optional_param_combinations = get_param_list_combinations(optional_params_list, max_combinations)
+        optional_param_combinations = get_param_list_combinations(optional_params_list, max_combinations, choose_n)
 
         for opc in optional_param_combinations:
             yield required_params_list + opc
@@ -68,3 +107,297 @@ def get_param_combinations(req, param_combinations_setting, param_list, param_ty
         raise Exception("Invalid setting for parameter combinations:"
                         f"{param_type}_{param_combinations_setting}.  \
                         Valid values are: required, optional, all.")
+
+
+class JsonBodySchemaFuzzerBase:
+    """ Base Class for generating structural json body combinations.
+
+        The functions named 'fuzz_<schema member>' correspond to schema members defined in 'request_params.py'.
+        When 'schema.get_fuzzing_pool' is invoked, 'get_fuzzing_pool' will be invoked on each node, which
+        will, in turn, invoke the 'fuzz_<_>' functions defined below (or overridden in a subclass).
+        The 'fuzz_<_>' do not generate any combinations, and should by default return a fuzzing pool
+        with one schema, equal to the seed.
+        When inheriting from this base class, override the desired 'fuzz_<member kind>' function to
+        generate more than one fuzzed schema.
+    """
+
+    def __init__(self):
+        """ Initialize the body schema fuzzer
+
+        @return: None
+        @rtype:  None
+
+        """
+        self._max_combination = 1000
+        self._max_propagation = 1000
+        self._filter_fn = None
+
+    def set_filter_fn(self, filter_fn):
+        self._filter_fn = filter_fn
+
+    def _get_propagation_product(self, children, bound):
+        """ Return the product sets for propagation
+
+        @param children: A list of children (variants)
+        @type  children: List
+        @param bound: Max num of combination
+        @type  bound: Int
+
+        @return: A list of product
+        @rtype:  List
+
+        """
+        return get_product_linear_fair(children, bound)
+
+    def run(self, schema_seed, config={}):
+        """ Fuzz the seed body schema
+
+        @param schema_seed: Seed body schema to fuzz
+        @type  schema_seed: BodySchema
+        @param config: Run-time configuration
+        @type  config: Dict
+
+        @return: A list of body schema variants
+        @rtype:  List [ParamObject]
+
+        """
+        pool = schema_seed.get_fuzzing_pool(self, config)
+        if len(pool) <= self._max_combination:
+            return pool
+        else:
+            return pool[:self._max_combination]
+
+    def _fuzz_member(self, param_member, fuzzed_value):
+        """ Fuzz a ParamMember node
+        @param param_member: Current fuzzing node
+        @type  param_member: ParamMember
+        @param fuzzed_value: List of value variants (of the member)
+        @type  fuzzed_value: List [ParamValue]
+        @return: A list of member variants
+        @rtype:  List [ParamMember]
+        """
+        include_param_member = self._filter_fn is None or self._filter_fn(param_member)
+        if not include_param_member:
+            return []
+
+        fuzzed_members = []
+        # compose
+        for new_value in fuzzed_value:
+            new_member = ParamMember(param_member.name, new_value, param_member.is_required)
+            new_member.meta_copy(param_member)
+            fuzzed_members.append(new_member)
+
+        return fuzzed_members
+
+    def _fuzz_object(self, param_object, fuzzed_members):
+        """ Fuzz a ParamObject node (with members)
+
+        @param param_object: Current fuzzing node
+        @type  param_object: ParamObject
+        @param fuzzed_members: List of members variants (of the object)
+        @type  fuzzed_members: List [ [ParamMember] ]
+
+        @return: A list of object variants
+        @rtype:  List [ParamObject]
+
+        """
+        # structurally fuzz the object node
+        structurally_fuzzed_fuzzed_members = self._fuzz_members_in_object(
+            fuzzed_members
+        )
+
+        # Each element in structurally_fuzzed_fuzzed_members is a list of
+        # member variants, whose products define an object.
+        members_pool = []
+        for new_fuzzed_members in structurally_fuzzed_fuzzed_members:
+            # new_fuzzed_members =
+            #   [ member1_variants, member2_variants, member3_variants ]
+            members_pool += self._get_propagation_product(
+                new_fuzzed_members, self._max_propagation
+            )
+
+        # shuffle
+        self._apply_shuffle_propagation(members_pool)
+
+        # compose
+        fuzzed_objects = []
+        for members in members_pool:
+            new_object = ParamObject(members)
+            new_object.meta_copy(param_object)
+            fuzzed_objects.append(new_object)
+
+        return fuzzed_objects
+
+    def _fuzz_object_leaf(self, param_object):
+        """ Fuzz a ParamObject node (without members)
+
+        @param param_object: Current fuzzing node
+        @type  param_object: ParamObject
+
+        @return: A list of object variants
+        @rtype:  List [ParamObject]
+
+        """
+        return [param_object]
+
+    def _apply_shuffle_propagation(self, values_pool):
+        """ Shuffle (re-order) the values in the list.  No shuffling is done by default.
+        """
+        pass
+
+    def _fuzz_array(self, param_array, fuzzed_values):
+        """ Fuzz a ParamArray node
+
+        @param param_array: Current fuzzing node
+        @type  param_array: ParamArray
+        @param fuzzed_values: List of values variants (of the array)
+        @type  fuzzed_values: List [ [ParamValue] ]
+
+        @return: A list of array variants
+        @rtype:  List [ParamArray]
+
+        """
+        # structurally fuzz the array node
+        structurally_fuzzed_fuzzed_values = self._fuzz_values_in_array(
+            fuzzed_values
+        )
+
+        # Each element in structurally_fuzzed_fuzzed_values is a list of value
+        # variants, whose products define an array.
+        values_pool = []
+        for new_fuzzed_values in structurally_fuzzed_fuzzed_values:
+            # new_fuzzed_values =
+            #   [ value1_variants, value2_variants, value3_variants ]
+            values_pool += self._get_propagation_product(
+                new_fuzzed_values, self._max_propagation
+            )
+
+        # shuffle
+        self._apply_shuffle_propagation(values_pool)
+
+        # compose
+        fuzzed_array = []
+        for values in values_pool:
+            new_array = ParamArray(values)
+            new_array.meta_copy(param_array)
+            fuzzed_array.append(new_array)
+
+        return fuzzed_array
+
+    def _fuzz_string(self, param_string):
+        """ Fuzz a ParamString node
+
+        @param param_string: Current fuzzing node
+        @type  param_string: ParamString
+
+        @return: A list of string variants
+        @rtype:  List [ParamString]
+
+        """
+        return [param_string]
+
+    def _fuzz_number(self, param_number):
+        """ Fuzz a ParamNumber node
+
+        @param param_number: Current fuzzing node
+        @type  param_number: ParamNumber
+
+        @return: A list of number variants
+        @rtype:  List [ParamNumber]
+
+        """
+        return [param_number]
+
+    def _fuzz_boolean(self, param_boolean):
+        """ Fuzz a ParamBoolean node
+
+        @param param_number: Current fuzzing node
+        @type: param_number: ParamBoolean
+
+        @return: A lsit of Boolean variants
+        @rtype:  List [ParamBoolean]
+
+        """
+        return [param_boolean]
+
+    def _fuzz_enum(self, param_enum):
+        """ Fuzz a ParamEnum node
+
+        @param param_enum: Current fuzzing node
+        @type  param_enum: ParamEnum
+
+        @return: A list of enum variants
+        @rtype:  List [ParamEnum]
+
+        """
+        return [param_enum]
+
+    def _fuzz_members_in_object(self, fuzzed_members):
+        """ Fuzz members in a ParamObject node
+
+        @param fuzzed_members: A list of member variants (length == object size)
+        @type  fuzzed_members: List [ [ParamMember] ]
+
+        @return: A list of variants of member variants
+        @rtype:  List [ [ [ParamMember] ] ]
+
+        """
+        # fuzzed_members =
+        #   [ member1_variants, member2_variants, ..., memberN_variants ]
+        return [fuzzed_members]
+
+    def _fuzz_values_in_array(self, fuzzed_values):
+        """ Fuzz values in a ParamArray node
+
+        @param fuzzed_values: A list of value variants (length == array size)
+        @type  fuzzed_values: List [ [ParamValue] ]
+
+        @return: A list of variants of value variants
+        @rtype:  List [ [ [ParamValue] ] ]
+
+        """
+        # fuzzed_values =
+        #   [ value1_variants, value2_variants, ..., valueN_variants ]
+        return [fuzzed_values]
+
+
+class JsonBodyPropertyCombinations(JsonBodySchemaFuzzerBase):
+    """
+    Generates combinations of JSON body properties.
+    """
+    def __init__(self):
+        JsonBodySchemaFuzzerBase.__init__(self)
+
+    def _generate_member_combinations(self, fuzzed_items, max_combinations=None):
+        """ Compute combinations of the fuzzed items, which are
+            properties.
+            Supports returning n-wise combinations up to 'max_combinations'.
+        """
+        member_combinations = get_param_list_combinations(fuzzed_items, max_combinations, choose_n=None)
+        combination_list = list(member_combinations)
+        return combination_list
+
+    def _fuzz_members_in_object(self, fuzzed_members):
+        return self._generate_member_combinations(fuzzed_members)
+
+
+def get_body_param_combinations(req, param_combinations_setting, body_schema):
+    """
+    Gets the body parameter combinations according to the specified setting.
+
+    TODO: not fully implemented.  Currently, this function supports filtering
+    the schema only.  The rest of the 'param_combination_setting' properties
+    are not used.
+    """
+    max_combinations = get_max_combinations(param_combinations_setting)
+    param_kind = get_param_kind(param_combinations_setting)
+
+    schema_generator = JsonBodySchemaFuzzerBase()
+
+    if param_kind == "optional":
+        schema_generator.set_filter_fn(lambda x: x.is_required)
+
+    schema_pool = schema_generator.run(body_schema)
+    for new_schema in schema_pool:
+        yield new_schema
+

--- a/restler/engine/fuzzing_parameters/parameter_schema.py
+++ b/restler/engine/fuzzing_parameters/parameter_schema.py
@@ -67,26 +67,26 @@ class KeyValueParamList():
         """
         self.param_list.append(param_item)
 
-    # def get_fuzzing_pool(self, fuzzer, config):
-    #     """ Returns the fuzzing pool
-    #
-    #     @param fuzzer: The body fuzzer object to use for fuzzing
-    #     @type  fuzzer: BodySchemaStructuralFuzzer
-    #
-    #     @return: The fuzzing pool
-    #     @rtype : List[ParamObject]
-    #
-    #     """
-    #     fuzzed_members = []
-    #     for param_item in self.param_list:
-    #         item_fuzzing_pool = param_item.get_fuzzing_pool(fuzzer, config)  #list of key=value pairs
-    #         # It is possible that this member was excluded from fuzzing by
-    #         # a filter configured by the fuzzer.  If so, do not add it to
-    #         # 'fuzzed_members'.
-    #         if len(item_fuzzing_pool) > 0:
-    #             fuzzed_members.append(item_fuzzing_pool)
-    #
-    #     return fuzzer._fuzz_param_list(fuzzed_members)  # list of lists of key=value pairs
+    def get_fuzzing_pool(self, fuzzer, config):
+        """ Returns the fuzzing pool
+
+        @param fuzzer: The body fuzzer object to use for fuzzing
+        @type  fuzzer: BodySchemaStructuralFuzzer
+
+        @return: The fuzzing pool
+        @rtype : List[ParamObject]
+
+        """
+        fuzzed_members = []
+        for param_item in self.param_list:
+            item_fuzzing_pool = param_item.get_fuzzing_pool(fuzzer, config)  #list of key=value pairs
+            # It is possible that this member was excluded from fuzzing by
+            # a filter configured by the fuzzer.  If so, do not add it to
+            # 'fuzzed_members'.
+            if len(item_fuzzing_pool) > 0:
+                fuzzed_members.append(item_fuzzing_pool)
+
+        return fuzzer._fuzz_param_list(fuzzed_members)  # list of lists of key=value pairs
 
 class QueryList(KeyValueParamList):
     def __init__(self, request_schema_json=None, param=None):

--- a/restler/engine/fuzzing_parameters/request_examples.py
+++ b/restler/engine/fuzzing_parameters/request_examples.py
@@ -43,6 +43,7 @@ class RequestExamples():
         except Exception as err:
             msg = f'Fail deserializing request schema header examples: {err!s}'
             logger.write_to_main(msg, print_to_console=True)
+            raise Exception(msg)
 
         try:
             self._set_body_params(request_schema_json['bodyParameters'])

--- a/restler/unit_tests/grammar_schema_test_files/null_test_example_grammar.json
+++ b/restler/unit_tests/grammar_schema_test_files/null_test_example_grammar.json
@@ -1,0 +1,477 @@
+{
+  "Requests": [
+    {
+      "id": {
+        "endpoint": "/customer",
+        "method": "Post"
+      },
+      "method": "Post",
+      "basePath": "",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "customer"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Examples",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Constant": [
+                        "String",
+                        "zzz"
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Examples",
+          {
+            "ParameterList": [
+              {
+                "name": "body",
+                "payload": {
+                  "InternalNode": [
+                    {
+                      "name": "",
+                      "propertyType": "Object",
+                      "isRequired": true,
+                      "isReadOnly": false
+                    },
+                    [
+                      {
+                        "LeafNode": {
+                          "name": "id",
+                          "payload": {
+                            "Constant": [
+                              "String",
+                              "zzz"
+                            ]
+                          },
+                          "isRequired": false,
+                          "isReadOnly": false
+                        }
+                      },
+                      {
+                        "InternalNode": [
+                          {
+                            "name": "Person",
+                            "propertyType": "Property",
+                            "isRequired": false,
+                            "isReadOnly": false
+                          },
+                          [
+                            {
+                              "InternalNode": [
+                                {
+                                  "name": "",
+                                  "propertyType": "Object",
+                                  "isRequired": false,
+                                  "isReadOnly": false
+                                },
+                                [
+                                  {
+                                    "LeafNode": {
+                                      "name": "name",
+                                      "payload": {
+                                        "Constant": [
+                                          "String",
+                                          "zzz"
+                                        ]
+                                      },
+                                      "isRequired": true,
+                                      "isReadOnly": false
+                                    }
+                                  },
+                                  {
+                                    "LeafNode": {
+                                      "name": "address",
+                                      "payload": {
+                                        "Constant": [
+                                          "Object",
+                                          null
+                                        ]
+                                      },
+                                      "isRequired": true,
+                                      "isReadOnly": false
+                                    }
+                                  }
+                                ]
+                              ]
+                            }
+                          ]
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "body",
+                "payload": {
+                  "InternalNode": [
+                    {
+                      "name": "",
+                      "propertyType": "Object",
+                      "isRequired": true,
+                      "isReadOnly": false
+                    },
+                    [
+                      {
+                        "LeafNode": {
+                          "name": "id",
+                          "payload": {
+                            "Fuzzable": {
+                              "primitiveType": "String",
+                              "defaultValue": "fuzzstring"
+                            }
+                          },
+                          "isRequired": false,
+                          "isReadOnly": false
+                        }
+                      },
+                      {
+                        "InternalNode": [
+                          {
+                            "name": "Person",
+                            "propertyType": "Property",
+                            "isRequired": false,
+                            "isReadOnly": false
+                          },
+                          [
+                            {
+                              "InternalNode": [
+                                {
+                                  "name": "",
+                                  "propertyType": "Object",
+                                  "isRequired": false,
+                                  "isReadOnly": false
+                                },
+                                [
+                                  {
+                                    "LeafNode": {
+                                      "name": "name",
+                                      "payload": {
+                                        "Fuzzable": {
+                                          "primitiveType": "String",
+                                          "defaultValue": "fuzzstring"
+                                        }
+                                      },
+                                      "isRequired": true,
+                                      "isReadOnly": false
+                                    }
+                                  },
+                                  {
+                                    "LeafNode": {
+                                      "name": "address",
+                                      "payload": {
+                                        "Fuzzable": {
+                                          "primitiveType": "Object",
+                                          "defaultValue": "{ \"fuzz\": false }"
+                                        }
+                                      },
+                                      "isRequired": true,
+                                      "isReadOnly": false
+                                    }
+                                  }
+                                ]
+                              ]
+                            }
+                          ]
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Examples",
+          {
+            "ParameterList": [
+              {
+                "name": "schema-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Constant": [
+                        "String",
+                        "zzz"
+                      ]
+                    },
+                    "isRequired": false,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "schema-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": false,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": [
+              {
+                "name": "Content-Type",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Constant": [
+                        "String",
+                        "application/json"
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          null
+        ]
+      ],
+      "httpVersion": "1.1",
+      "dependencyData": {
+        "responseParser": {
+          "writerVariables": [
+            {
+              "requestId": {
+                "endpoint": "/customer",
+                "method": "Post"
+              },
+              "accessPathParts": {
+                "path": [
+                  "id"
+                ]
+              },
+              "primitiveType": "String",
+              "kind": "BodyResponseProperty"
+            }
+          ],
+          "headerWriterVariables": []
+        },
+        "inputWriterVariables": [],
+        "orderingConstraintWriterVariables": [],
+        "orderingConstraintReaderVariables": []
+      },
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/customer/{customerId}",
+        "method": "Get"
+      },
+      "method": "Get",
+      "basePath": "",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "customer"
+          ]
+        },
+        {
+          "DynamicObject": {
+            "primitiveType": "String",
+            "variableName": "_customer_post_id",
+            "isWriter": false
+          }
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "schema-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": false,
+                    "isReadOnly": false
+                  }
+                }
+              },
+              {
+                "name": "view-option",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": {
+                          "Enum": [
+                            "view-option",
+                            "String",
+                            [
+                              "detailed",
+                              "minimal"
+                            ],
+                            null
+                          ]
+                        },
+                        "defaultValue": "detailed"
+                      }
+                    },
+                    "isRequired": false,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          null
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    }
+  ]
+}

--- a/restler/unit_tests/grammar_schema_test_files/null_test_example_grammar.py
+++ b/restler/unit_tests/grammar_schema_test_files/null_test_example_grammar.py
@@ -1,0 +1,124 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_customer_post_id = dependencies.DynamicVariable("_customer_post_id")
+
+def parse_customerpost(data, **kwargs):
+    """ Automatically generated response parser """
+    # Declare response variables
+    temp_7262 = None
+
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        try:
+            data = json.loads(data)
+        except Exception as error:
+            raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+        pass
+
+    # Try to extract each dynamic object
+
+        try:
+            temp_7262 = str(data["id"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
+
+
+
+    # If no dynamic objects were extracted, throw.
+    if not (temp_7262):
+        raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
+
+    # Set dynamic variables
+    if temp_7262:
+        dependencies.set_variable("_customer_post_id", temp_7262)
+
+req_collection = requests.RequestCollection([])
+# Endpoint: /customer, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("customer"),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("api-version="),
+    primitives.restler_static_string("zzz"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("schema-version: "),
+    primitives.restler_static_string("zzz"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "id":"zzz",
+    "Person":
+        {
+            "name":"zzz",
+            "address":null
+        }
+    }"""),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+
+        'post_send':
+        {
+            'parser': parse_customerpost,
+            'dependencies':
+            [
+                _customer_post_id.writer()
+            ]
+        }
+
+    },
+
+],
+requestId="/customer"
+)
+req_collection.add_request(request)
+
+# Endpoint: /customer/{customerId}, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("customer"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_customer_post_id.reader(), quoted=False),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("api-version="),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("schema-version: "),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("view-option: "),
+    primitives.restler_fuzzable_group("view-option", ['detailed','minimal']  ,quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/customer/{customerId}"
+)
+req_collection.add_request(request)

--- a/restler/unit_tests/grammar_schema_test_files/null_test_swagger.json
+++ b/restler/unit_tests/grammar_schema_test_files/null_test_swagger.json
@@ -1,0 +1,130 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple Swagger with all parameter types",
+    "version": "1"
+  },
+  "paths": {
+    "/customer": {
+      "post": {
+        "operationId": "post_customer",
+        "examples": {
+            "null example": {
+              "parameters": {
+              "api-version": "zzz",
+              "schema-version": "zzz",
+              "body": {
+                "id": "zzz",
+                "Person": {
+                  "name": "zzz",
+                  "address": null
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "schema-version",
+            "type": "string",
+            "in": "header",
+            "required": false
+          },
+          {
+            "name": "body",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Customer"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Customer"
+            }
+          }
+        }
+      }
+    },
+    "/customer/{customerId}": {
+      "get": {
+        "operationId": "post_customer",
+        "parameters": [
+          {
+            "name": "customerId",
+            "type": "string",
+            "in": "path",
+            "required": true
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "schema-version",
+            "type": "string",
+            "in": "header",
+            "required": false
+          },
+          {
+            "name": "view-option",
+            "type": "string",
+            "enum": [
+              "detailed",
+              "minimal"
+            ],
+            "in": "header",
+            "required": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Customer"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Customer": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "Person": {
+          "$ref": "#/definitions/Person"
+        }
+      }
+    },
+    "Person": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "address": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "address"
+      ]
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/restler/unit_tests/grammar_schema_test_files/uuidsuffix_test_grammar.json
+++ b/restler/unit_tests/grammar_schema_test_files/uuidsuffix_test_grammar.json
@@ -1,0 +1,348 @@
+{
+  "Requests": [
+    {
+      "id": {
+        "endpoint": "/customer",
+        "method": "Post"
+      },
+      "method": "Post",
+      "basePath": "",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "customer"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "body",
+                "payload": {
+                  "InternalNode": [
+                    {
+                      "name": "",
+                      "propertyType": "Object",
+                      "isRequired": true,
+                      "isReadOnly": false
+                    },
+                    [
+                      {
+                        "LeafNode": {
+                          "name": "id",
+                          "payload": {
+                            "Custom": {
+                              "payloadType": "UuidSuffix",
+                              "primitiveType": "String",
+                              "payloadValue": "id",
+                              "isObject": false
+                            }
+                          },
+                          "isRequired": false,
+                          "isReadOnly": false
+                        }
+                      },
+                      {
+                        "InternalNode": [
+                          {
+                            "name": "Person",
+                            "propertyType": "Property",
+                            "isRequired": false,
+                            "isReadOnly": false
+                          },
+                          [
+                            {
+                              "InternalNode": [
+                                {
+                                  "name": "",
+                                  "propertyType": "Object",
+                                  "isRequired": false,
+                                  "isReadOnly": false
+                                },
+                                [
+                                  {
+                                    "LeafNode": {
+                                      "name": "name",
+                                      "payload": {
+                                        "Fuzzable": {
+                                          "primitiveType": "String",
+                                          "defaultValue": "fuzzstring"
+                                        }
+                                      },
+                                      "isRequired": true,
+                                      "isReadOnly": false
+                                    }
+                                  },
+                                  {
+                                    "LeafNode": {
+                                      "name": "address",
+                                      "payload": {
+                                        "Fuzzable": {
+                                          "primitiveType": "Object",
+                                          "defaultValue": "{ \"fuzz\": false }"
+                                        }
+                                      },
+                                      "isRequired": true,
+                                      "isReadOnly": false
+                                    }
+                                  }
+                                ]
+                              ]
+                            }
+                          ]
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "schema-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": false,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": [
+              {
+                "name": "Content-Type",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Constant": [
+                        "String",
+                        "application/json"
+                      ]
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          null
+        ]
+      ],
+      "httpVersion": "1.1",
+      "dependencyData": {
+        "responseParser": {
+          "writerVariables": [
+            {
+              "requestId": {
+                "endpoint": "/customer",
+                "method": "Post"
+              },
+              "accessPathParts": {
+                "path": [
+                  "id"
+                ]
+              },
+              "primitiveType": "String",
+              "kind": "BodyResponseProperty"
+            }
+          ],
+          "headerWriterVariables": []
+        },
+        "inputWriterVariables": [],
+        "orderingConstraintWriterVariables": [],
+        "orderingConstraintReaderVariables": []
+      },
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/customer/{customerId}",
+        "method": "Get"
+      },
+      "method": "Get",
+      "basePath": "",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "customer"
+          ]
+        },
+        {
+          "DynamicObject": {
+            "primitiveType": "String",
+            "variableName": "_customer_post_id",
+            "isWriter": false
+          }
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "api-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": true,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": [
+              {
+                "name": "schema-version",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": "String",
+                        "defaultValue": "fuzzstring"
+                      }
+                    },
+                    "isRequired": false,
+                    "isReadOnly": false
+                  }
+                }
+              },
+              {
+                "name": "view-option",
+                "payload": {
+                  "LeafNode": {
+                    "name": "",
+                    "payload": {
+                      "Fuzzable": {
+                        "primitiveType": {
+                          "Enum": [
+                            "view-option",
+                            "String",
+                            [
+                              "detailed",
+                              "minimal"
+                            ],
+                            null
+                          ]
+                        },
+                        "defaultValue": "detailed"
+                      }
+                    },
+                    "isRequired": false,
+                    "isReadOnly": false
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          null
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    }
+  ]
+}

--- a/restler/unit_tests/grammar_schema_test_files/uuidsuffix_test_grammar.py
+++ b/restler/unit_tests/grammar_schema_test_files/uuidsuffix_test_grammar.py
@@ -1,0 +1,131 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_customer_post_id = dependencies.DynamicVariable("_customer_post_id")
+
+def parse_customerpost(data, **kwargs):
+    """ Automatically generated response parser """
+    # Declare response variables
+    temp_7262 = None
+
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        try:
+            data = json.loads(data)
+        except Exception as error:
+            raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+        pass
+
+    # Try to extract each dynamic object
+
+        try:
+            temp_7262 = str(data["id"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
+
+
+
+    # If no dynamic objects were extracted, throw.
+    if not (temp_7262):
+        raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
+
+    # Set dynamic variables
+    if temp_7262:
+        dependencies.set_variable("_customer_post_id", temp_7262)
+
+req_collection = requests.RequestCollection([])
+# Endpoint: /customer, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("customer"),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("api-version="),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("schema-version: "),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "id":"""),
+    primitives.restler_static_string('"'),
+    primitives.restler_custom_payload_uuid4_suffix("id"),
+    primitives.restler_static_string("""",
+    "Person":
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "address":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    }"""),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+
+        'post_send':
+        {
+            'parser': parse_customerpost,
+            'dependencies':
+            [
+                _customer_post_id.writer()
+            ]
+        }
+
+    },
+
+],
+requestId="/customer"
+)
+req_collection.add_request(request)
+
+# Endpoint: /customer/{customerId}, method: Get
+request = requests.Request([
+    primitives.restler_static_string("GET "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("customer"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_customer_post_id.reader(), quoted=False),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("api-version="),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_static_string("schema-version: "),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("view-option: "),
+    primitives.restler_fuzzable_group("view-option", ['detailed','minimal']  ,quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/customer/{customerId}"
+)
+req_collection.add_request(request)

--- a/restler/unit_tests/grammar_schema_test_files/uuidsuffix_test_swagger.json
+++ b/restler/unit_tests/grammar_schema_test_files/uuidsuffix_test_swagger.json
@@ -1,0 +1,115 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple Swagger with all parameter types",
+    "version": "1"
+  },
+  "paths": {
+    "/customer": {
+      "post": {
+        "operationId": "post_customer",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "schema-version",
+            "type": "string",
+            "in": "header",
+            "required": false
+          },
+          {
+            "name": "body",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Customer"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Customer"
+            }
+          }
+        }
+      }
+    },
+    "/customer/{customerId}": {
+      "get": {
+        "operationId": "post_customer",
+        "parameters": [
+          {
+            "name": "customerId",
+            "type": "string",
+            "in": "path",
+            "required": true
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "schema-version",
+            "type": "string",
+            "in": "header",
+            "required": false
+          },
+          {
+            "name": "view-option",
+            "type": "string",
+            "enum": [
+              "detailed",
+              "minimal"
+            ],
+            "in": "header",
+            "required": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Customer"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Customer": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "Person": {
+          "$ref": "#/definitions/Person"
+        }
+      }
+    },
+    "Person": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "address": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "address"
+      ]
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/restler/unit_tests/log_baseline_test_files/abc_smoke_test_settings_prefix_cache.json
+++ b/restler/unit_tests/log_baseline_test_files/abc_smoke_test_settings_prefix_cache.json
@@ -12,5 +12,8 @@
         "reset_after_success": false
       }
     ]
+  },
+  "test_combinations_settings": {
+    "max_schema_combinations": 1
   }
 }

--- a/restler/unit_tests/log_baseline_test_files/always_render_full_seq_settings.json
+++ b/restler/unit_tests/log_baseline_test_files/always_render_full_seq_settings.json
@@ -2,5 +2,8 @@
   "sequence_exploration_settings": {
     "create_prefix_once": [
     ]
+  },
+  "test_combinations_settings": {
+    "max_schema_combinations": 1
   }
 }

--- a/restler/unit_tests/log_baseline_test_files/test_one_schema_settings.json
+++ b/restler/unit_tests/log_baseline_test_files/test_one_schema_settings.json
@@ -1,0 +1,5 @@
+{
+  "test_combinations_settings": {
+    "max_schema_combinations":  1
+  }
+}

--- a/restler/unit_tests/log_baseline_test_files/test_settings_createonce.json
+++ b/restler/unit_tests/log_baseline_test_files/test_settings_createonce.json
@@ -1,4 +1,7 @@
 {
+  "test_combinations_settings": {
+    "max_schema_combinations":  1
+  },
     "per_resource_settings": {
         "/item/{itemName}": {
             "producer_timing_delay": 0,

--- a/restler/unit_tests/log_baseline_test_files/value_gen_settings.json
+++ b/restler/unit_tests/log_baseline_test_files/value_gen_settings.json
@@ -1,1 +1,1 @@
-{"custom_value_generators": "D:\\git\\restler-fuzzer\\restler\\unit_tests\\log_baseline_test_files\\custom_value_gen.py", "max_combinations": 6}
+{"custom_value_generators": "D:\\git\\restler-fuzzer\\restler\\unit_tests\\log_baseline_test_files\\custom_value_gen.py", "max_combinations": 6, "test_combinations_settings": {"max_schema_combinations": 1}}

--- a/restler/unit_tests/test_basic_functionality_end_to_end.py
+++ b/restler/unit_tests/test_basic_functionality_end_to_end.py
@@ -93,7 +93,7 @@ class FunctionalityTests(unittest.TestCase):
                   "Experiments directory was not deleted.")
 
     def test_abc_invalid_b_smoke_test(self):
-        self.run_abc_smoke_test(Test_File_Directory, "abc_test_grammar_invalid_b.py", "directed-smoke-test")
+        self.run_abc_smoke_test(Test_File_Directory, "abc_test_grammar_invalid_b.py", "directed-smoke-test", settings_file="test_one_schema_settings.json")
         experiments_dir = self.get_experiments_dir()
 
         # Make sure all requests were successfully rendered.  This is because the comparisons below do not
@@ -170,7 +170,8 @@ class FunctionalityTests(unittest.TestCase):
 
 
         """
-        self.run_abc_smoke_test(Test_File_Directory, "abc_test_grammar_combinations.py", "test-all-combinations")
+        self.run_abc_smoke_test(Test_File_Directory, "abc_test_grammar_combinations.py", "test-all-combinations",
+                                settings_file="test_one_schema_settings.json")
         experiments_dir = self.get_experiments_dir()
 
         ## Make sure all requests were successfully rendered.  This is because the comparisons below do not
@@ -462,10 +463,12 @@ class FunctionalityTests(unittest.TestCase):
         bugs planted for each checker, and a main driver bug, will produce the
         appropriate bug buckets and the requests will be sent in the correct order.
         """
+        settings_file_path = os.path.join(Test_File_Directory, "test_one_schema_settings.json")
         args = Common_Settings + [
             '--fuzzing_mode', 'directed-smoke-test',
             '--restler_grammar', f'{os.path.join(Test_File_Directory, "test_grammar_bugs.py")}',
-            '--enable_checkers', '*'
+            '--enable_checkers', '*',
+            '--settings', f'{settings_file_path}'
         ]
 
         result = subprocess.run(args, capture_output=True)
@@ -541,12 +544,15 @@ class FunctionalityTests(unittest.TestCase):
         """
         Fuzz_Time = 0.1 # 6 minutes
         Num_Sequences = 300
+        settings_file_path = os.path.join(Test_File_Directory, "test_one_schema_settings.json")
+
         args = Common_Settings + [
             '--fuzzing_mode', 'bfs-cheap',
             '--restler_grammar',f'{os.path.join(Test_File_Directory, "test_grammar.py")}',
             '--time_budget', f'{Fuzz_Time}',
             '--enable_checkers', '*',
-            '--disable_checkers', 'namespacerule'
+            '--disable_checkers', 'namespacerule',
+            '--settings', f'{settings_file_path}'
         ]
 
         result = subprocess.run(args, capture_output=True)
@@ -578,10 +584,14 @@ class FunctionalityTests(unittest.TestCase):
         unexpected changes exist.
 
         """
+
+        settings_file_path = os.path.join(Test_File_Directory, "test_one_schema_settings.json")
+
         args = Common_Settings + [
             '--fuzzing_mode', 'directed-smoke-test',
             '--restler_grammar', f'{os.path.join(Test_File_Directory, "test_grammar.py")}',
-            '--enable_checkers', 'payloadbody'
+            '--enable_checkers', 'payloadbody',
+            '--settings', f'{settings_file_path}'
         ]
 
         result = subprocess.run(args, capture_output=True)
@@ -626,10 +636,12 @@ class FunctionalityTests(unittest.TestCase):
         unexpected changes exist.
 
         """
+        settings_file_path = os.path.join(Test_File_Directory, "test_one_schema_settings.json")
         args = Common_Settings + [
             '--fuzzing_mode', 'directed-smoke-test',
             '--restler_grammar', f'{os.path.join(Test_File_Directory, "test_grammar_body.py")}',
-            '--enable_checkers', 'payloadbody'
+            '--enable_checkers', 'payloadbody',
+            '--settings', f'{settings_file_path}'
         ]
 
         result = subprocess.run(args, capture_output=True)


### PR DESCRIPTION
Test mode is modified as follows:
- instead of just testing the first schema, test all examples (if available), then required only parameters, then the
originally tested request in grammar.py

TODO:
- unit testing
- implement remaining items in param_combinations.py
- modify the last request to be 'test all parameters' (this will be done outside of this PR)
- switch to 'get_original_blocks' in requests.py