### PR TITLE
Fix double slash in basepath issue

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -662,7 +662,12 @@ class Request(object):
             basepath = self._definition[basepath_idx][1]
             if Settings().basepath is not None:
                 basepath = Settings().basepath
+            # If the base path ends with a slash, remove it - the
+            # following line already contains a static slash
+            if basepath.endswith("/"):
+                basepath = basepath[:-1]
             self._definition[basepath_idx] = primitives.restler_static_string(basepath)
+
         else:
             # No basepath custom payload in the grammar - this is possible for older grammar versions.
             # Do nothing

--- a/src/compiler/Restler.Compiler.Test/DependencyTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DependencyTests.fs
@@ -164,9 +164,11 @@ module Dependencies =
         /// Regression test for cycles created from body dependencies
         [<Fact>]
         let ``no dependencies when the same body is used in unrelated requests`` () =
+            let outputDirectory = ctx.testRootDirPath
+                             
             let config = { Restler.Config.SampleConfig with
                              IncludeOptionalParameters = true
-                             GrammarOutputDirectoryPath = Some ctx.testRootDirPath
+                             GrammarOutputDirectoryPath = Some outputDirectory
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\body_dependency_cycles.json"))]
@@ -177,7 +179,7 @@ module Dependencies =
 
             // Read the dependencies.json and check that there are 3 producer-consumer dependencies.
             let dependencies =
-                let dependenciesJsonFilePath = Path.Combine(ctx.testRootDirPath,
+                let dependenciesJsonFilePath = Path.Combine(outputDirectory,
                                                             Restler.Workflow.Constants.DependenciesDebugFileName)
 
                 Microsoft.FSharpLu.Json.Compact.deserializeFile<ProducerConsumerDependency list> dependenciesJsonFilePath

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
@@ -10,6 +10,7 @@
         "method": "Put"
       },
       "method": "Put",
+      "basePath": "",
       "path": [
         {
           "Constant": [
@@ -112,6 +113,7 @@
         "method": "Put"
       },
       "method": "Put",
+      "basePath": "",
       "path": [
         {
           "Custom": {
@@ -310,6 +312,7 @@
         "method": "Put"
       },
       "method": "Put",
+      "basePath": "",
       "path": [
         {
           "Custom": {
@@ -469,6 +472,7 @@
         "method": "Get"
       },
       "method": "Get",
+      "basePath": "",
       "path": [
         {
           "DynamicObject": {
@@ -601,6 +605,7 @@
         "method": "Get"
       },
       "method": "Get",
+      "basePath": "",
       "path": [
         {
           "DynamicObject": {
@@ -694,6 +699,7 @@
         "method": "Delete"
       },
       "method": "Delete",
+      "basePath": "",
       "path": [
         {
           "DynamicObject": {

--- a/src/compiler/Restler.Compiler/Compiler.fs
+++ b/src/compiler/Restler.Compiler/Compiler.fs
@@ -1340,7 +1340,19 @@ let generateRequestGrammar (swaggerDocs:Types.ApiSpecFuzzingConfig list)
 
     let dependencyInfo = getResponseParsers dependencies orderingConstraints
 
-    let basePath = swaggerDocs.[0].swaggerDoc.BasePath
+    let basePath = 
+        // Remove the ending slash if present, since a static slash will
+        // be inserted in the grammar
+        // Note: this code is not sufficient, and the same logic must be added in the engine,
+        // since the user may specify their own base path through a custom payload.
+        // However, this is included here as well so reading the grammar is not confusing and for any
+        // other tools that may process the grammar separately from the engine.
+        let bp = swaggerDocs.[0].swaggerDoc.BasePath 
+        if String.IsNullOrEmpty bp then ""
+        elif bp.EndsWith("/") then
+            bp.[0..bp.Length-2]
+        else
+            bp
     let host = swaggerDocs.[0].swaggerDoc.Host
 
     // Get the request primitives for each request


### PR DESCRIPTION
This change has two parts:
1) Remove extra slash in the compiler.  This makes only one slash appear in the grammar.
2) Remove extra slash in the engine.  This is not needed to fix the reported issue, but will address the same issue where the user dynamically specifies a basepath that ends in a slash in the engine settings.

Testing:
- manual testing

Closes #580