### PR TITLE
Script for creating a RESTler job configuration.

### DIFF
--- a/src/compiler/Restler.Compiler/Annotations.fs
+++ b/src/compiler/Restler.Compiler/Annotations.fs
@@ -11,6 +11,10 @@ open Newtonsoft.Json.Linq
 open Restler.Utilities.JsonParse
 open Restler.XMsPaths
 
+module Constants = 
+    let GlobalAnnotationKey = "x-restler-global-annotations"
+    let EmptyAnnotationFile = JObject(JProperty(GlobalAnnotationKey)).ToString()
+
 type ExceptConsumerUserAnnotation =
     {
        consumer_endpoint : string
@@ -208,8 +212,8 @@ let getGlobalAnnotationsFromFile filePath =
     if File.Exists filePath then
         let annFileText = System.IO.File.ReadAllText(filePath)
         let globalAnnotationsJson = JObject.Parse(annFileText)
-        let globalAnnotationKey = "x-restler-global-annotations"
-        match Restler.Utilities.JsonParse.getProperty globalAnnotationsJson globalAnnotationKey with
+
+        match Restler.Utilities.JsonParse.getProperty globalAnnotationsJson Constants.GlobalAnnotationKey with
         | Some globalAnn ->
             getAnnotationsFromJson globalAnn
         | None ->

--- a/src/compiler/Restler.Compiler/Config.fs
+++ b/src/compiler/Restler.Compiler/Config.fs
@@ -4,6 +4,7 @@
 module Restler.Config
 
 open System.IO
+open Newtonsoft.Json.Linq
 
 /// The 'type' of the resource is inferred based on the naming of its name and container as
 /// well as conventions for the API method (e.g. PUT vs. POST).
@@ -291,3 +292,11 @@ let DefaultConfig =
         TrackFuzzedParameterNames = false
         JsonPropertyMaxDepth = None
     }
+
+// A helper function to override defaults with user-specified config values 
+// when the user specifies only some of the properties
+let mergeWithDefaultConfig (userConfigAsString:string) =
+    let defaultConfig = Microsoft.FSharpLu.Json.Compact.serialize DefaultConfig
+    let newConfig = Restler.Utilities.JsonParse.mergeWithOverride defaultConfig userConfigAsString
+
+    Microsoft.FSharpLu.Json.Compact.deserialize<Config> newConfig

--- a/src/compiler/Restler.Compiler/Restler.Compiler.fsproj
+++ b/src/compiler/Restler.Compiler/Restler.Compiler.fsproj
@@ -14,9 +14,9 @@
     <Tailcalls>true</Tailcalls>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Utilities.fs" />
     <Compile Include="Config.fs" />
     <Compile Include="Telemetry.fs" />
-    <Compile Include="Utilities.fs" />
     <Compile Include="XMsPaths.fs" />
     <Compile Include="SwaggerSpecPreprocessor.fs" />
     <Compile Include="Swagger.fs" />

--- a/src/compiler/Restler.Compiler/Utilities.fs
+++ b/src/compiler/Restler.Compiler/Utilities.fs
@@ -61,6 +61,17 @@ module JsonParse =
         else
             None
 
+    let mergeWithOverride (defaultJson:string) (overrideJson:string) =
+        let newJson = JObject.Parse(defaultJson)
+        let userConfigAsJson = JObject.Parse(overrideJson)
+        for prop in userConfigAsJson.Properties() do
+            // Overwrite the default property
+            newJson.Remove(prop.Name) |> ignore
+            newJson.Add(prop.Name, prop.Value)
+
+        newJson.ToString()
+
+
 module Dict =
     open System.Collections.Generic
     let tryGetString (dict:IDictionary<_, obj>) name =


### PR DESCRIPTION
Use case:

1. Compile the spec with ```restler compile --api_spec <spec path>```
(The output files are now in a ```Compile``` subdirectory)
2. Run the script to create a configuration directory from the RESTler-generated files, which will be modified to improve coverage.

python ./extract-config.py --compile_dir .\Compile

Testing:
- manual testing

TODO:
- add documentation for the new script once the UX is finalized.


Closes #211.