### PR TITLE
Several fixes to Open API 3 Examples support

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -181,6 +181,9 @@
     <Content Include="swagger\schemaTests\openapi3_requestbody.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+	  <Content Include="swagger\schemaTests\openapi3_examples.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
 
     <Content Include="swagger\schemaTests\xMsPaths_annotations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/compiler/Restler.Compiler.Test/SchemaTests.fs
+++ b/src/compiler/Restler.Compiler.Test/SchemaTests.fs
@@ -170,4 +170,30 @@ module ApiSpecSchema =
             for ep in expectedProperties do
                 Assert.True(grammar.Contains(sprintf "\"%s\":" ep))
 
+        [<Fact>]
+        let ``openapi3 examples`` () =
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\openapi3_examples.json")
+            let config = { Restler.Config.SampleConfig with
+                                IncludeOptionalParameters = true
+                                GrammarOutputDirectoryPath = Some ctx.testRootDirPath
+                                ResolveBodyDependencies = true
+                                ResolveQueryDependencies = true
+                                SwaggerSpecFilePath = Some [specFilePath]
+                            }
+            Restler.Workflow.generateRestlerGrammar None config
+            let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
+            let grammar = File.ReadAllText(grammarOutputFilePath)
+            
+            Assert.True(grammar.Contains("9.9999"))
+            Assert.True(grammar.Contains("examples=[\"string_param_example999\"]"))
+            Assert.True(grammar.Contains("examples=[\"string_schema_example888\"]"))
+            Assert.True(grammar.Contains("examples=[\"id_string_example_12345\"]"))
+            // the below are body example properties
+            Assert.True(grammar.Contains("examples=[\"50000\"]"))
+            Assert.True(grammar.Contains("examples=[\"10000000\"]"))
+            Assert.True(grammar.Contains("examples=[\"48\"]"))
+            Assert.False(grammar.Contains("schema_example_9574638"))
+            Assert.True(grammar.Contains("\\\"completed\\\":true"))
+
+
         interface IClassFixture<Fixtures.TestSetupAndCleanup>

--- a/src/compiler/Restler.Compiler.Test/swagger/inline_examples.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/inline_examples.json
@@ -20,7 +20,7 @@
         "memory": {
           "description": "The amount of memory in GB",
           "type": "integer",
-          "example":  "32"
+          "example": 32
         }
       }
     }
@@ -34,7 +34,7 @@
               "name": "serverId",
               "required": true,
               "type": "integer",
-              "example": "1234567"
+              "example": 1234567
             },
             {
               "in": "header",
@@ -51,8 +51,8 @@
               "required": true,
               "type": "number",
               "examples": {
-                "firstExample": "1.67",
-                 "secondExample": "999.99"
+                "firstExample": 1.67,
+                 "secondExample": 999.99
                 }
               },
             {
@@ -76,7 +76,7 @@
               },
               "example": {
                 "cpu": "i7",
-                "memory": 12
+                "memory": 120
               }
             }
           ],

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/openapi3_examples.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/openapi3_examples.json
@@ -1,0 +1,138 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Simple OpenAPI spec with examples across different parameter data types",
+    "version": "1"
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "paths": {
+    "/customer": {
+      "post": {
+        "operationId": "post_customer",
+        "parameters": [
+          {
+            "name": "float-number-query-param",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "float",
+              "example": 4.56
+            },
+            "example": 9.9999
+          },
+          {
+            "name": "string-query-param-1",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "string_param_example999"
+          },
+          {
+            "name": "string-query-param-2",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "string_schema_example888"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/Customer"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Success",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Customer": {
+        "required": [
+          "Person",
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example":  "id_string_example_12345"
+          },
+          "Person": {
+            "$ref": "#/components/schemas/ParameterTests"
+          }
+        }
+      },
+      "ParameterTests": {
+        "required": [
+          "int-body-param",
+          "int32-body-param",
+          "int64-body-param",
+          "number-body-param",
+          "obj-body-param",
+          "string-body-param"
+        ],
+        "type": "object",
+        "example": {
+          "int-body-param": 48,
+          "number-body-param":  23.4,
+            "int32-body-param": 50000,
+          "int64-body-param": 10000000,
+          "string-body-param":  "string_body_param_example_2020",
+            "obj-body-param": { "tags": {"completed":  true} }
+        },
+        "properties": {
+          "string-body-param": {
+            "type": "string",
+            "example": "string_schema_body_param_example_9574638"
+          },
+          "number-body-param": {
+            "type": "number",
+            "example": 56.8
+          },
+          "int32-body-param": {
+            "type": "integer",
+            "format": "int32",
+            "example": "schema_example_9574638"
+          },
+          "int64-body-param": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "int-body-param": {
+            "type": "integer"
+          },
+          "obj-body-param": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
1) schema examples were not correctly extracted in all cases

2) parameter examples need to override the examples in the schema per OpenAPI spec definition

3) pass example values as JToken in the code so they are consistently quoted in one place