### PR TITLE
wip: Add support for string ipv4 format

### DIFF
--- a/restler/engine/primitives.py
+++ b/restler/engine/primitives.py
@@ -3,6 +3,7 @@
 
 """  Primitive types supported by restler. """
 from __future__ import print_function
+import random
 import sys
 import os
 import time
@@ -38,6 +39,7 @@ FUZZABLE_GROUP = "restler_fuzzable_group"
 FUZZABLE_BOOL = "restler_fuzzable_bool"
 FUZZABLE_INT = "restler_fuzzable_int"
 FUZZABLE_NUMBER = "restler_fuzzable_number"
+FUZZABLE_IPV4 = "restler_fuzzable_ipv4"
 FUZZABLE_DATETIME = "restler_fuzzable_datetime"
 FUZZABLE_DATE = "restler_fuzzable_date"
 FUZZABLE_OBJECT = "restler_fuzzable_object"
@@ -137,6 +139,7 @@ class CandidateValuesPool(object):
             FUZZABLE_BOOL,
             FUZZABLE_INT,
             FUZZABLE_NUMBER,
+            FUZZABLE_IPV4,
             FUZZABLE_DATETIME,
             FUZZABLE_DATE,
             FUZZABLE_OBJECT,
@@ -186,6 +189,24 @@ class CandidateValuesPool(object):
         oneday = datetime.timedelta(days=1)
         yesterday = today - oneday
         self._past_date = yesterday.strftime(PAYLOAD_DATE_FORMAT)
+
+    def _create_fuzzable_ipv4(self):
+        list = [str(random.randint(0, 255)) for x in range(0,4)]
+        return ".".join(list)
+
+    def _add_fuzzable_ipv4(self, candidate_values):
+        """ Adds fuzzable dates to a candidate values dict
+
+        @param candidate_values: The candidate values to add the dates to
+        @type  candidate_values: Dict
+
+        @return: None
+        @rtype : None
+
+        """
+        if Settings().add_fuzzable_ipv4:
+            if FUZZABLE_IPV4 in candidate_values:
+                candidate_values[FUZZABLE_IPV4].values.append(self._create_fuzzable_ipv4())
 
     def _add_fuzzable_dates(self, candidate_values):
         """ Adds fuzzable dates to a candidate values dict
@@ -734,6 +755,38 @@ def restler_fuzzable_datetime(*args, **kwargs) :
 
 def restler_fuzzable_date(*args, **kwargs) :
     """ date primitive
+
+    @param args: The argument with which the primitive is defined in the block
+                    of the request to which it belongs to. This is a date-time
+                    primitive and therefore the arguments will be added to the
+                    existing candidate values for date-time mutations.
+    @type  args: Tuple
+    @param kwargs: Optional keyword arguments.
+    @type  kwargs: Dict
+
+    @return: A tuple of the primitive's name and its default value or its tag
+                both passed as arguments via the restler grammar.
+    @rtype : Tuple
+
+    """
+    # datetime works the same as date
+    field_name = args[0]
+    quoted = False
+    if QUOTED_ARG in kwargs:
+        quoted = kwargs[QUOTED_ARG]
+    examples=[]
+    if EXAMPLES_ARG in kwargs:
+        examples = kwargs[EXAMPLES_ARG]
+    param_name = None
+    if PARAM_NAME_ARG in kwargs:
+        param_name = kwargs[PARAM_NAME_ARG]
+    writer_variable = None
+    if WRITER_VARIABLE_ARG in kwargs:
+        writer_variable = kwargs[WRITER_VARIABLE_ARG]
+    return sys._getframe().f_code.co_name, field_name, quoted, examples, param_name, writer_variable
+
+def restler_fuzzable_ipv4(*args, **kwargs) :
+    """ ipv4 primitive
 
     @param args: The argument with which the primitive is defined in the block
                     of the request to which it belongs to. This is a date-time

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -470,6 +470,8 @@ class RestlerSettings(object):
         self._disable_logging = SettingsArg('disable_logging', bool, False, user_args)
         ## Add current dates in addition to the ones specified in the dictionary
         self._add_fuzzable_dates = SettingsArg('add_fuzzable_dates', bool, False, user_args)
+        ## Add ipv4 in addition to the ones specified in the dictionary
+        self._add_fuzzable_ipv4 = SettingsArg("add_fuzzable_ipv4", bool, False, user_args)
         ## The command to execute in order to refresh the authentication token
         self._token_refresh_cmd = SettingsArg('token_refresh_cmd', str, None, user_args)
         ## Interval to periodically refresh the authentication token (seconds)
@@ -678,6 +680,10 @@ class RestlerSettings(object):
     @property
     def add_fuzzable_dates(self):
         return self._add_fuzzable_dates.val
+
+    @property
+    def add_fuzzable_ipv4(self):
+        return self._add_fuzzable_ipv4.val
 
     @property
     def token_refresh_cmd(self):

--- a/src/compiler/Restler.Compiler/CodeGenerator.fs
+++ b/src/compiler/Restler.Compiler/CodeGenerator.fs
@@ -47,6 +47,7 @@ module Types =
         | Restler_fuzzable_int of RequestPrimitiveTypeData * DynamicObjectWriter option
         | Restler_fuzzable_number of RequestPrimitiveTypeData * DynamicObjectWriter option
         | Restler_multipart_formdata of string
+        | Restler_fuzzable_ipv4 of RequestPrimitiveTypeData * DynamicObjectWriter option
         | Restler_custom_payload of RequestPrimitiveTypeData * DynamicObjectWriter option
         | Restler_custom_payload_header of string * DynamicObjectWriter option
         | Restler_custom_payload_query of string * DynamicObjectWriter option
@@ -99,6 +100,7 @@ let rec getRestlerPythonPayload (payload:FuzzingPayload) (isQuoted:bool) : Reque
             | Number -> Restler_fuzzable_number ({ defaultValue = v ; isQuoted = false ; exampleValue = exv  ; trackedParameterName = parameterName }, dynamicObject)
             | Uuid ->
                 Restler_fuzzable_uuid4 ({ defaultValue = v ; isQuoted = isQuoted ; exampleValue = exv ; trackedParameterName = parameterName }, dynamicObject)
+            | PrimitiveType.Ipv4 -> Restler_fuzzable_ipv4 ({ defaultValue = v ; isQuoted = false ; exampleValue = exv  ; trackedParameterName = parameterName  }, dynamicObject)
             | PrimitiveType.Enum (enumPropertyName, _, enumeration, defaultValue) ->
                 let defaultStr =
                     match defaultValue with
@@ -332,6 +334,7 @@ let generatePythonParameter includeOptionalParameters parameterSource parameterK
             | PrimitiveType.Object
             | PrimitiveType.Int
             | PrimitiveType.Bool
+            | PrimitiveType.Ipv4
             | PrimitiveType.Number ->
                 false
 
@@ -1148,6 +1151,13 @@ let getRequests(requests:Request list) includeOptionalParameters =
             | Restler_fuzzable_bool (s, dynamicObject) ->
                 sprintf "primitives.restler_fuzzable_bool(\"%s\"%s%s%s)"
                         s.defaultValue
+                        (getExamplePrimitiveParameter s.exampleValue)
+                        (getTrackedParamPrimitiveParameter s.trackedParameterName)
+                        (formatDynamicObjectVariable dynamicObject)
+            | Restler_fuzzable_ipv4 (s, dynamicObject) ->
+                sprintf "primitives.restler_fuzzable_ipv4(\"%s\", quoted=%s%s%s%s)"
+                        s.defaultValue
+                        (if s.isQuoted then "True" else "False")
                         (getExamplePrimitiveParameter s.exampleValue)
                         (getTrackedParamPrimitiveParameter s.trackedParameterName)
                         (formatDynamicObjectVariable dynamicObject)

--- a/src/compiler/Restler.Compiler/Dictionary.fs
+++ b/src/compiler/Restler.Compiler/Dictionary.fs
@@ -22,6 +22,9 @@ type MutationsDictionary =
         restler_fuzzable_date_unquoted : string list
         restler_fuzzable_uuid4 : string list
         restler_fuzzable_uuid4_unquoted : string list
+        restler_fuzzable_ipv4 : string list
+        restler_fuzzable_ipv4_unquoted : string list
+
 
         restler_fuzzable_int : string list
         restler_fuzzable_number : string list
@@ -207,6 +210,8 @@ let DefaultMutationsDictionary =
         restler_fuzzable_object = [DefaultPrimitiveValues.[PrimitiveType.Object]]
         restler_fuzzable_uuid4 = [DefaultPrimitiveValues.[PrimitiveType.Uuid]]
         restler_fuzzable_uuid4_unquoted = []
+        restler_fuzzable_ipv4 = [DefaultPrimitiveValues.[PrimitiveType.Ipv4]]
+        restler_fuzzable_ipv4_unquoted = []
         restler_custom_payload = Some (Map.empty<string, string list>)
         restler_custom_payload_unquoted = Some (Map.empty<string, string list>)
         restler_custom_payload_uuid4_suffix = Some (Map.empty<string, string>)

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -112,6 +112,7 @@ type PrimitiveType =
     | Bool
     | DateTime
     | Date
+    | Ipv4
     /// The enum type specifies the list of possible enum values
     /// and the default value, if specified.
     /// (tag, data type, possible values, default value if present)
@@ -535,6 +536,7 @@ let DefaultPrimitiveValues =
         PrimitiveType.Int, "1"
         PrimitiveType.Bool, "true"
         PrimitiveType.Object, "{ \"fuzz\": false }"
+        PrimitiveType.Ipv4, "193.63.0.0"
     ]
     |> Map.ofSeq
 

--- a/src/compiler/Restler.Compiler/SwaggerVisitors.fs
+++ b/src/compiler/Restler.Compiler/SwaggerVisitors.fs
@@ -81,6 +81,9 @@ module SchemaUtilities =
                     PrimitiveType.String, DefaultPrimitiveValues.[PrimitiveType.String]
                 if not (isNull format) then
                     match (format.ToLower()) with
+                    | "ipv4" ->
+                        PrimitiveType.Ipv4,
+                        DefaultPrimitiveValues.[PrimitiveType.Ipv4]
                     | "uuid"
                     | "guid" ->
                         PrimitiveType.Uuid,


### PR DESCRIPTION
Hi, this is draft PR. I am trying to use restler on an openAPI that makes extensive use of the ipv4 string format for an internship at Keysight. I based this on your date and date-time #365 support update PR. Could you let me know if there are areas of code that might still need changing? I am also not exactly certain how the unit-tests should be run, could you also help me with that?