### PR TITLE
Fix #626 - missing Content-Type in examples

### DIFF
--- a/restler/engine/fuzzing_parameters/request_examples.py
+++ b/restler/engine/fuzzing_parameters/request_examples.py
@@ -104,7 +104,7 @@ class RequestExamples():
                     query_list.append(query)
                 self._query_examples.append(query_list)
 
-    def _set_header_params(self, query_parameters):
+    def _set_header_params(self, header_parameters):
         """ Deserializes and populates the header parameters
 
         @param query_parameters: Header parameters from request schema
@@ -114,12 +114,23 @@ class RequestExamples():
         @rtype : None
 
         """
+        # Special case: 'DictionaryCustomPayload' may contain the 'Content-Type' parameter
+        content_type_headers = []
+        for header_parameter in header_parameters:
+            if header_parameter[0] == 'DictionaryCustomPayload':
+                # Save this and later append to every example parameter
+                for header in des_header_param(header_parameter[1]):
+                    content_type_headers.append(header)
+                break
+
         # Iterate through each collection of header parameters
-        for header_parameter in query_parameters:
+        for header_parameter in header_parameters:
             if header_parameter[0] == 'Examples':
                 header_list = HeaderList()
                 # Set each header parameter of the query
                 for header in des_header_param(header_parameter[1]):
+                    header_list.append(header)
+                for header in content_type_headers:
                     header_list.append(header)
                 self._header_examples.append(header_list)
 

--- a/src/compiler/Restler.Compiler/CodeGenerator.fs
+++ b/src/compiler/Restler.Compiler/CodeGenerator.fs
@@ -688,9 +688,10 @@ let generatePythonFromRequest (request:Request) includeOptionalParameters mergeS
                             [parameterList ; currentPList] |> Seq.concat)
                         Seq.empty
 
-    let getParameterListPayload (queryOrBodyParameters:(ParameterPayloadSource * RequestParametersPayload) list) =
-        let payloadSource, declaredPayload = getParameterPayload queryOrBodyParameters
-        let injectedPayload = getCustomParameterPayload queryOrBodyParameters
+    /// Gets the parameter list payload for query, header, or body parameters
+    let getParameterListPayload (parameters:(ParameterPayloadSource * RequestParametersPayload) list) =
+        let payloadSource, declaredPayload = getParameterPayload parameters
+        let injectedPayload = getCustomParameterPayload parameters
         payloadSource, ParameterList ([declaredPayload ; injectedPayload] |> Seq.concat)
 
     let getExamplePayload (queryOrBodyParameters:(ParameterPayloadSource * RequestParametersPayload) list) =


### PR DESCRIPTION
The special case parameter type that was added in order to allow fuzzing the content type was missed in example schema parsing in the engine.  This change adds it to all of the examples when generating the request grammar.