### PR TITLE
Fix schema parser for arrays.

### DIFF
--- a/restler/engine/fuzzing_parameters/request_schema_parser.py
+++ b/restler/engine/fuzzing_parameters/request_schema_parser.py
@@ -143,10 +143,10 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
                 value = des_param_payload(data, next_tag)
                 values.append(value)
 
-            array = ParamArray(values)
+            array = ParamArray(values, param_properties=param_properties)
 
             if body_param and name:
-                param = ParamMember(name, array, is_required)
+                param = ParamMember(name, array, param_properties=param_properties)
             else:
                 param = array
 
@@ -159,7 +159,7 @@ def des_param_payload(param_payload_json, tag='', body_param=True):
                 member = des_param_payload(member_json, tag)
                 members.append(member)
 
-            param = ParamObject(members)
+            param = ParamObject(members, param_properties=param_properties)
 
             param.tag = f'{next_tag}_object'
 

--- a/restler/unit_tests/grammar_schema_test_files/readonly_test_grammar.json
+++ b/restler/unit_tests/grammar_schema_test_files/readonly_test_grammar.json
@@ -95,6 +95,31 @@
                                       "isRequired": true,
                                       "isReadOnly": false
                                     }
+                                  },
+                                  {
+                                    "InternalNode": [
+                                      {
+                                        "name": "previous_addresses",
+                                        "propertyType": "Array",
+                                        "isRequired": true,
+                                        "isReadOnly": false
+                                      },
+                                      [
+                                        {
+                                          "LeafNode": {
+                                            "name": "",
+                                            "payload": {
+                                              "Fuzzable": {
+                                                "primitiveType": "String",
+                                                "defaultValue": "fuzzstring"
+                                              }
+                                            },
+                                            "isRequired": true,
+                                            "isReadOnly": false
+                                          }
+                                        }
+                                      ]
+                                    ]
                                   }
                                 ]
                               ]

--- a/restler/unit_tests/grammar_schema_test_files/readonly_test_grammar.py
+++ b/restler/unit_tests/grammar_schema_test_files/readonly_test_grammar.py
@@ -62,6 +62,9 @@ request = requests.Request([
     primitives.restler_static_string("\r\n"),
     primitives.restler_static_string("{"),
     primitives.restler_static_string("""
+    "id":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
     "person":
         {
             "name":"""),
@@ -69,7 +72,13 @@ request = requests.Request([
     primitives.restler_static_string(""",
             "address":"""),
     primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+            "previous_addresses":
+            [
+                """),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
     primitives.restler_static_string("""
+            ]
         }
     }"""),
     primitives.restler_static_string("\r\n"),

--- a/restler/unit_tests/grammar_schema_test_files/readonly_test_swagger.json
+++ b/restler/unit_tests/grammar_schema_test_files/readonly_test_swagger.json
@@ -69,11 +69,19 @@
         },
         "address": {
           "type": "object"
+        },
+        "previous_addresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
+
       },
       "required": [
         "name",
-        "address"
+        "address",
+        "previous_addresses"
       ]
     }
   },


### PR DESCRIPTION
The schema parser for arrays and internal objects were not correctly updated after introducing readonly parameters, causing a crash. Found while reproducing #627.

Testing:
- confirmed original repro is fixed
- added unit test