### PR TITLE
Fix crash in body schema fuzzer.

### DIFF
--- a/restler/checkers/body_schema_fuzzer.py
+++ b/restler/checkers/body_schema_fuzzer.py
@@ -160,7 +160,10 @@ class BodySchemaStructuralFuzzer(JsonBodySchemaFuzzerBase):
 
         # compose
         for new_value in fuzzed_value:
-            new_member = ParamMember(param_member.name, new_value, param_member.is_required)
+            param_properties = ParamProperties(is_required=param_member.is_required,
+                                               is_readonly=param_member.is_readonly)
+
+            new_member = ParamMember(param_member.name, new_value, param_properties=param_properties)
             new_member.meta_copy(param_member)
             fuzzed_members.append(new_member)
 


### PR DESCRIPTION
This was also caused by the readonly refactoring.

Testing: covered by the quick start test.