### PR TITLE
WIP: HTTP/2 support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN python3 -m ensurepip
 RUN pip3 install --upgrade pip
 RUN pip3 install requests
 RUN pip3 install applicationinsights
+RUN pip3 install h2
 COPY ./engine /RESTler/engine
 RUN python3 -m compileall -b /RESTler/engine
 COPY ./resultsAnalyzer /RESTler/resultsAnalyzer

--- a/restler/engine/transport_layer/messaging.py
+++ b/restler/engine/transport_layer/messaging.py
@@ -8,6 +8,9 @@ import socket
 import time
 import threading
 from importlib import util
+import h2.connection
+import h2.events
+import h2.config
 
 from utils.logger import raw_network_logging as RAW_LOGGING
 from engine.errors import TransportLayerException
@@ -20,8 +23,373 @@ if util.find_spec("test_servers"):
 DELIM = "\r\n\r\n"
 UTF8 = 'utf-8'
 
-
 class HttpSock(object):
+    __last_request_sent_time = time.time()
+    __request_sem = threading.Semaphore()
+
+    def __init__(self, connection_settings):
+        if Settings().use_http2:
+            self._subject = Http20Sock(connection_settings)
+        else:
+            self._subject = Http11Sock(connection_settings)
+    
+    def sendRecv(self, message: str, req_timeout_sec: int, reconnect: bool = False):
+        """ Sends a specified request to the server and waits for a response
+        @param message: Message to be sent.
+        @type message : Str
+        @param req_timeout_sec: The time, in seconds, to wait for request to complete
+        @type req_timeout_sec : Int
+        @return:
+            False if failure, True if success
+            Response if True returned, Error if False returned
+        @rtype : Tuple (Bool, String)
+        """
+        return self._subject.sendRecv(message, req_timeout_sec, reconnect=reconnect)
+
+class Http20Sock(object):
+    __last_request_sent_time = time.time()
+    __request_sem = threading.Semaphore()
+
+    def set_up_connection(self):
+        try:
+            host = Settings().host
+            target_ip = self.connection_settings.target_ip or host
+            target_port = self.connection_settings.target_port
+            if Settings().use_test_socket: #TODO: investigate test_server for http2 problems
+                self._sock = TestSocket(Settings().test_server)
+            elif self.connection_settings.use_ssl:
+                if self.connection_settings.disable_cert_validation:
+                    context = ssl._create_unverified_context()
+                    self._scheme = "https"
+                else:
+                    context = ssl.create_default_context()
+                    self._scheme = "https"
+                if Settings().client_certificate_path:
+                    context.load_cert_chain(
+                        certfile = Settings().client_certificate_path,
+                        keyfile = Settings().client_certificate_key_path,
+                    )
+
+                with socket.create_connection((target_ip, target_port or 443)) as sock:
+                    self._sock = context.wrap_socket(sock, server_hostname=host)
+                    self._connection = h2.connection.H2Connection(config=h2.config.H2Configuration())
+                    self._connection.initiate_connection()
+                    self._sock.sendall(self._connection.data_to_send())
+                    self._stream_id = self._connection.get_next_available_stream_id()
+
+            else:
+                self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self._scheme = "http"
+                self._sock.connect((target_ip, target_port or 80))
+                self._connection = h2.connection.H2Connection(config=h2.config.H2Configuration())
+                self._connection.initiate_connection()
+                self._sock.sendall(self._connection.data_to_send())
+                self._stream_id = self._connection.get_next_available_stream_id()
+        except Exception as error:
+            raise TransportLayerException(f"Exception Creating Socket: {error!s}")
+
+    def __init__(self, connection_settings):
+        """ Initializes a socket object using low-level python socket objects.
+
+        @param connection_settings: The connection settings for this socket
+        @type  connection_settings: ConnectionSettings
+
+        @return: None
+        @rtype : None
+
+        """
+        self._request_throttle_sec = (float)(Settings().request_throttle_ms/1000.0)\
+            if Settings().request_throttle_ms else None
+
+        self.connection_settings = connection_settings
+
+        self.ignore_decoding_failures = Settings().ignore_decoding_failures
+        self._connected = False
+        self._sock = None
+    
+    def __del__(self):
+        """ Destructor - Closes socket
+
+        """
+        if self._sock:
+            self._closeSocket()
+
+    def _get_method_from_message(self, message):
+        end_of_method_idx = message.find(" ")
+        method_name = message[0:end_of_method_idx]
+        return method_name
+
+    def sendRecv(self, message, req_timeout_sec, reconnect=False):
+        """ Sends a specified request to the server and waits for a response
+
+        @param message: Message to be sent.
+        @type message : Str
+        @param req_timeout_sec: The time, in seconds, to wait for request to complete
+        @type req_timeout_sec : Int
+
+        @return:
+            False if failure, True if success
+            Response if True returned, Error if False returned
+        @rtype : Tuple (Bool, String)
+
+        """
+
+        try:
+            if reconnect or not self._connected:
+                if reconnect:
+                    if self._sock:
+                        self._closeSocket()
+                self.set_up_connection()
+                self._connected = True
+
+            self._sendRequest(message)
+            if not Settings().use_test_socket: # TODO: investigate test socket situation
+                http_method_name = self._get_method_from_message(message)
+                received_response = self._recvResponse(req_timeout_sec, http_method_name)
+                if not received_response and not reconnect:
+                    # Re-connect and try again, since this may be due to the connection being closed.
+                    RAW_LOGGING("Empty response received.  Re-creating connection and re-trying.")
+                    return self.sendRecv(message, req_timeout_sec, reconnect=True)
+
+                response = HttpResponse(received_response)
+                self._stream_id = self._connection.get_next_available_stream_id()
+            else:
+                response = self._sock.recv() ##TODO: recv with h2 maybe? investigate test_server problems
+                self._stream_id = self._connection.get_next_available_stream_id()
+            RAW_LOGGING(f'Received: {response.to_str!r}\n')
+
+            return (True, response)
+        except TransportLayerException as error:
+            response = HttpResponse(str(error).strip('"\''))
+            if 'timed out' in str(error):
+                response._status_code = TIMEOUT_CODE
+                RAW_LOGGING(f"Reached max req_timeout_sec of {req_timeout_sec}.")
+            elif self._contains_connection_closed(str(error)):
+                response._status_code = CONNECTION_CLOSED_CODE
+                RAW_LOGGING(f"Connection error: {error!s}")
+                if not reconnect:
+                    RAW_LOGGING("Re-creating connection and re-trying.")
+                    return self.sendRecv(message, req_timeout_sec, reconnect=True)
+            else:
+                RAW_LOGGING(f"Unknown error: {error!s}")
+                if not reconnect:
+                    RAW_LOGGING("Re-creating connection and re-trying.")
+                    return self.sendRecv(message, req_timeout_sec, reconnect=True)
+            return (False, response)
+    
+    def _contains_connection_closed(self, error_str):
+        """ Returns whether or not the error string contains a connection closed error
+
+        @param error_str: The error string to check for connection closed error
+        @type  error_str: Str
+
+        @return: True if the error string contains the connection closed error
+        @rtype : Bool
+
+        """
+        # WinError 10054 occurs when the server terminates the connection and RESTler
+        # is being run from a Windows system.
+        # Errno 104 occurs when the server terminates the connection and RESTler
+        # is being run from a Linux system.
+        connection_closed_strings = [
+                # Windows
+                '[WinError 10054]',
+                '[WinError 10053]',
+                # Linux
+                '[Errno 104]'
+            ]
+        return any(filter(lambda x : x in error_str, connection_closed_strings))
+
+    def _sendRequest(self, message):
+        """ Sends message via current instance of socket object.
+
+        @param message: Message to be sent.
+        @type message : Str
+
+        @return: None
+        @rtype : None
+
+        """
+        def _get_end_of_header(message):
+            return message.index(DELIM)
+
+        def _get_start_of_body(message):
+            return _get_end_of_header(message) + len(DELIM)
+
+        def _append_to_header(message, content):
+            header = message[:_get_end_of_header(message)] + "\r\n" + content + DELIM
+            return header + message[_get_start_of_body(message):]
+
+        def _get_data_from_message(message):
+            data_index = message.find(DELIM)
+            data = message[data_index+len(DELIM):]
+            return data
+
+        def _get_uri_segment_from_message(message):
+            segment_start_index = message.find(' ')
+            segment_end_index = message[segment_start_index+1:].find(' ') + segment_start_index+1
+            segment = message[segment_start_index+1:segment_end_index]
+            return segment
+
+        def _create_h2_header(message):
+            h2_request_header = [ #special headers must appear at the start of the header block
+                (':method', self._get_method_from_message(message)),
+                (':authority', self.connection_settings.target_ip or Settings().host),
+                (':scheme', self._scheme),
+                (':path', _get_uri_segment_from_message(message))
+            ]
+            
+            original_header = message[message.index('\r\n')+2:_get_end_of_header(message)] #we only want the header fields e.g. Accept: ..., 
+            for line in original_header.split('\r\n'):
+                key, value = line.split(':')
+                h2_request_header.append((key, value))
+            
+            return h2_request_header
+
+        def _send_h2_data(data):
+            encoded_data = data.encode(UTF8)
+            window_size = self._connection.local_flow_control_window(stream_id = self._stream_id)
+            max_frame_size = self._connection.max_outbound_frame_size
+            bytes_to_send = min(window_size, len(encoded_data))
+            bytes_read = 0
+
+            while bytes_to_send > 0:
+                chunk_size = min(bytes_to_send, max_frame_size)
+                data_chunk = encoded_data[bytes_read:bytes_read+max_frame_size]
+                self._connection.send_data(stream_id=self._stream_id, data=data_chunk)
+
+                bytes_to_send -= chunk_size
+                bytes_read += chunk_size
+
+        h2_header = _create_h2_header(message)
+        h2_data = _get_data_from_message(message)
+
+        # Attempt to throttle the request if necessary
+        self._begin_throttle_request()
+
+        try:
+            RAW_LOGGING(f'Sending: {message!r}\n')
+            self._connection.send_headers(self._stream_id, h2_header) 
+            if h2_data:
+                _send_h2_data(h2_data)
+            self._connection.end_stream(self._stream_id)
+            self._sock.sendall(self._connection.data_to_send())
+        except Exception as error:
+            raise TransportLayerException(f"Exception Sending Data: {error!s}")
+        finally:
+            self._end_throttle_request()
+
+    def _begin_throttle_request(self):
+        """ Will attempt to throttle a request by comparing the last time
+        a request was sent to the throttle time (if any).
+
+        @return: None
+        @rtype : None
+
+        """
+        if self._request_throttle_sec:
+            Http20Sock.__request_sem.acquire()
+            elapsed = time.time() - Http20Sock.__last_request_sent_time
+            throttle_time_remaining = self._request_throttle_sec - elapsed
+            if throttle_time_remaining > 0:
+                time.sleep(throttle_time_remaining)
+
+    def _end_throttle_request(self):
+        """ Will release the throttle lock (if held), so another
+        request can be sent.
+
+        Sets last_request_sent_time
+
+        @return: None
+        @rtype : None
+
+        """
+        if self._request_throttle_sec:
+            Http20Sock.__last_request_sent_time = time.time()
+            Http20Sock.__request_sem.release()    
+
+    def _recvResponse(self, req_timeout_sec, method_name):
+        """ Reads data from socket object.
+
+        @param req_timeout_sec: The time, in seconds, to wait for request to complete
+        @type req_timeout_sec : Int
+
+        @return: Data received on current socket.
+        @rtype : Str
+
+        """
+        global DELIM
+        received_bytes = ''
+        header = ''
+        data = ''
+        response_stream_ended = False
+
+        def decode_buf (buf):
+            try:
+                return buf.decode(UTF8)
+            except Exception as ex:
+                if self.ignore_decoding_failures:
+                    RAW_LOGGING(f'Failed to decode data due to {ex}. \
+                        Trying again while ignoring offending bytes.')
+                    return buf.decode(UTF8, "ignore")
+                else:
+                    raise
+  
+        while not response_stream_ended:
+            try:
+                self._sock.settimeout(req_timeout_sec)
+                received_bytes = self._sock.recv(2**20)
+                events = self._connection.receive_data(received_bytes)
+
+                for event in events:
+                    if isinstance(event, h2.events.DataReceived):
+                        # update flow control so the server doesn't starve us
+                        self._connection.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                        if event.stream_id == self._stream_id:
+                            data += decode_buf(event.data)
+                        received_bytes += event.data
+                    if isinstance(event, h2.events.ResponseReceived):
+                        if event.stream_id == self._stream_id:
+                            for tuples in event.headers:
+                                header += decode_buf(tuples[0]) + ': ' + decode_buf(tuples[1]) + ' \r\n'
+                            header += DELIM
+                    if isinstance(event, h2.events.StreamEnded):
+                        response_stream_ended = True
+                    if isinstance(event, h2.events.StreamReset):
+                        if event.stream_id == self._stream_id:
+                            return ''
+                    if isinstance(event, h2.events.ConnectionTerminated):
+                        return ''
+            
+                # send any pending data to the server
+                self._sock.sendall(self._connection.data_to_send())
+            except Exception as error:
+                raise TransportLayerException(f"Exception: {error!s}")
+            if len(received_bytes) == 0:
+                return header + data
+        return header + data
+        
+
+
+
+    def _closeSocket(self):
+        """ Closes open socket object.
+
+        @return: None
+        @rtype : None
+
+        """
+        try:
+            self._connection.close_connection()
+            self._sock.sendall(self._connection.data_to_send())
+            self._sock.close()
+        except BrokenPipeError:
+            self._sock.close() #if the peer is unresponsive due to a crash, the h2 close_connection call will raise an exception
+        except Exception as error:
+                raise TransportLayerException(f"Exception: {error!s}")
+
+
+class Http11Sock(object):
     __last_request_sent_time = time.time()
     __request_sem = threading.Semaphore()
 
@@ -209,8 +577,8 @@ class HttpSock(object):
 
         """
         if self._request_throttle_sec:
-            HttpSock.__request_sem.acquire()
-            elapsed = time.time() - HttpSock.__last_request_sent_time
+            Http11Sock.__request_sem.acquire()
+            elapsed = time.time() - Http11Sock.__last_request_sent_time
             throttle_time_remaining = self._request_throttle_sec - elapsed
             if throttle_time_remaining > 0:
                 time.sleep(throttle_time_remaining)
@@ -226,8 +594,8 @@ class HttpSock(object):
 
         """
         if self._request_throttle_sec:
-            HttpSock.__last_request_sent_time = time.time()
-            HttpSock.__request_sem.release()
+            Http11Sock.__last_request_sent_time = time.time()
+            Http11Sock.__request_sem.release()
 
     def _recvResponse(self, req_timeout_sec, method_name):
         """ Reads data from socket object.

--- a/restler/requirements.txt
+++ b/restler/requirements.txt
@@ -1,2 +1,3 @@
 applicationinsights
 pytest
+h2

--- a/restler/restler.py
+++ b/restler/restler.py
@@ -256,6 +256,9 @@ if __name__ == '__main__':
     parser.add_argument('--no_ssl',
                         help='Set this flag if you do not want to use SSL validation for the socket',
                         action='store_true')
+    parser.add_argument('--http2',
+                        help='Set this flag if you would like to use HTTP2',
+                        action='store_true')
     parser.add_argument('--include_user_agent',
                         help='Set this flag if you would like to add User-Agent to the request headers',
                         action='store_true')

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -20,7 +20,7 @@ class OptionValidationError(Exception):
     pass
 
 class ConnectionSettings(object):
-    def __init__(self, target_ip, target_port, use_ssl=True, include_user_agent=False, disable_cert_validation=False):
+    def __init__(self, target_ip, target_port, use_ssl=True, include_user_agent=False, disable_cert_validation=False, use_http2=False):
         """ Initializes an object that contains the connection settings for the socket
         @param target_ip: The ip of the target service.
         @type  target_ip: Str
@@ -32,6 +32,8 @@ class ConnectionSettings(object):
         @type  include_user_agent: Boolean
         @param disable_cert_validation: Whether or not to disable SSL certificate validation
         @type  disable_cert_validation: Bool
+        @param use_http2: Whether or not to use HTTP2 for connection
+        @type use_http2: Boolean
 
         @return: None
         @rtype : None
@@ -42,6 +44,7 @@ class ConnectionSettings(object):
         self.use_ssl = use_ssl
         self.include_user_agent = include_user_agent
         self.disable_cert_validation = disable_cert_validation
+        self.use_http2  = use_http2
 
 class SettingsArg(object):
     """ Holds a setting's information """
@@ -440,6 +443,8 @@ class RestlerSettings(object):
         self._max_sequence_length = SettingsArg('max_sequence_length', int, MAX_SEQUENCE_LENGTH_DEFAULT, user_args, minval=0)
         ## Do not use SSL validation
         self._no_ssl = SettingsArg('no_ssl', bool, False, user_args)
+        ## Use HTTP2
+        self._use_http2 = SettingsArg('http2', bool, False, user_args)
         ## Do not print auth token data in logs
         self._no_tokens_in_logs = SettingsArg('no_tokens_in_logs', bool, True, user_args)
         ## Save the results in a dir with a fixed name (skip 'experiment<pid>' subdir)
@@ -492,7 +497,8 @@ class RestlerSettings(object):
                                         self._target_port.val,
                                         not self._no_ssl.val,
                                         self._include_user_agent.val,
-                                        self._disable_cert_validation.val)
+                                        self._disable_cert_validation.val,
+                                        self._use_http2.val)
 
         # Set per resource arguments
         if 'per_resource_settings' in user_args:
@@ -683,6 +689,10 @@ class RestlerSettings(object):
     @property
     def test_server(self):
         return self._test_server.val
+
+    @property
+    def use_http2(self):
+        return self._use_http2.val
 
     @property
     def time_budget(self):

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -67,6 +67,8 @@ let usage() =
             Example: (\w*)/virtualNetworks/(\w*)
         --no_ssl
             When connecting to the service, do not use SSL.  The default is to connect with SSL.
+        --http2
+            When connecting to the service, use HTTP2.  The default is to connect with HTTP/1.1.
         --host <Host string>
             If specified, this string will set or override the Host in each request.
             Example: management.web.com
@@ -239,6 +241,7 @@ module Fuzz =
                 sprintf "--producer_timing_delay %d" parameters.producerTimingDelay
             else "")
             (if not parameters.useSsl then "--no_ssl" else "")
+            (if not parameters.useHTTP2 then "" else "--http2")
             (match parameters.host with
              | Some h -> sprintf "--host %s" h
              | None -> "")
@@ -636,6 +639,8 @@ let rec parseEngineArgs task (args:EngineParameters) = function
             usage()
     | "--no_ssl"::rest ->
         parseEngineArgs task { args with useSsl = false } rest
+    | "--http2"::rest ->
+        parseEngineArgs task { args with useHTTP2 = true} rest
     | "--host"::host::rest->
         parseEngineArgs task { args with host = Some host } rest
     | "--settings"::settingsFilePath::rest ->

--- a/src/driver/Types.fs
+++ b/src/driver/Types.fs
@@ -53,6 +53,9 @@ type EngineParameters =
         /// Specifies to use SSL when connecting to the server
         useSsl : bool
 
+        /// Specifies to use HTTP2 when connecting to the server
+        useHTTP2 : bool
+
         /// The string to use in overriding the Host for each request
         host : string option
 
@@ -86,6 +89,7 @@ let DefaultEngineParameters =
         searchStrategy = None
         producerTimingDelay = 0
         useSsl = true
+        useHTTP2 = false
         host = None
         settingsFilePath= ""
         checkerOptions = []


### PR DESCRIPTION
## PR Checklist
* [x] Applies to work item: engine/transport_layer
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign.
* [ ] Tests added/passed.  
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach. Issue number where discussion took place: #xxx

## Info on Pull Request

This pull request includes the first iteration of `HTTP20Sock`, which aims to implement HTTP/2 support for RESTler. However, HTTP/2 is more complicated than HTTP/1.1 (e.g. the state machine of HTTP/2 and streams), which means that unique situations could lead to RESTler crashing or being stuck in a loop since I could not test it in the individual unique situation. 
I use the [h2](https://github.com/python-hyper/h2) library for the HTTP/2 connections. Since it is relatively low-level, malformed requests should work library-wise.

`h2` uses 2-Tuples since the HTTP/2 headers must be ordered (:path, :method must be first etc). I decided to "parse" these and stringify those tuples to HTTP/1.1 headers in order to work with `HttpResponse`. However, it is also possible to create another `Http20Response` class which works with the Tuples directly. I would need feedback for this decision. I did not want to modify many places in the source code, since RESTler is mostly hardcoded for HTTP/1.1. 

I added a `--http2` flag (in the Python and F# part). 

## Validation Steps Performed

I mostly used [Open5GS](https://github.com/open5gs/open5gs) with the [Nnrf_NFManagement](https://github.com/jdegre/5GC_APIs/blob/Rel-15/TS29510_Nnrf_NFManagement.yaml) OpenAPI spec. However, Open5GS has problems with `DATA` frames bigger than 8192 Bytes. Since it does not share that limitation via the `SETTINGS` frame, Open5GS crashes once RESTler sends the `PUT` request in the aforementioned OpenAPI spec. RESTler works in such cases.

To validate, install the restler/requirements.txt and add the --http2 flag to your restler engine command.

## Comment
I intend to implement a HTTP/2 test_server for RESTler. However, I am slightly confused by the documentation of `restler/test_servers/README.md`. I understand that the new test_server has to inherit from `test_servers.test_server_base.TestServerBase` and implement the `parse_message` function. However, I did not understand to which requests the new test_server should react and with what status code. 

I am ready to work on fully implementing this version of HTTP/2 in RESTler. However, I need feedback and help (answering questions) in regards to implementing tests and a test_server. The HTTP/1.1 part of RESTler is unaffected, so merging this should be no problem. 

