### PR TITLE
Increase json serialization MaxDepth

### DIFF
--- a/src/compiler/Restler.CompilerExe/Program.fs
+++ b/src/compiler/Restler.CompilerExe/Program.fs
@@ -12,6 +12,12 @@ let usage() =
     let sampleConfig = Json.Compact.serialize SampleConfig
     printfn "Sample config:\n %s" sampleConfig
 
+// Make sure NewtOnSoft.Json is loaded with a higher than default MaxDepth limit, which
+// is required by some OpenAPI specifications
+open Newtonsoft.Json
+JsonConvert.DefaultSettings <- fun () -> JsonSerializerSettings(MaxDepth = 128)
+
+
 [<EntryPoint>]
 let main argv =
 


### PR DESCRIPTION
The latest version of Newtonsoft.Json has a default maximum depth limit of 64. Set a higher internal limit in RESTler, since some specifications require it.

Closes #658

Testing: manual testing with issue repro.