### PR TITLE
Fix writer variable update bug

### DIFF
--- a/restler/checkers/invalid_dynamic_object_checker.py
+++ b/restler/checkers/invalid_dynamic_object_checker.py
@@ -58,7 +58,8 @@ class InvalidDynamicObjectChecker(CheckerBase):
         InvalidDynamicObjectChecker.generation_executed_requests[generation].add(last_request.hex_definition)
 
         # Get the current rendering of the sequence, which will be the valid rendering of the last request
-        last_rendering, last_request_parser, tracked_parameters = last_request.render_current(self._req_collection.candidate_values_pool)
+        last_rendering, last_request_parser, tracked_parameters, updated_writer_variables =\
+            last_request.render_current(self._req_collection.candidate_values_pool)
 
         # Execute the sequence up until the last request
         new_seq = self._execute_start_of_sequence()
@@ -70,6 +71,9 @@ class InvalidDynamicObjectChecker(CheckerBase):
         for data in self._prepare_invalid_requests(last_rendering):
             self._checker_log.checker_print(repr(data))
             response = self._send_request(last_request_parser, data)
+            if response.has_valid_code():
+                for name,v in updated_writer_variables.items():
+                    dependencies.set_variable(name, v)
             request_utilities.call_response_parser(last_request_parser, response)
             if response and self._rule_violation(new_seq, response):
                 # Append the data that we just sent to the sequence's sent list

--- a/restler/checkers/payload_body_checker.py
+++ b/restler/checkers/payload_body_checker.py
@@ -1122,7 +1122,7 @@ class PayloadBodyChecker(CheckerBase):
         cnt = 0
 
         # iterate through different value combinations
-        for rendered_data, parser,_ in new_request.render_iter(
+        for rendered_data, parser,_,updated_writer_variables in new_request.render_iter(
             self._req_collection.candidate_values_pool
         ):
             # check time budget
@@ -1204,6 +1204,10 @@ class PayloadBodyChecker(CheckerBase):
 
             # send out the request and parse the response
             response = self._send_request(parser, rendered_data)
+            if response.has_valid_code():
+                for name,v in updated_writer_variables.items():
+                    dependencies.set_variable(name, v)
+
             async_wait = Settings().get_max_async_resource_creation_time(request.request_id)
             responses_to_parse, _, _ = async_request_utilities.try_async_poll(
                 rendered_data, response, async_wait)

--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -1108,6 +1108,7 @@ class Request(object):
                     len(value_generators) == len(value_gen_tracker):
                         break
 
+                dynamic_object_variables_to_update = {}
                 for val_idx, val in enumerate(values):
                     (writer_variable, writer_is_quoted) = writer_variables[val_idx]
                     if writer_variable is not None:
@@ -1115,7 +1116,7 @@ class Request(object):
                         # It will be quoted again at the time it is used, if needed
                         if writer_is_quoted:
                             val = val[1:-1]
-                        dependencies.set_variable(writer_variable, val)
+                        dynamic_object_variables_to_update[writer_variable] = val
 
                 tracked_parameter_values = {}
                 for (k, idx_list) in tracked_parameters.items():
@@ -1152,7 +1153,7 @@ class Request(object):
                 # Save the schema for this combination.
                 self._last_rendered_schema_request = (req, is_example)
 
-                yield rendered_data, parser, tracked_parameter_values
+                yield rendered_data, parser, tracked_parameter_values, dynamic_object_variables_to_update
 
                 next_combination = next_combination + 1
                 remaining_combinations_count = remaining_combinations_count - 1

--- a/restler/engine/dependencies.py
+++ b/restler/engine/dependencies.py
@@ -457,7 +457,7 @@ class GarbageCollector:
 
             # Iterate in reverse to give priority to newest resources
             for value in reversed(self.overflowing[type]):
-                rendered_data, _ , _ = destructor.\
+                rendered_data, _ , _, _ = destructor.\
                     render_current(self.req_collection.candidate_values_pool)
 
                 # replace dynamic parameters

--- a/restler/unit_tests/test_grammar_schema_parser.py
+++ b/restler/unit_tests/test_grammar_schema_parser.py
@@ -104,8 +104,8 @@ class SchemaParserTest(unittest.TestCase):
         # TODO: enums equal
 
         # Payloads equal
-        original_rendered_data,_,_ = next(original_req.render_iter(req_collection.candidate_values_pool))
-        generated_rendered_data,_,_ = next(generated_req.render_iter(req_collection.candidate_values_pool))
+        original_rendered_data,_,_,_ = next(original_req.render_iter(req_collection.candidate_values_pool))
+        generated_rendered_data,_,_,_ = next(generated_req.render_iter(req_collection.candidate_values_pool))
 
         original_rendered_data = original_rendered_data.replace("\r\n", "")
 
@@ -370,7 +370,7 @@ class SchemaParserTest(unittest.TestCase):
 
         combinations_count = 0
         for x, is_example in req_with_body.get_schema_combinations(use_grammar_py_schema=False):
-            rendered_data,_,_ = next(x.render_iter(request_collection.candidate_values_pool))
+            rendered_data,_,_,_ = next(x.render_iter(request_collection.candidate_values_pool))
             self.assertTrue("\"id\"" not in rendered_data)
             self.assertTrue("\"person\"" in rendered_data)
             self.assertTrue("\"name\"" in rendered_data)


### PR DESCRIPTION
'render_iter' should only generate combinations - it should not have any side effects.   Garbage collection was being triggered in the presence of writer variables even if the request was never executed, because dynamic objects were added to the cache in render().  This was missed in the original implementation of writer variables.

Instead, writer variables should only be updated after the request has succeeded (returned a valid code), indicating that the dynamic object exists.

Testing: existing unit tests and manual inspection of GC logs.