### PR TITLE
Eliminate explicit backslash path separators to fix tests on MacOS

### DIFF
--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -124,8 +124,8 @@ module CodeGenerator =
                              GrammarOutputDirectoryPath = Some grammarDirectoryPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some false
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo1.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo_dictionary.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger" , "example_demo1.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
             let grammarFilePath = Path.Combine(grammarDirectoryPath, "grammar.py")

--- a/src/compiler/Restler.Compiler.Test/ConfigTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ConfigTests.fs
@@ -24,31 +24,31 @@ module Config =
             let multiDictConfig =
                 {   Restler.Config.SampleConfig with
                         SwaggerSpecFilePath = None
-                        CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\configTests\maindict.json"))
+                        CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "configTests", "maindict.json"))
                         UseBodyExamples = Some false
                         ResolveBodyDependencies = true
                         SwaggerSpecConfig =
                             Some [
                                 {
-                                    SpecFilePath = (Path.Combine(Environment.CurrentDirectory, @"swagger\configTests\swagger1.json"))
-                                    DictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\configTests\dict1.json"))
+                                    SpecFilePath = (Path.Combine(Environment.CurrentDirectory, "swagger", "configTests", "swagger1.json"))
+                                    DictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "configTests", "dict1.json"))
                                     Dictionary = None
                                     AnnotationFilePath = None
                                 }
                                 {
-                                    SpecFilePath = (Path.Combine(Environment.CurrentDirectory, @"swagger\configTests\swagger2.json"))
-                                    DictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\configTests\dict2.json"))
+                                    SpecFilePath = (Path.Combine(Environment.CurrentDirectory, "swagger", "configTests", "swagger2.json"))
+                                    DictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "configTests", "dict2.json"))
                                     Dictionary = None
                                     AnnotationFilePath = None
                                 }
                                 {
-                                    SpecFilePath = (Path.Combine(Environment.CurrentDirectory, @"swagger\configTests\swagger3.json"))
+                                    SpecFilePath = (Path.Combine(Environment.CurrentDirectory, "swagger", "configTests", "swagger3.json"))
                                     DictionaryFilePath = None
                                     Dictionary = None
                                     AnnotationFilePath = None
                                 }
                             ]
-                        EngineSettingsFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\configTests\restlerEngineSettings.json"))
+                        EngineSettingsFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "configTests", "restlerEngineSettings.json"))
                         GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
                 }
 
@@ -127,7 +127,7 @@ module Config =
                              GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some false
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\annotationTests\pathAnnotation.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "annotationTests", "pathAnnotation.json"))]
                              CustomDictionaryFilePath = None
                          }
             let externalConfig =
@@ -136,16 +136,16 @@ module Config =
                         SwaggerSpecConfig =
                             Some [
                                 {
-                                    SpecFilePath = (Path.Combine(Environment.CurrentDirectory, @"swagger\annotationTests\pathAnnotationInSeparateFile.json"))
+                                    SpecFilePath = (Path.Combine(Environment.CurrentDirectory, "swagger", "annotationTests", "pathAnnotationInSeparateFile.json"))
                                     DictionaryFilePath = None
                                     Dictionary = None
-                                    AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\annotationTests\globalAnnotations.json"))
+                                    AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "annotationTests", "globalAnnotations.json"))
                                 }
                             ]
                 }
             let noAnnotationsConfig =
                 {   config with
-                        SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\annotationTests\pathAnnotationInSeparateFile.json"))]
+                        SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "annotationTests", "pathAnnotationInSeparateFile.json"))]
                 }
 
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -189,10 +189,10 @@ module Config =
             // With 'exactCopy' set to false, the first example should filter out "door" and contain just "window".
             // With 'exactCopy' set to true, the second example should contain "wood".
             let config = { Restler.Config.SampleConfig with
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\configTests\exampleConfigTestPut.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "configTests", "exampleConfigTestPut.json"))]
                              ExampleConfigFiles = Some [
-                                                         { exactCopy = false ; filePath = @"swagger\configTests\exampleConfigTestConfig1.json" }
-                                                         { exactCopy = true ; filePath = @"swagger\configTests\exampleConfigTestConfig2.json" }
+                                                         { exactCopy = false ; filePath = Path.Combine("swagger", "configTests", "exampleConfigTestConfig1.json") }
+                                                         { exactCopy = true ; filePath = Path.Combine("swagger", "configTests", "exampleConfigTestConfig2.json") }
                                                        ]
                              UseBodyExamples = Some true
                              GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath

--- a/src/compiler/Restler.Compiler.Test/DependencyTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DependencyTests.fs
@@ -68,7 +68,7 @@ module Dependencies =
                              GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some false
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\put_createorupdate.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "put_createorupdate.json"))]
                              CustomDictionaryFilePath = None
                          }
             Restler.Workflow.generateRestlerGrammar None config
@@ -101,7 +101,7 @@ module Dependencies =
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\get_path_dependencies.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "get_path_dependencies.json"))]
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
@@ -120,7 +120,7 @@ module Dependencies =
                              GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\annotationTests\pathAnnotation.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "annotationTests", "pathAnnotation.json"))]
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
@@ -129,7 +129,7 @@ module Dependencies =
             // Read the baseline and make sure it matches the expected one
             //
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                       @"baselines\dependencyTests\path_annotation_grammar.py")
+                                                       "baselines", "dependencyTests", "path_annotation_grammar.py")
             let actualGrammarFilePath = Path.Combine(grammarOutputDirectoryPath,
                                                      Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
@@ -145,8 +145,8 @@ module Dependencies =
                              GrammarOutputDirectoryPath = Some grammarOutputDirPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\pathDictionaryPayload.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\dict.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "pathDictionaryPayload.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "dict.json"))
                              AllowGetProducers = true
                          }
             Restler.Workflow.generateRestlerGrammar None config
@@ -154,7 +154,7 @@ module Dependencies =
             // Read the baseline and make sure it matches the expected one
             //
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                       @"baselines\dependencyTests\path_in_dictionary_payload_grammar.py")
+                                                       "baselines", "dependencyTests", "path_in_dictionary_payload_grammar.py")
             let actualGrammarFilePath = Path.Combine(grammarOutputDirPath,
                                                      Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
@@ -171,7 +171,7 @@ module Dependencies =
                              GrammarOutputDirectoryPath = Some outputDirectory
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\body_dependency_cycles.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "body_dependency_cycles.json"))]
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
@@ -197,7 +197,7 @@ module Dependencies =
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\lowercase_paths.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "lowercase_paths.json"))]
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
@@ -231,7 +231,7 @@ module Dependencies =
         let ``inconsistent camel case is fixed by RESTler`` () =
             let config = { Restler.Config.SampleConfig with
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\inconsistent_casing_paths.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "inconsistent_casing_paths.json"))]
                              CustomDictionaryFilePath = None
                          }
             Restler.Workflow.generateRestlerGrammar None config
@@ -261,7 +261,7 @@ module Dependencies =
                              GrammarOutputDirectoryPath = Some grammarOutputDirPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\post_patch_dependency.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "post_patch_dependency.json"))]
                              AllowGetProducers = true
                          }
             Restler.Workflow.generateRestlerGrammar None config
@@ -295,7 +295,7 @@ module Dependencies =
                                 Some
                                   [{
                                       SpecFilePath =
-                                         Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\array_dep_multiple_items.json")
+                                         Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "array_dep_multiple_items.json")
                                       Dictionary = customDictionary
                                       DictionaryFilePath = None
                                       AnnotationFilePath = None
@@ -325,9 +325,9 @@ module Dependencies =
                              GrammarOutputDirectoryPath = Some grammarOutputDirPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\input_producer_spec.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\input_producer_dict.json"))
-                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\input_producer_annotations.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "input_producer_spec.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "input_producer_dict.json"))
+                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "input_producer_annotations.json"))
                              AllowGetProducers = true
                          }
             Restler.Workflow.generateRestlerGrammar None config
@@ -376,7 +376,7 @@ module Dependencies =
                              GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\subnet_id.json")]
+                             SwaggerSpecFilePath = Some [Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "subnet_id.json")]
                              AllowGetProducers = true
                              CustomDictionaryFilePath = Some dictionaryFilePath
                          }
@@ -397,7 +397,7 @@ module Dependencies =
                              GrammarOutputDirectoryPath = Some grammarOutputDirPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\response_headers.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "response_headers.json"))]
                              CustomDictionaryFilePath = None
                              AnnotationFilePath = None
                              AllowGetProducers = true
@@ -409,7 +409,7 @@ module Dependencies =
             let grammar = File.ReadAllText(grammarFilePath)
 
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                       @"baselines\dependencyTests\header_response_writer_grammar.py")
+                                                       "baselines", "dependencyTests", "header_response_writer_grammar.py")
             let actualGrammarFilePath = Path.Combine(grammarOutputDirPath,
                                                      Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
@@ -418,11 +418,11 @@ module Dependencies =
 
             // Confirm the same works with annotations
             let configWithAnnotations = { config with
-                                            AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\response_headers_annotations.json"))}
+                                            AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "response_headers_annotations.json"))}
             Restler.Workflow.generateRestlerGrammar None configWithAnnotations
 
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                       @"baselines\dependencyTests\header_response_writer_annotation_grammar.py")
+                                                       "baselines", "dependencyTests", "header_response_writer_annotation_grammar.py")
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
             let message = sprintf "Grammar (test with annotations) does not match baseline.  First difference: %A" grammarDiff
             Assert.True(grammarDiff.IsNone, message)
@@ -436,7 +436,7 @@ module Dependencies =
                              ResolveBodyDependencies = true
                              ResolveHeaderDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\header_deps.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "header_deps.json"))]
                              CustomDictionaryFilePath = None
                              AnnotationFilePath = None
                              AllowGetProducers = true
@@ -446,11 +446,11 @@ module Dependencies =
             let actualGrammarFilePath = Path.Combine(grammarOutputDirPath,
                                                      Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                       @"baselines\dependencyTests\header_deps_grammar.py")
+                                                       "baselines", "dependencyTests", "header_deps_grammar.py")
 
             // This scenario should work with annotations only.
             let configWithAnnotations = { config with
-                                            AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\header_deps_annotations.json"))}
+                                            AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "header_deps_annotations.json"))}
             Restler.Workflow.generateRestlerGrammar None configWithAnnotations
 
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
@@ -475,7 +475,7 @@ module Dependencies =
                              ResolveBodyDependencies = true
                              ResolveHeaderDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\ordering_test.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "ordering_test.json"))]
                              CustomDictionaryFilePath = None
                              AnnotationFilePath = None
                              AllowGetProducers = true
@@ -485,10 +485,10 @@ module Dependencies =
             let actualGrammarFilePath = Path.Combine(grammarOutputDirPath,
                                                      Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                       @"baselines\dependencyTests\ordering_test_grammar.py")
+                                                       "baselines", "dependencyTests", "ordering_test_grammar.py")
 
             let configWithAnnotations = { config with
-                                            AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\ordering_test_annotations.json"))}
+                                            AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "ordering_test_annotations.json"))}
             Restler.Workflow.generateRestlerGrammar None configWithAnnotations
 
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
@@ -503,9 +503,9 @@ module Dependencies =
             let config = { Restler.Config.SampleConfig with
                              IncludeOptionalParameters = true
                              GrammarOutputDirectoryPath = Some grammarOutputDirPath
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\simple_crud_api.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "simple_crud_api.json"))]
                              CustomDictionaryFilePath = None
-                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\simple_crud_api_annotations.json"))
+                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "simple_crud_api_annotations.json"))
                              AllowGetProducers = true
                              ResolveQueryDependencies = true
                          }
@@ -533,9 +533,9 @@ module Dependencies =
                 let config = { Restler.Config.SampleConfig with
                                  IncludeOptionalParameters = true
                                  GrammarOutputDirectoryPath = Some grammarOutputDirPath
-                                 SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\simple_api_soft_delete.json"))]
+                                 SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "simple_api_soft_delete.json"))]
                                  CustomDictionaryFilePath = None
-                                 AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, sprintf @"swagger\dependencyTests\simple_api_soft_delete_annotations%s.json" annotationTest))
+                                 AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", sprintf "simple_api_soft_delete_annotations%s.json" annotationTest))
                                  AllowGetProducers = true
                                  ResolveQueryDependencies = true
                              }
@@ -544,7 +544,7 @@ module Dependencies =
                 let actualGrammarFilePath = Path.Combine(grammarOutputDirPath,
                                                          Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
                 let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                           sprintf @"baselines\dependencyTests\soft_delete_test_grammar%s.py" annotationTest)
+                                                        "baselines", "dependencyTests", sprintf "soft_delete_test_grammar%s.py" annotationTest)
 
                 let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
                 let message = sprintf "Grammar for annotation test %s does not match baseline.  First difference: %A" annotationTest grammarDiff

--- a/src/compiler/Restler.Compiler.Test/DictionaryTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DictionaryTests.fs
@@ -21,13 +21,13 @@ module Dictionary =
                              ResolveQueryDependencies = true
                              UseBodyExamples = Some false
                              UseQueryExamples = Some false
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\customPayloadSwagger.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\customPayloadDict.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadSwagger.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadDict.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
 
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                       @"baselines\dictionaryTests\quoted_primitives_grammar.py")
+                                                       "baselines", "dictionaryTests", "quoted_primitives_grammar.py")
             let actualGrammarFilePath = Path.Combine(grammarOutputDirPath,
                                                      Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
@@ -45,8 +45,8 @@ module Dictionary =
                              ResolveQueryDependencies = true
                              UseBodyExamples = Some false
                              UseQueryExamples = Some false
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\multipleIdenticalUuidSuffix.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\multipleIdenticalUuidSuffixDict.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "multipleIdenticalUuidSuffix.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "multipleIdenticalUuidSuffixDict.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
 
@@ -74,8 +74,8 @@ module Dictionary =
                              ResolveQueryDependencies = true
                              UseBodyExamples = Some false
                              UseQueryExamples = Some false
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\no_params.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\inject_custom_payloads_dict.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "no_params.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "inject_custom_payloads_dict.json"))
 
                          }
 
@@ -136,8 +136,8 @@ module Dictionary =
                              ResolveQueryDependencies = true
                              UseBodyExamples = Some false
                              UseQueryExamples = Some false
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\customPayloadSwagger.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\customPayloadRequestTypeDict.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadSwagger.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadRequestTypeDict.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
 
@@ -160,13 +160,13 @@ module Dictionary =
                              ResolveQueryDependencies = true
                              UseBodyExamples = Some false
                              UseQueryExamples = Some false
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\customPayloadSwagger.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dictionaryTests\customPayloadDict.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadSwagger.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadDict.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
 
             let expectedValueGenTemplatePath = Path.Combine(Environment.CurrentDirectory,
-                                                            @"baselines\dictionaryTests\customPayloadDict_ValueGeneratorTemplate.py")
+                                                            @"baselines", "dictionaryTests", "customPayloadDict_ValueGeneratorTemplate.py")
             let actualValueGenTemplatePath = Path.Combine(grammarOutputDirPath,
                                                           Restler.Workflow.Constants.CustomValueGeneratorTemplateFileName)
             let valueGenDiff = getLineDifferences expectedValueGenTemplatePath actualValueGenTemplatePath

--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -19,8 +19,8 @@ module Examples =
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some false
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo1.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo_dictionary.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo1.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
             let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
@@ -37,7 +37,7 @@ module Examples =
 
         [<Fact>]
         let ``example config file test`` () =
-            let exampleConfigFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\example_config_file.json")
+            let exampleConfigFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "example_config_file.json")
             let x = Restler.Examples.tryDeserializeExampleConfigFile exampleConfigFilePath
             Assert.True(x.IsSome)
             Assert.True(x.Value.paths |> List.exists (fun x -> x.path = "/vm"))
@@ -55,8 +55,8 @@ module Examples =
                              UseBodyExamples = Some true
                              UseQueryExamples = Some true
                              DataFuzzing = true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\array_example.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo_dictionary.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "array_example.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
             // Run the example test using the Swagger example and using the external example.
             let runTest testConfig =
@@ -64,7 +64,7 @@ module Examples =
                 // Read the baseline and make sure it matches the expected one
                 //
                 let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                           @"baselines\exampleTests\array_example_grammar.py")
+                                                           "baselines", "exampleTests", "array_example_grammar.py")
                 let actualGrammarFilePath = Path.Combine(grammarDirectoryPath,
                                                          Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
                 let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
@@ -75,10 +75,10 @@ module Examples =
             // Also test this scenario when 'DataFuzzing' is false.  This tests the case where
             // only examples are used for the schema.
             runTest { config with DataFuzzing = false }
-            let exampleConfigFile = Path.Combine(Environment.CurrentDirectory, "swagger\example_config_file.json")
+            let exampleConfigFile = Path.Combine(Environment.CurrentDirectory, "swagger", "example_config_file.json")
             let config =
                  { config with
-                        SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\array_example_external.json"))]
+                        SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "array_example_external.json"))]
                         ExampleConfigFilePath = Some exampleConfigFile }
             runTest config
 
@@ -90,8 +90,8 @@ module Examples =
                              GrammarOutputDirectoryPath = Some grammarDirectoryPath
                              ResolveBodyDependencies = false
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\array_example.json"))]
-                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\array_example_annotations.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "array_example.json"))]
+                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "array_example_annotations.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
             let grammarFilePath = Path.Combine(grammarDirectoryPath,
@@ -110,8 +110,8 @@ module Examples =
                              GrammarOutputDirectoryPath = Some grammarDirectoryPath
                              ResolveBodyDependencies = false
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\object_example.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo_dictionary.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "object_example.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
             let grammarFilePath = Path.Combine(grammarDirectoryPath,
@@ -129,8 +129,8 @@ module Examples =
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
                              ResolveBodyDependencies = false
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\secgroup_example.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\dict_secgroup_example.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "secgroup_example.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dict_secgroup_example.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
 
@@ -139,7 +139,7 @@ module Examples =
             let swaggerSpecConfig =
                   {
                       SpecFilePath =
-                         (Path.Combine(Environment.CurrentDirectory, @"swagger\empty_array_example.json"))
+                         (Path.Combine(Environment.CurrentDirectory, "swagger", "empty_array_example.json"))
                       Dictionary = None
                       DictionaryFilePath = None
                       AnnotationFilePath = None
@@ -178,8 +178,8 @@ module Examples =
                              IncludeOptionalParameters = true
                              GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
                              UseHeaderExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\headers.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\headers_dict.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "headers.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "headers_dict.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, "grammar.py")
@@ -213,8 +213,8 @@ module Examples =
                                  ResolveBodyDependencies = false
                                  UseBodyExamples = Some true
                                  SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory,
-                                                                           sprintf @"swagger\example_demo1%s" extension))]
-                                 CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo_dictionary.json"))
+                                                                            "swagger", sprintf "example_demo1%s" extension))]
+                                 CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                              }
                 Restler.Workflow.generateRestlerGrammar None config
                 let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
@@ -237,8 +237,8 @@ module Examples =
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
                              DiscoverExamples = true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo1.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo_dictionary.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo1.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
             let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
@@ -264,8 +264,8 @@ module Examples =
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
                              ResolveBodyDependencies = true
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo.json"))]
-                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, @"swagger\example_demo_dictionary.json"))
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo.json"))]
+                             CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
             Restler.Workflow.generateRestlerGrammar None config
             let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
@@ -295,7 +295,7 @@ module Examples =
                             ResolveQueryDependencies = true
                             UseBodyExamples = Some true
                             DataFuzzing = true  // TODO: also test with false, dependencies here should work in both cases.
-                            SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\subnet_id.json"))]
+                            SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "subnet_id.json"))]
                             CustomDictionaryFilePath = None
                          }
             Restler.Workflow.generateRestlerGrammar None config
@@ -324,7 +324,7 @@ module Examples =
                             ResolveBodyDependencies = true
                             ResolveQueryDependencies = true
                             UseBodyExamples = Some true
-                            SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\nested_objects_naming.json"))]
+                            SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "nested_objects_naming.json"))]
                             CustomDictionaryFilePath = None
                          }
             Restler.Workflow.generateRestlerGrammar None config
@@ -395,7 +395,7 @@ module Examples =
                             ResolveBodyDependencies = true
                             ResolveQueryDependencies = true
                             UseBodyExamples = Some true
-                            SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\dependencyTests\frontend_port_id.json"))]
+                            SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "frontend_port_id.json"))]
                             CustomDictionaryFilePath = None
                          }
             Restler.Workflow.generateRestlerGrammar None config
@@ -444,7 +444,7 @@ module Examples =
                             ResolveBodyDependencies = true
                             ResolveQueryDependencies = true
                             UseBodyExamples = Some true
-                            SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\DependencyTests\ip_configurations_get.json"))]
+                            SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "DependencyTests", "ip_configurations_get.json"))]
                             CustomDictionaryFilePath = None
                          }
             Restler.Workflow.generateRestlerGrammar None config
@@ -462,7 +462,7 @@ module Examples =
                              UseQueryExamples = None
                              UseBodyExamples = None
                              GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\inline_examples.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "inline_examples.json"))]
                              CustomDictionaryFilePath = None
                          }
             Restler.Workflow.generateRestlerGrammar None config
@@ -490,11 +490,11 @@ module Examples =
                              UseBodyExamples = Some true
                              UseQueryExamples = Some true
                              DataFuzzing = true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\exactCopy\array_example.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "exactCopy", "array_example.json"))]
                          }
 
             let exampleConfigFile = {
-                filePath = Path.Combine(Environment.CurrentDirectory, @"swagger\exactCopy\examples.json")
+                filePath = Path.Combine(Environment.CurrentDirectory, "swagger", "exactCopy", "examples.json")
                 exactCopy = true
             }
 
@@ -524,11 +524,11 @@ module Examples =
                              ResolveBodyDependencies = false
                              UseQueryExamples = Some true
                              DataFuzzing = true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\exampleTests\optional_params.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "exampleTests", "optional_params.json"))]
                          }
 
             let exampleConfigFile = {
-                filePath = Path.Combine(Environment.CurrentDirectory, @"swagger\exampleTests\optional_params_example.json")
+                filePath = Path.Combine(Environment.CurrentDirectory, "swagger", "exampleTests", "optional_params_example.json")
                 exactCopy = false
             }
 
@@ -553,11 +553,11 @@ module Examples =
                              UseBodyExamples = Some true
                              UseQueryExamples = Some true
                              DataFuzzing = true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\exampleTests\body_param.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "exampleTests", "body_param.json"))]
                          }
 
             let exampleConfigFile = {
-                filePath = Path.Combine(Environment.CurrentDirectory, @"swagger\exampleTests\body_param_example.json")
+                filePath = Path.Combine(Environment.CurrentDirectory, "swagger", "exampleTests", "body_param_example.json")
                 exactCopy = true
             }
 
@@ -565,7 +565,7 @@ module Examples =
             Restler.Workflow.generateRestlerGrammar None testConfig
 
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                        @"baselines\exampleTests\body_param_exactCopy_grammar.py")
+                                                        "baselines", "exampleTests", "body_param_exactCopy_grammar.py")
             let actualGrammarFilePath = Path.Combine(grammarOutputDirectoryPath,
                                                      Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath

--- a/src/compiler/Restler.Compiler.Test/JsonGrammarTests.fs
+++ b/src/compiler/Restler.Compiler.Test/JsonGrammarTests.fs
@@ -23,7 +23,7 @@ module GrammarTests =
                              GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
                              ResolveBodyDependencies = false
                              UseBodyExamples = Some true
-                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\grammarTests\required_params.json"))]
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "grammarTests", "required_params.json"))]
                          }
 
             // Confirm the baselines match for grammar.json and grammar.py
@@ -37,7 +37,7 @@ module GrammarTests =
                         if extension = ".json" || includeOptionalParameters then "required_params_grammar"
                         else "required_params_grammar_requiredonly"
                     let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
-                                                               sprintf @"baselines\grammarTests\%s%s" expectedGrammarFileName extension)
+                                                               "baselines", "grammarTests", sprintf "%s%s" expectedGrammarFileName extension)
                     let actualGrammarFilePath = Path.Combine(grammarOutputDirectoryPath,
                                                              actualGrammarFileName + extension)
                     let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath

--- a/src/compiler/Restler.Compiler.Test/ReferencesTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ReferencesTests.fs
@@ -15,7 +15,7 @@ module References =
     type ReferencesTests(ctx:Fixtures.TestSetupAndCleanup, output:Xunit.Abstractions.ITestOutputHelper) =
 
         let testReferenceTypes specFileName (expectedGrammarLines: string list) =
-            let filePath = Path.Combine(Environment.CurrentDirectory, sprintf @"swagger\referencesTests\%s" specFileName)
+            let filePath = Path.Combine(Environment.CurrentDirectory, "swagger", "referencesTests", sprintf "%s" specFileName)
             let grammarOutputDirectoryPath = Some ctx.testRootDirPath
             let config = { Restler.Config.SampleConfig with
                              IncludeOptionalParameters = true

--- a/src/compiler/Restler.Compiler.Test/SchemaTests.fs
+++ b/src/compiler/Restler.Compiler.Test/SchemaTests.fs
@@ -37,14 +37,14 @@ module ApiSpecSchema =
 
         [<Fact>]
         let ``required header is parsed successfully`` () =
-            compileSpec @"swagger\schemaTests\requiredHeader.yml"
+            compileSpec (Path.Combine("swagger", "schemaTests", "requiredHeader.yml"))
 
         [<Fact>]
         let ``spec with x-ms-paths is parsed successfully`` () =
-            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\xMsPaths.json")
-            let dictionaryFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\xMsPaths_dict.json")
-            let annotationsFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\xMsPaths_annotations.json")
-            let exampleConfigFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\xMsPaths_examples.json")
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "schemaTests", "xMsPaths.json")
+            let dictionaryFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "schemaTests", "xMsPaths_dict.json")
+            let annotationsFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "schemaTests", "xMsPaths_annotations.json")
+            let exampleConfigFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "schemaTests", "xMsPaths_examples.json")
             let config = { Restler.Config.SampleConfig with
                              IncludeOptionalParameters = true
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
@@ -61,20 +61,20 @@ module ApiSpecSchema =
             let grammarDiff =
                 getLineDifferences
                     (config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
-                    (Path.Combine(Environment.CurrentDirectory, @"baselines\schemaTests\xMsPaths_grammar.py"))
+                    (Path.Combine(Environment.CurrentDirectory, "baselines", "schemaTests", "xMsPaths_grammar.py"))
             let message = sprintf "grammar.py does not match baseline.  First difference: %A" grammarDiff
             Assert.True(grammarDiff.IsNone, message)
 
             let grammarDiff =
                 getLineDifferences
                     (config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultJsonGrammarFileName)
-                    (Path.Combine(Environment.CurrentDirectory, @"baselines\schemaTests\xMsPaths_grammar.json"))
+                    (Path.Combine(Environment.CurrentDirectory, "baselines", "schemaTests", "xMsPaths_grammar.json"))
             let message = sprintf "grammar.json does not match baseline.  First difference: %A" grammarDiff
             Assert.True(grammarDiff.IsNone, message)
 
         [<Fact>]
         let ``path parameter is read from the global parameters`` () =
-            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\global_path_parameters.json")
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "schemaTests", "global_path_parameters.json")
             let config = { Restler.Config.SampleConfig with
                              IncludeOptionalParameters = true
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
@@ -89,7 +89,7 @@ module ApiSpecSchema =
 
         [<Fact>]
         let ``swagger escape characters is parsed successfully`` () =
-            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\swagger_escape_characters.json")
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "schemaTests", "swagger_escape_characters.json")
             let config = { Restler.Config.SampleConfig with
                              IncludeOptionalParameters = true
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
@@ -107,7 +107,7 @@ module ApiSpecSchema =
 
         [<Fact>]
         let ``openapi3 requestBody`` () =
-            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\openapi3_requestbody.json")
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "schemaTests", "openapi3_requestbody.json")
             let config = { Restler.Config.SampleConfig with
                                 IncludeOptionalParameters = true
                                 GrammarOutputDirectoryPath = Some ctx.testRootDirPath
@@ -125,7 +125,7 @@ module ApiSpecSchema =
 
         [<Fact>]
         let ``json depth limit test`` () =
-            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\large_json_body.json")
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "schemaTests", "large_json_body.json")
             let config = { Restler.Config.SampleConfig with
                              IncludeOptionalParameters = true
                              GrammarOutputDirectoryPath = Some ctx.testRootDirPath
@@ -155,7 +155,7 @@ module ApiSpecSchema =
 
         [<Fact>]
         let ``additionalProperties schema`` () =
-            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\additionalProperties.yml")
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "schemaTests", "additionalProperties.yml")
             let config = { Restler.Config.SampleConfig with
                                 IncludeOptionalParameters = true
                                 GrammarOutputDirectoryPath = Some ctx.testRootDirPath
@@ -172,7 +172,7 @@ module ApiSpecSchema =
 
         [<Fact>]
         let ``openapi3 examples`` () =
-            let specFilePath = Path.Combine(Environment.CurrentDirectory, @"swagger\schemaTests\openapi3_examples.json")
+            let specFilePath = Path.Combine(Environment.CurrentDirectory, "swagger", "schemaTests", "openapi3_examples.json")
             let config = { Restler.Config.SampleConfig with
                                 IncludeOptionalParameters = true
                                 GrammarOutputDirectoryPath = Some ctx.testRootDirPath

--- a/src/compiler/Restler.Compiler.Test/SwaggerSpecs.fs
+++ b/src/compiler/Restler.Compiler.Test/SwaggerSpecs.fs
@@ -16,7 +16,7 @@ module SwaggerSpecs =
         [
             ("demo_server",
                 { DefaultConfig with
-                    SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger\demo_server.json")) ]
+                    SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, @"swagger", "demo_server.json")) ]
                     IncludeOptionalParameters = true
                 })
         ] |> Map.ofSeq

--- a/src/compiler/Restler.Compiler.Test/swagger/exactCopy/examples.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/exactCopy/examples.json
@@ -2,7 +2,7 @@
     "paths": {
         "/stores/{storeId}/order": {
             "post": {
-                "0": ".\\make_order_post.json"
+                "0": "./make_order_post.json"
             }
         }
     }


### PR DESCRIPTION
This PR fixes the compiler tests to run on MacOS by splitting up paths with explicit "\" path separators into multiple segments that are combined with Path.Combine.

In almost all cases the code was already using Path.Combine so this was relatively straightforward.

One special case was flipping a "\" to a "/" in the "examples.json" file.  I'm hoping this won't cause problems for the tests on Windows ...