### PR TITLE
Fix incorrect usage of 'endpoint'

### DIFF
--- a/restler/engine/core/sequences.py
+++ b/restler/engine/core/sequences.py
@@ -358,7 +358,7 @@ class Sequence(object):
 
             last_req = self.requests[-1]
 
-            self.create_prefix_once, self.re_render_prefix_on_success = Settings().get_cached_prefix_request_settings(last_req.endpoint, last_req.method)
+            self.create_prefix_once, self.re_render_prefix_on_success = Settings().get_cached_prefix_request_settings(last_req.endpoint_no_dynamic_objects, last_req.method)
 
             # Clean up internal state
             self.status_codes = []


### PR DESCRIPTION
When ```x-ms-paths``` are used, the ```endpoint``` method removes the query part.

This code should use 'endpoint_no_dynamic_objects' instead, since this corresponds to the endpoint in the Swagger spec (which could include query parameters for x-ms-paths)