### PR TITLE
Remove missing file from demo server Dockerfile

### DIFF
--- a/demo_server/Dockerfile
+++ b/demo_server/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-alpine
 RUN apk add --no-cache build-base
 
 COPY demo_server/  /app/demo_server
-COPY requirements.txt logging.conf swagger.json /app/
+COPY requirements.txt swagger.json /app/
 
 WORKDIR /app
 


### PR DESCRIPTION
logging.conf is no longer present, preventing demo image container from being built.