### PR TITLE
Update RESTler version to 9.1.1

### DIFF
--- a/ci_build_pipelines/variables/version-variables.yml
+++ b/ci_build_pipelines/variables/version-variables.yml
@@ -4,7 +4,7 @@ variables:
   - name: version.minor
     value: 1
   - name: devRevision
-    value: 0
+    value: 1
   - name: buildPlatform
     value: 'Any CPU'
   - name: buildConfiguration

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -14,7 +14,7 @@ open Microsoft.FSharpLu.Diagnostics.Process
 open Restler.Telemetry
 
 [<Literal>]
-let CurrentVersion = "9.1.0"
+let CurrentVersion = "9.1.1"
 let EngineErrorCode = -2
 
 let exitRestler status =


### PR DESCRIPTION
Updates in this version:
- clean-up enhancements
- new authentication methods
- new report for quickly diagnosing coverage bottlenecks
- bug fixes