### PR TITLE
Fix duplicate extension in driver output

### DIFF
--- a/src/driver/TaskResults.fs
+++ b/src/driver/TaskResults.fs
@@ -89,4 +89,4 @@ module TaskResults =
 
             SpecCoverage.printFailedRequestSequences failedRequestSequences stream
 
-            Logging.logInfo <| sprintf "See '%s.txt' to investigate API coverage." specCovToInvestigateFileName
+            Logging.logInfo <| sprintf "See '%s' to investigate API coverage." specCovToInvestigateFileName


### PR DESCRIPTION
coverage_failures_to_investigate.txt.txt - this change removes the duplicate