### PR TITLE
Enable customizing telemetry metadata

### DIFF
--- a/src/compiler/Restler.Compiler/Telemetry.fs
+++ b/src/compiler/Restler.Compiler/Telemetry.fs
@@ -6,7 +6,8 @@ module Restler.Telemetry
 //Instrumentation key is from app insights resource in Azure Portal
 let [<Literal>] InstrumentationKey = "6a4d265f-98cd-432f-bfb9-18ced4cd43a9"
 
-type TelemetryClient(machineId: System.Guid, instrumentationKey: string) =
+type TelemetryClient(machineId: System.Guid, instrumentationKey: string, 
+                     environmentMetadata: (string*string) list) =
     let client =
         let c = Microsoft.ApplicationInsights.TelemetryClient(
                     new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration(instrumentationKey))
@@ -24,7 +25,7 @@ type TelemetryClient(machineId: System.Guid, instrumentationKey: string) =
                 "version", version
                 "task", task
                 "executionId", sprintf "%A" executionId
-            ]@featureList))
+            ]@environmentMetadata@featureList))
 
     member __.RestlerFinished(version, task, executionId, status,
                               specCoverageCounts,

--- a/src/driver/Telemetry.fs
+++ b/src/driver/Telemetry.fs
@@ -15,6 +15,20 @@ module Telemetry =
 
     let [<Literal>] AppInsightsInstrumentationSettingsKey = "restlerAppInsightsTelemetry"
 
+    let [<Literal>] AppInsightsAdditionalPropertiesSettingsKey = "additionalTelemetryProperties"
+
+    type TelemetryProperty = 
+        {
+            key : string
+            value : string
+        }
+
+    type AdditionalTelemetryProperties = 
+        {
+            envVars : string list option
+            properties : TelemetryProperty list option
+        }
+
     let getMicrosoftOptOut() =
         // Disable telemetry if the environment variable is set to 1 or true
         let optOutValues = ["1" ; "true"]


### PR DESCRIPTION
Currently the usage data sent to AppInsights does not allow customization.  Users may want to send additional metadata specific to their organization in order to better analyze usage.  This change allows customizing the metadata to telemetry via app settings in two ways:

1) Environment variables: RESTler will attempt to read the environment variables with the specified names and send the (variableName, value) pair.
2) Specific values: the specified key-value pairs will be sent

Example settings:
```
"additionalTelemetryProperties": {
    "envVars": [
       "ServiceId"
    ],
    "properties": [
      {
        "key": "TargetEnvironment",
        "value":  "Dev"
      }
    ]
  }
```

Testing:
	- Manual testing with existing telemetry pipeline