### PR TITLE
Fix date serialization bug in the mutations dictionary.

### DIFF
--- a/src/ResultsAnalyzer/Analyze/Main.fs
+++ b/src/ResultsAnalyzer/Analyze/Main.fs
@@ -51,7 +51,7 @@ let main (args:AnalyzeArgs) =
         | None -> List.empty
         | Some dictionaryFilePath ->
             if File.Exists dictionaryFilePath then
-                match Microsoft.FSharpLu.Json.Compact.tryDeserializeFile<Restler.Dictionary.MutationsDictionary> dictionaryFilePath with
+                match Restler.Utilities.JsonSerialization.tryDeserializeFile<Restler.Dictionary.MutationsDictionary> dictionaryFilePath with
                 | Choice1Of2 d ->
                     d.restler_custom_payload_uuid4_suffix
                     |> Option.defaultValue Map.empty
@@ -114,7 +114,7 @@ let main (args:AnalyzeArgs) =
                         errorCode, trimmed |> Map.ofSeq) //maybe dont need this?
         |> Map.ofSeq
 
-    Microsoft.FSharpLu.Json.Compact.serializeToFile errorBucketsFilePath allBucketsMapTrimmed
+    Restler.Utilities.JsonSerialization.serializeToFile errorBucketsFilePath allBucketsMapTrimmed
 
     let runSummaryFilePath = Path.Combine(args.outputDirPath, "runSummary.json")
     let runDataMap = failedByResponseCode |> Map.ofSeq
@@ -139,4 +139,4 @@ let main (args:AnalyzeArgs) =
                                     |> Map.ofSeq
         }
 
-    Microsoft.FSharpLu.Json.Compact.serializeToFile runSummaryFilePath runSummary
+    Restler.Utilities.JsonSerialization.serializeToFile runSummaryFilePath runSummary

--- a/src/ResultsAnalyzer/Program.fs
+++ b/src/ResultsAnalyzer/Program.fs
@@ -134,7 +134,7 @@ let (|AbstractionOptions|_|) (parsedOptions:AbstractionOptions) = function
         Some ({ parsedOptions with abstractCustom = new Regex(regex) :: parsedOptions.abstractCustom }, rest)
     | "-af"::dictionaryFile::rest | "--abstract-dictionary-file"::dictionaryFile::rest ->
         let dictionarySuffixes =
-            match Microsoft.FSharpLu.Json.Compact.tryDeserializeFile<Restler.Dictionary.MutationsDictionary> dictionaryFile with
+            match Restler.Utilities.JsonSerialization.tryDeserializeFile<Restler.Dictionary.MutationsDictionary> dictionaryFile with
             | Choice1Of2 d ->
                 d.restler_custom_payload_uuid4_suffix
                 |> Option.defaultValue Map.empty

--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -30,7 +30,7 @@ module CodeGenerator =
             Restler.Workflow.generateRestlerGrammar None
                                     { configs.["demo_server"] with
                                        GrammarOutputDirectoryPath = Some grammarOutputDirectory1 }
-            let grammar1 = Microsoft.FSharpLu.Json.Compact.deserializeFile<GrammarDefinition>
+            let grammar1 = Restler.Utilities.JsonSerialization.deserializeFile<GrammarDefinition>
                                 (Path.Combine(grammarOutputDirectory1, Restler.Workflow.Constants.DefaultJsonGrammarFileName))
             let pythonGrammar1 = File.ReadAllText (Path.Combine(grammarOutputDirectory1, Restler.Workflow.Constants.DefaultRestlerGrammarFileName))
 

--- a/src/compiler/Restler.Compiler.Test/DependencyTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DependencyTests.fs
@@ -22,7 +22,7 @@ module Dependencies =
             let dictionary =
                 match config.CustomDictionaryFilePath with
                 | Some customDictionaryPath when File.Exists customDictionaryPath ->
-                    let d = Microsoft.FSharpLu.Json.Compact.deserializeFile<Restler.Dictionary.MutationsDictionary> customDictionaryPath
+                    let d = Restler.Utilities.JsonSerialization.deserializeFile<Restler.Dictionary.MutationsDictionary> customDictionaryPath
                     { d with restler_custom_payload_uuid4_suffix = Some (Map.empty<string, string>) }
                 | _ -> Restler.Dictionary.DefaultMutationsDictionary
 
@@ -80,7 +80,7 @@ module Dependencies =
 
             // A new dictionary should be produced with two entries in 'restler_custom_payload_uuid_suffix'
             let dictionaryFilePath = Path.Combine(grammarOutputDirectoryPath, "dict.json")
-            let dictionary = Microsoft.FSharpLu.Json.Compact.tryDeserializeFile<Restler.Dictionary.MutationsDictionary> dictionaryFilePath
+            let dictionary = Restler.Utilities.JsonSerialization.tryDeserializeFile<Restler.Dictionary.MutationsDictionary> dictionaryFilePath
             match dictionary with
             | Choice2Of2 str -> Assert.True(false, sprintf "dictionary error: %s" str)
             | Choice1Of2 dict ->
@@ -206,7 +206,7 @@ module Dependencies =
                 let dependenciesJsonFilePath = Path.Combine(outputDirectory,
                                                             Restler.Workflow.Constants.DependenciesDebugFileName)
 
-                Microsoft.FSharpLu.Json.Compact.deserializeFile<ProducerConsumerDependency list> dependenciesJsonFilePath
+                Restler.Utilities.JsonSerialization.deserializeFile<ProducerConsumerDependency list> dependenciesJsonFilePath
             let resolvedDependencies =
                 dependencies
                 |> Seq.filter (fun dep -> dep.producer.IsSome)
@@ -232,7 +232,7 @@ module Dependencies =
                 let dependenciesJsonFilePath = Path.Combine(ctx.testRootDirPath,
                                                             Restler.Workflow.Constants.DependenciesDebugFileName)
 
-                Microsoft.FSharpLu.Json.Compact.deserializeFile<ProducerConsumerDependency list> dependenciesJsonFilePath
+                Restler.Utilities.JsonSerialization.deserializeFile<ProducerConsumerDependency list> dependenciesJsonFilePath
             let resolvedDependencies =
                 dependencies
                 |> Seq.filter (fun dep -> dep.producer.IsSome)
@@ -265,7 +265,7 @@ module Dependencies =
                 let dependenciesJsonFilePath = Path.Combine(ctx.testRootDirPath,
                                                             Restler.Workflow.Constants.DependenciesDebugFileName)
 
-                Microsoft.FSharpLu.Json.Compact.deserializeFile<ProducerConsumerDependency list> dependenciesJsonFilePath
+                Restler.Utilities.JsonSerialization.deserializeFile<ProducerConsumerDependency list> dependenciesJsonFilePath
             let resolvedDependencies =
                 dependencies
                 |> Seq.filter (fun dep -> dep.producer.IsSome)

--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -424,7 +424,7 @@ module Examples =
 
             // A new dictionary should be produced with the above entries in 'restler_custom_payload_uuid_suffix'
             let dictionaryFilePath = Path.Combine(grammarOutputDirectoryPath, "dict.json")
-            let dictionary = Microsoft.FSharpLu.Json.Compact.tryDeserializeFile<Restler.Dictionary.MutationsDictionary> dictionaryFilePath
+            let dictionary = Restler.Utilities.JsonSerialization.tryDeserializeFile<Restler.Dictionary.MutationsDictionary> dictionaryFilePath
             match dictionary with
             | Choice2Of2 str -> Assert.True(false, sprintf "dictionary error: %s" str)
             | Choice1Of2 dict ->

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -203,6 +203,9 @@
     <Content Include="swagger\dictionaryTests\customPayloadRequestTypeDict.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="swagger\dictionaryTests\serializationTestDict.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="swagger\DependencyTests\lowercase_paths.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/serializationTestDict.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/serializationTestDict.json
@@ -1,0 +1,7 @@
+{
+  "restler_fuzzable_datetime": ["2023-03-13T10:36:56.0000000Z"],
+  "restler_custom_payload": {
+    "custom_date1": [ "2023-03-13T10:36:56.0000000Z" ],
+    "custom_date2": [ "03/13/2023 10:36:56 " ]
+  }
+}

--- a/src/compiler/Restler.Compiler/Annotations.fs
+++ b/src/compiler/Restler.Compiler/Annotations.fs
@@ -46,7 +46,7 @@ type ProducerConsumerUserAnnotation =
 let parseAnnotation (ann:JToken) =
     let annJson = ann.ToString(Newtonsoft.Json.Formatting.None)
 
-    match Microsoft.FSharpLu.Json.Compact.tryDeserialize<ProducerConsumerUserAnnotation>
+    match Utilities.JsonSerialization.tryDeserialize<ProducerConsumerUserAnnotation>
             annJson with
     | Choice2Of2 error ->
         failwith (sprintf "Invalid producer annotation: %s (%s)" error annJson)

--- a/src/compiler/Restler.Compiler/Config.fs
+++ b/src/compiler/Restler.Compiler/Config.fs
@@ -296,7 +296,7 @@ let DefaultConfig =
 // A helper function to override defaults with user-specified config values 
 // when the user specifies only some of the properties
 let mergeWithDefaultConfig (userConfigAsString:string) =
-    let defaultConfig = Microsoft.FSharpLu.Json.Compact.serialize DefaultConfig
+    let defaultConfig = Utilities.JsonSerialization.serialize DefaultConfig
     let newConfig = Restler.Utilities.JsonParse.mergeWithOverride defaultConfig userConfigAsString
 
-    Microsoft.FSharpLu.Json.Compact.deserialize<Config> newConfig
+    Utilities.JsonSerialization.deserialize<Config> newConfig

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -1897,7 +1897,7 @@ let writeDependenciesDebug dependenciesFilePath dependencies =
     // The below statement is present as an assertion, to check for deserialization issues
 #if TEST_GRAMMAR
     use f = System.IO.File.OpenRead(dependenciesFilePath)
-    Microsoft.FSharpLu.Json.Compact.deserializeStream<ProducerConsumerDependency list> f
+    Restler.Utilities.JsonSerialization.deserializeStream<ProducerConsumerDependency list> f
     |> ignore
 #endif
 

--- a/src/compiler/Restler.Compiler/Examples.fs
+++ b/src/compiler/Restler.Compiler/Examples.fs
@@ -55,6 +55,7 @@ let tryDeserializeJObjectFromFile filePath =
     if System.IO.File.Exists filePath then
         use stream = System.IO.File.OpenText(filePath)
         use reader = new Newtonsoft.Json.JsonTextReader(stream)
+        reader.DateParseHandling <- Newtonsoft.Json.DateParseHandling.None
         let jObject = JObject.Load(reader)
         Some (jObject, Some filePath)
     else

--- a/src/compiler/Restler.Compiler/SwaggerVisitors.fs
+++ b/src/compiler/Restler.Compiler/SwaggerVisitors.fs
@@ -25,7 +25,7 @@ type UnsupportedRecursiveExample (msg:string) =
 module SchemaUtilities =
 
     let formatExampleValue (exampleObject:obj) = 
-        Microsoft.FSharpLu.Json.Compact.serialize exampleObject
+        Restler.Utilities.JsonSerialization.serialize exampleObject
 
     /// Get an example value as a string, either directly from the 'example' attribute or
     /// from the extension 'Examples' property.

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -133,7 +133,7 @@ module Compile =
             match config.CustomDictionaryFilePath with
             | None ->
                 let newDictionaryFilePath = workingDirectory ++ "defaultDict.json"
-                Microsoft.FSharpLu.Json.Compact.serializeToFile newDictionaryFilePath Restler.Dictionary.DefaultMutationsDictionary
+                Restler.Utilities.JsonSerialization.serializeToFile newDictionaryFilePath Restler.Dictionary.DefaultMutationsDictionary
                 Some newDictionaryFilePath
             | Some s ->
                 config.CustomDictionaryFilePath
@@ -148,7 +148,7 @@ module Compile =
                 GrammarOutputDirectoryPath = Some compilerOutputDirPath
                 CustomDictionaryFilePath = dictionaryFilePath }
         let compilerConfigPath = workingDirectory ++ Restler.Workflow.Constants.DefaultCompilerConfigName
-        Microsoft.FSharpLu.Json.Compact.serializeToFile compilerConfigPath compilerConfig
+        Restler.Utilities.JsonSerialization.serializeToFile compilerConfigPath compilerConfig
 
         // Run compiler
         let! result =
@@ -531,7 +531,7 @@ module Config =
         let defaultDictionary =
             match Restler.Dictionary.getDictionaryFromString customPayloads with
             | Ok d ->
-                Microsoft.FSharpLu.Json.Compact.serializeToFile dictionaryFilePath d
+                Restler.Utilities.JsonSerialization.serializeToFile dictionaryFilePath d
             | error ->
                 failwith "Could not deserialize default dictionary during generate_config."
         let engineSettingsFilePath = configDirPath ++ Restler.Workflow.Constants.DefaultEngineSettingsFileName
@@ -562,7 +562,7 @@ module Config =
         let configFilePath = configDirPath ++ Restler.Workflow.Constants.DefaultCompilerConfigName
         // Deserialize the config to make sure it is valid before writing it.
         let defaultConfig = config.ToString()
-        let _ = Microsoft.FSharpLu.Json.Compact.deserialize<Restler.Config.Config> defaultConfig
+        let _ = Restler.Utilities.JsonSerialization.deserialize<Restler.Config.Config> defaultConfig
         File.WriteAllText(configFilePath, defaultConfig)
         ()
 
@@ -725,7 +725,7 @@ let rec parseArgs (args:DriverArgs) = function
             Logging.logError <| sprintf "File %s does not exist." compilerConfigFilePath
             usage()
 
-        match Microsoft.FSharpLu.Json.Compact.tryDeserializeFile<Restler.Config.Config> compilerConfigFilePath with
+        match Restler.Utilities.JsonSerialization.tryDeserializeFile<Restler.Config.Config> compilerConfigFilePath with
         | Choice1Of2 config->
             let config = Restler.Config.mergeWithDefaultConfig (File.ReadAllText compilerConfigFilePath)
             let config = Restler.Config.convertRelativeToAbsPaths compilerConfigFilePath config
@@ -836,7 +836,7 @@ let main argv =
         match getConfigValue Telemetry.AppInsightsAdditionalPropertiesSettingsKey with
         | None -> []
         | Some str ->
-            match Microsoft.FSharpLu.Json.Compact.tryDeserialize<Telemetry.AdditionalTelemetryProperties> str with
+            match Restler.Utilities.JsonSerialization.tryDeserialize<Telemetry.AdditionalTelemetryProperties> str with
             | Choice1Of2 p ->
                 let envVarValues = 
                     match p.envVars with

--- a/src/driver/TaskResults.fs
+++ b/src/driver/TaskResults.fs
@@ -25,7 +25,7 @@ module TaskResults =
                 [], []
             | Some testingSummaryFilePath ->
                 let testingSummary =
-                    Microsoft.FSharpLu.Json.Compact.deserializeFile<Engine.TestingSummary> testingSummaryFilePath
+                    Restler.Utilities.JsonSerialization.deserializeFile<Engine.TestingSummary> testingSummaryFilePath
 
                 Logging.logInfo <| sprintf "Request coverage (successful / total): %s" testingSummary.final_spec_coverage
                 Logging.logInfo <| sprintf "Attempted requests: %s" testingSummary.rendered_requests


### PR DESCRIPTION
In some cases, dates were being reformatted during compilation.  For example, if a custom payload specified a date as follows -

"2023-03-13T10:36:56.0000000Z"

It was reformatted to be:

"03/13/2023 10:36:56"

This was due to using the default option for Json deserialization - the fix is to specify DateParseHandling.None in the serializer settings.

Since this issue could occur in many places (examples, grammar, mutations dictionary), this change updates the serialization throughout the code to use the common module with this option.

Testing:
- added unit test

