### PR TITLE
Fix regression in compiling with `config.json`

### DIFF
--- a/src/compiler/Restler.Compiler/Utilities.fs
+++ b/src/compiler/Restler.Compiler/Utilities.fs
@@ -122,7 +122,7 @@ module JsonParse =
             // Overwrite the default property
             if newJson.ContainsKey(prop.Key) then
                 newJson.Remove(prop.Key) |> ignore
-                newJson.Add(prop.Key, prop.Value)
+            newJson.Add(prop.Key, userConfigAsJson.[prop.Key])
         JsonSerialization.serialize newJson
 
 module Stream =

--- a/src/compiler/Restler.CompilerExe/Program.fs
+++ b/src/compiler/Restler.CompilerExe/Program.fs
@@ -25,7 +25,7 @@ let main argv =
         match argv with
         | [|configFilePath|] ->
             if File.Exists configFilePath then
-                let config = Json.Compact.deserializeFile<Config> configFilePath
+                let config = Restler.Utilities.JsonSerialization.deserializeFile<Config> configFilePath
                 let config =
                     match config.GrammarOutputDirectoryPath with
                     | None ->


### PR DESCRIPTION
Fix bug in `mergeWithOverride` refactoring introduced with the previous deserialization change.

Testing:
- manual testing.
- There is currently a test gap where there are no automated end to end tests for compiling with a compiler config - this will be addressed in a separate change.