### PR TITLE
Add .replay suffix to the replay file

### DIFF
--- a/docs/user-guide/Replay.md
+++ b/docs/user-guide/Replay.md
@@ -7,9 +7,9 @@ In *Replay* mode, RESTler can replay a sequence from a bug_bucket log that was c
 To reproduce a bug bucket using RESTler,
 send the following command (as an example):
 
-`C:\restler_bin\restler\restler.exe replay --replay_log C:\demo-server-test\Test\RestlerResults\experiment20652\bug_buckets\PayloadBodyChecker_500_1.txt --token_refresh_command "<command>" --token_refresh_interval 30`
+`C:\restler_bin\restler\restler.exe replay --replay_log C:\demo-server-test\Test\RestlerResults\experiment20652\bug_buckets\PayloadBodyChecker_500_1.replay.txt --token_refresh_command "<command>" --token_refresh_interval 30`
 
-In this example, RESTler will replay the log `PayloadBodyChecker_500_1.txt`.
+In this example, RESTler will replay the log `PayloadBodyChecker_500_1.replay.txt`.
 If authentication is required to replay the sequence, the authentication options must be specified during replay.
 
 As you can see above,

--- a/restler-quick-start.py
+++ b/restler-quick-start.py
@@ -68,7 +68,7 @@ def replay_from_dir(ip, port, host, use_ssl, restler_dll_path, replay_dir):
     import glob
     from pathlib import Path
     # get all the 500 replay files in the bug buckets directory
-    bug_buckets = glob.glob(os.path.join(replay_dir, 'RestlerResults', '**/bug_buckets/*500*txt'))
+    bug_buckets = glob.glob(os.path.join(replay_dir, 'RestlerResults', '**/bug_buckets/*500*.replay.txt'))
     print(f"buckets: {bug_buckets}")
     for file_path in bug_buckets:
         if "bug_buckets" in os.path.basename(file_path):

--- a/restler/test_servers/log_parser.py
+++ b/restler/test_servers/log_parser.py
@@ -387,7 +387,7 @@ class BugLogParser(LogParser):
                 print("Failed to read bug log. Log was not a complete test log.\n"
                       f"{err!s}")
                 raise TestFailedException
-            
+
 class JsonFormattedBugsLogParser(LogParser):
     class FileType(enumerate):
         Bugs = 'Bugs',
@@ -405,10 +405,9 @@ class JsonFormattedBugsLogParser(LogParser):
         # key = bug type, value = list(tuple(ParsedSequence, reproduced-bool, bug-hash))
         self._bug_list = []
         self._bug_detail = None
-        self._bug_buckets_bychecker = []
         self._fileType = fileType
         self._parse()
-    
+
     def _parse(self):
         """ Parses the bug log to populate the bug list
 

--- a/restler/unit_tests/test_basic_functionality_end_to_end.py
+++ b/restler/unit_tests/test_basic_functionality_end_to_end.py
@@ -1059,7 +1059,7 @@ class FunctionalityTests(unittest.TestCase):
             self.fail("Smoke test failed: Fuzzing")
 
     def test_logger_jsonformatted_bugbuckets(self):
-        
+
         def verify_bug_details(baseline_bugdetail_filename, actual_bugdetail_filename):
             try:
             #Verify the generated bug details in json format.
@@ -1096,24 +1096,26 @@ class FunctionalityTests(unittest.TestCase):
         experiments_dir = self.get_experiments_dir()
         try:
             #Verify the generated bugs.json file
-            default_parser = JsonFormattedBugsLogParser(os.path.join(Test_File_Directory, "Bug_Buckets_Json","Bugs_Bucket_AsJson.json"),JsonFormattedBugsLogParser.FileType.Bugs)
-            test_parser = JsonFormattedBugsLogParser(os.path.join(experiments_dir, 'bug_buckets', 'Bugs.json'),JsonFormattedBugsLogParser.FileType.Bugs)
-            self.assertTrue(len(default_parser._bug_list) == len(test_parser._bug_list),"Expected count of bugs are not same.")
-            counter =0;
+            default_parser = JsonFormattedBugsLogParser(os.path.join(Test_File_Directory, "Bug_Buckets_Json","Bugs_Bucket_AsJson.json"),
+                                                        JsonFormattedBugsLogParser.FileType.Bugs)
+            test_parser = JsonFormattedBugsLogParser(os.path.join(experiments_dir, 'bug_buckets', 'Bugs.json'),
+                                                     JsonFormattedBugsLogParser.FileType.Bugs)
+            self.assertTrue(len(default_parser._bug_list) == len(test_parser._bug_list), "Expected count of bugs are not same.")
+            counter = 0
             for expected_bug in default_parser._bug_list:
                 actual_bug = test_parser._bug_list[counter]
                 self.assertTrue(expected_bug == actual_bug ,f"Expected bug :{expected_bug} and actual bug :{actual_bug} are different")
                 counter = counter + 1
         except TestFailedException:
             self.fail("verification of bugs json file failed")
-        
+
         verify_bug_details(os.path.join(Test_File_Directory,"Bug_Buckets_Json", "InvalidDynamicObjectChecker_20x_1.json"),
                            os.path.join(experiments_dir, 'bug_buckets', 'InvalidDynamicObjectChecker_20x_1.json'))
-        
+
         verify_bug_details(os.path.join(Test_File_Directory,"Bug_Buckets_Json", "UseAfterFreeChecker_20x_1.json"),
                            os.path.join(experiments_dir, 'bug_buckets', 'UseAfterFreeChecker_20x_1.json'))
-        
-        
+
+
     def test_gc_limits(self):
         """ This test checks that RESTler exits after N objects cannot be deleted according
         to the settings.  It also tests that async resource deletion is being performed.

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -73,7 +73,7 @@ LOG_TYPE_AUTH = 'auth'
 
 class Bug():
      def __init__(self):
-       
+
        self.filepath = None
        self.reproducible = False
        self.checker_name = None
@@ -84,7 +84,7 @@ class Bug():
 
 class BugDetail():
     def __init__(self):
-       
+
        self.status_code = 0
        self.checker_name = None
        self.reproducible = False
@@ -98,13 +98,13 @@ class BugDetail():
 
 class BugRequest():
     def __init__(self):
-        
+
         self.producer_timing_delay = 0
         self.max_async_wait_time = 0
-        self.replay_request = None 
-        self.response =None  
-        
-     
+        self.replay_request = None
+        self.response =None
+
+
 Network_Auth_Log = None
 
 class NetworkLog(object):
@@ -643,10 +643,10 @@ def update_bug_buckets(bug_buckets, bug_request_data, bug_hash, additional_log_s
     Header_Len = 80
     def get_bug_filename(file_extension):
         return f"{bucket_class}_{len(bug_buckets[bucket_class].keys())}.{file_extension}"
-    
+
     def log_new_bug():
         # Create the new bug log
-        filename = get_bug_filename("txt")
+        filename = get_bug_filename("replay.txt")
         filepath = os.path.join(BUG_BUCKETS_DIR, filename)
 
         with open(filepath, "w+", encoding='utf-8') as bug_file:
@@ -678,13 +678,13 @@ def update_bug_buckets(bug_buckets, bug_request_data, bug_hash, additional_log_s
             os.fsync(log_file.fileno())
 
             return filename
-    
+
     def log_new_bug_as_json():
         # Create the new bug log in json format
         filename = get_bug_filename("json")
         filepath = os.path.join(BUG_BUCKETS_DIR, filename)
         currentsequence = bug_bucket.sequence
-        
+
         bugDetail = BugDetail()
         bugDetail.checker_name = bug_bucket.origin
         bugDetail.reproducible = bug_bucket.reproducible
@@ -698,31 +698,31 @@ def update_bug_buckets(bug_buckets, bug_request_data, bug_hash, additional_log_s
                 bugRequest.response = req.response
                 bugRequest.producer_timing_delay = req.producer_timing_delay
                 bugRequest.max_async_wait_time = req.max_async_wait_time
-                bugDetail.request_sequence.append(bugRequest)    
-                if(sequence_request_counter == len(bug_request_data)-1):
-                    if(len(req.response.split(DELIM))>1):
+                bugDetail.request_sequence.append(bugRequest)
+                if sequence_request_counter == len(bug_request_data) - 1:
+                    if len(req.response.split(DELIM)) > 1:
                         split_responsebody = req.response.split(DELIM)
                         response_headers = split_responsebody[0].split("\r\n")
-                        response_statusCode_and_statusMessage = response_headers[0].split(" ")
-                        bugDetail.status_code = response_statusCode_and_statusMessage[1]
-                        bugDetail.status_text = ' '.join(response_statusCode_and_statusMessage[2:])
+                        response_status_code_and_status_message = response_headers[0].split(" ")
+                        bugDetail.status_code = response_status_code_and_status_message[1]
+                        bugDetail.status_text = ' '.join(response_status_code_and_status_message[2:])
                     else :
                         bugDetail.status_code = ''
                         bugDetail.status_text = ''
-                    
+
                 sequence_request_counter = sequence_request_counter + 1
             except Exception as error:
-                        write_to_main(f"Failed to write bug bucket as json log: {error!s}")
-                        filename = 'Failed to create bug bucket as json log.'
+                write_to_main(f"Failed to write bug bucket as json log: {error!s}")
+                filename = 'Failed to create bug bucket as json log.'
 
-        jsonString =bugDetail.toJson()
+        jsonString = bugDetail.toJson()
         with open(filepath, "w+", encoding='utf-8') as bug_file:
             print(f'{jsonString}', file=bug_file)
             log_file.flush()
             os.fsync(log_file.fileno())
 
-        return filename        
-    
+        return filename
+
     def write_incremental_bugs(file_path, req_bug):
         if not os.path.exists(file_path):
             with open(file_path, 'w', encoding='utf-8') as file:
@@ -783,8 +783,8 @@ def update_bug_buckets(bug_buckets, bug_request_data, bug_hash, additional_log_s
                         requestBug.filepath = filenameJson
                         requestBug.reproducible = bug_bucket.reproducible
                         requestBug.checker_name = bug_bucket.origin
-                        requestBug.error_code = bug_bucket.error_code 
-                        
+                        requestBug.error_code = bug_bucket.error_code
+
                         write_incremental_bugs(os.path.join(BUG_BUCKETS_DIR, "Bugs.json"),requestBug)
                         Bugs_Logged[bucket_hash] = BugTuple(filename, bug_hash, bug_bucket.reproduce_attempts, bug_bucket.reproduce_successes)
                         add_hash(filename)
@@ -1248,4 +1248,3 @@ def generate_summary_speccov():
     @rtype : None
     """
     SpecCoverageLog.Instance().generate_summary_speccov()
-    


### PR DESCRIPTION
Since bug report files in json format have been added, add the suffix to the replay file to make it clear which of the files can be used to replay the bug.

Also includes minor formatting changes in code related to bug logging/replay.