### PR TITLE
Fix incorrect quoting around example values

### DIFF
--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -572,6 +572,27 @@ module Examples =
             let message = sprintf "Grammar Does not match baseline.  First difference: %A" grammarDiff
             Assert.True(grammarDiff.IsNone, message)
 
+        [<Fact>]
+        let ``int64 format example with OpenAPI3 regression test`` () =
+            let config = { Restler.Config.SampleConfig with
+                             IncludeOptionalParameters = true
+                             GrammarOutputDirectoryPath = Some ctx.testRootDirPath
+                             ResolveBodyDependencies = true
+                             UseBodyExamples = Some false
+                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "exampleTests", "example_int_openapi3.yml"))]
+                             CustomDictionaryFilePath = None
+                         }
+            Restler.Workflow.generateRestlerGrammar None config
+            let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
+            let grammar = File.ReadAllText(grammarFilePath)
+
+            // The grammar should contain the example integer without quotes
+            Assert.True(grammar.Contains("examples=[\"1010101\"]"))
+
+            // Test that objects are still correctly generated
+            Assert.True(grammar.Contains("{\\\"cloudy_test_scenario\\\":{\\\"label\\\":\\\"cloudy\\\",\\\"duration\\\":60,"))
+            Assert.True(grammar.Contains("\\\"is_negative\\\":true}}"))
+
         ///// Test that the grammar is correct when the entire body is replaced by an example payload.
         ///// Both 'exactCopy' settings should be tested.
         //[<Fact>]

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -64,6 +64,9 @@
     <Content Include="baselines\exampleTests\array_example_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+	  <Content Include="swagger\exampleTests\example_int_openapi3.yml">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content> 
 	  <Content Include="baselines\exampleTests\body_param_exactCopy_grammar.py">
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>

--- a/src/compiler/Restler.Compiler.Test/baselines/exampleTests/array_example_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/exampleTests/array_example_grammar.py
@@ -108,10 +108,10 @@ request = requests.Request([
     primitives.restler_static_string("{"),
     primitives.restler_static_string("""
     "storeId":"""),
-    primitives.restler_fuzzable_int("1", examples=['"23456"']),
+    primitives.restler_fuzzable_int("1", examples=["23456"]),
     primitives.restler_static_string(""",
     "rush":"""),
-    primitives.restler_fuzzable_bool("true", examples=['"True"']),
+    primitives.restler_fuzzable_bool("true", examples=["true"]),
     primitives.restler_static_string(""",
     "bagType":"""),
     primitives.restler_fuzzable_string("fuzzstring", quoted=True, examples=["paperfestive"]),

--- a/src/compiler/Restler.Compiler.Test/swagger/exampleTests/example_int_openapi3.yml
+++ b/src/compiler/Restler.Compiler.Test/swagger/exampleTests/example_int_openapi3.yml
@@ -1,0 +1,49 @@
+openapi: 3.0.3
+info:
+  title: api with int path param
+  version: 1.2.3
+paths:
+  "/test/{testId}/{category}":
+    post:
+      parameters:
+        - $ref: '#/components/parameters/idParam'
+        - $ref: '#/components/parameters/categoryParam'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bodyParam'
+      responses:
+        '200':
+          description: OK
+components:
+  parameters:
+    idParam:
+      in: path
+      name: testId
+      description: 'Id of the test case'
+      required: true
+      schema:
+        type: integer
+        format: int64
+      example: 1010101
+    categoryParam:
+      in: path
+      name: category
+      description: 'category of the test case'
+      required: true
+      schema:
+        type: boolean
+      example: false
+  schemas:
+    bodyParam:
+      example:
+        testDescription:
+          cloudy_test_scenario:
+            label: 'cloudy'
+            duration: !!int 60
+            is_negative: !!bool true
+      type: object
+      properties:
+        testDescription:
+          type: object

--- a/src/compiler/Restler.Compiler.Test/swagger/examples/make_order_descriptions.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/examples/make_order_descriptions.json
@@ -8,7 +8,7 @@
     "expiration": 10,
     "orderDetails": {
       "storeId": "23456",
-      "rush": "True",
+      "rush": true,
       "bagType": "paperfestive",
       "item_descriptions": [
       ],

--- a/src/compiler/Restler.Compiler/SwaggerVisitors.fs
+++ b/src/compiler/Restler.Compiler/SwaggerVisitors.fs
@@ -230,24 +230,16 @@ module SwaggerVisitors =
 
             match primitiveType with
             | _ when v.Type = JTokenType.Null -> null
-            | PrimitiveType.String
-            | PrimitiveType.DateTime
-            | PrimitiveType.Enum (_, PrimitiveType.String, _, _)
-            | PrimitiveType.Uuid
-            // Special case: non-Json bodies (e.g. text, xml) should not be quoted
-            | PrimitiveType.Object when (rawValue.[0] = ''' || rawValue.[0] =  '"') ->
-                // Remove the start and end quotes, which are preserved with 'Formatting.None'.
-                if rawValue.Length > 1 then
-                    match rawValue.[0], rawValue.[rawValue.Length-1] with
-                    | '"', '"' ->
-                        rawValue.[1..rawValue.Length-2]
-                    | '"', _
-                    | _, '"' ->
-                        printfn "WARNING: example file contains malformed value in property %A.  The compiler does not currently support this.  Please modify the grammar manually to send the desired payload."
-                                rawValue
-                        rawValue
-                    | _ -> rawValue
-                else rawValue
+            | _ when rawValue.Length > 1 && (rawValue.[0] = ''' || rawValue.[0] =  '"') ->
+                match rawValue.[0], rawValue.[rawValue.Length-1] with
+                | '"', '"' ->
+                    rawValue.[1..rawValue.Length-2]
+                | '"', _
+                | _, '"' ->
+                    printfn "WARNING: example file contains malformed value in property %A.  The compiler does not currently support this.  Please modify the grammar manually to send the desired payload."
+                            rawValue
+                    rawValue
+                | _ -> rawValue
             | _ -> rawValue
 
         /// Returns the specified property when the object contains it.


### PR DESCRIPTION
Fix quoting logic in the formatJTokenProperty function.

Testing:
- fix the test baseline bug
- add new test for path parameter with integer example

Closes #724