### PR TITLE
Minor documentation updates

### DIFF
--- a/docs/user-guide/CompilerConfig.md
+++ b/docs/user-guide/CompilerConfig.md
@@ -66,14 +66,14 @@ file named ```examples.json``` will also be generated in the examples directory.
 This file can be augmented with additional examples, and passed as an input to the
 compilation using the *ExampleConfigFilePath* parameter (see below).
 
-* *ExampleConfigFilePath* is the path to the file containing metadata about example parameter payloads.  See /docs/user-guide/Examples.md for a description of the file format.
+* *ExampleConfigFilePath* is the path to the file containing metadata about example parameter payloads.  See [Examples](Examples.md) for a description of the file format.
 If this setting is not specified, and *DiscoverExamples* is set to ```false```,
 the compiler looks for a default file named ```examples.json``` in the specified examples
 directory.  If *DiscoverExamples* is false, every time an example is used
 in the Swagger file, RESTler will first look for it in metadata,
 and, if found, the externally specified example will override the example from the specification.
 
-    See /docs/user-guide/Examples.md for a description of the file format.
+    See [Examples](Examples.md) for a description of the file format.
 If this setting is not specified, and *DiscoverExamples* is set to ```false```,
 the compiler looks for a default file named ```examples.json``` in the specified examples
 directory.  If *DiscoverExamples* is false, every time an example is used

--- a/docs/user-guide/FuzzingDictionary.md
+++ b/docs/user-guide/FuzzingDictionary.md
@@ -24,7 +24,7 @@ configuration files and then re-compiling.
 
 To add more values to the existing lists of values in the dictionary (```restler_fuzzable_string```, etc.): simply copy the dictionary out of the ```Compile```
 folder (to avoid accidentally re-compiling and overwriting the dictionary in the future),
-modify it, and proceed to testing and fuzzing (see Testing.md).
+modify it, and proceed to testing and fuzzing (see [Testing](Testing.md)).
 
 **If you add a new custom property to the dictionary:**
 

--- a/docs/user-guide/ImprovingCoverage.md
+++ b/docs/user-guide/ImprovingCoverage.md
@@ -37,7 +37,7 @@ To analyze the grammar directly, use one of these two files:
 One quick analysis of the grammar that can be done to check if a path parameter is set to '*fuzzstring*'.  Such cases often require extra configuration, such as
 
 - setting a *restler_custom_payload* or *restler_custom_payload_uuid_suffix* for this parameter in the dictionary (see [FuzzingDictionary](FuzzingDictionary.md))
-- adding a *producer-consumer annotation* to retrieve the value from a response of a different request in he API (see [Annotations](Annotations.md)).
+- adding a *producer-consumer annotation* to retrieve the value from a response of a different request in the API (see [Annotations](Annotations.md)).
 
 In some cases, it is more convenient to analyze the grammar since it does not require invoking the API.  However, for a complex API with many parameters, analyzing live logs rather than the grammar is recommended.
 

--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -38,7 +38,7 @@ Path to your key file in a txt file.
 If provided and valid, RESTler will attempt to use it during the SSL handshake.
 
 ### authentication: dict (default empty)
-Settings for specifying authentication. See Authentication.md for details
+Settings for specifying authentication. See [Authentication](Authentication.md) for details
 
 #### _token_ dict (default empty): Can optionally provide one of {```location```, ```token_refresh_cmd```, ```module```}
 


### PR DESCRIPTION
While reading through the documentation I noticed a typo, and a few spots where replacing plaintext file names with markdown links would make the documentation easier to navigate.

This PR has changes to fix these up.
