### PR TITLE
Checkers doc: update command line example

### DIFF
--- a/docs/user-guide/Checkers.md
+++ b/docs/user-guide/Checkers.md
@@ -14,7 +14,7 @@ To enable or disable more checkers during fuzzing (fuzz-lean or fuzz modes),
 simply add one, or both, of the following to the command-line (as example):
 
 ```
---enable_checkers UseAfterFree InvalidDynamicObject
+--enable_checkers UseAfterFree,InvalidDynamicObject
 --disable_Checkers LeakageRule
 ```
 


### PR DESCRIPTION
This PR is another small update to documentation to improve readability.

The example command-line for specifying checkers was a list of checkers separated by spaces. However, the list of checkers must be comma-separated values.

This commit updates the example to use comma-separated values.