### PR TITLE
change the protocol to http for local demo server

### DIFF
--- a/demo_server/swagger.json
+++ b/demo_server/swagger.json
@@ -6,7 +6,7 @@
     },
     "servers": [
         {
-            "url": "https://localhost:8888",
+            "url": "http://localhost:8888",
             "description": "Staging environment"
         }
     ],


### PR DESCRIPTION
For local demo server test, the protocol should be "http" not "https" as user can't access the python web app service via "https". There is "SSL_PROTOCOL_ERROR" when user execute [/api/blog/posts] in the Swagger Page as the real url is "https://localhost:8888/api/blog/posts?page=10&per_page=5". Please correct me if I am wrong. Thx!