### PR TITLE
Add script to diff network logs for debugging end to end tests.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,18 @@
             ]
         },
         {
+            "name": "Python: diff network logs",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}\\restler\\utils\\network_logs\\diff_network_logs.py",
+            "args" :[
+                "--left_file",
+                "D:\\test\\734\\logs_before_2\\logs\\network.testing.48660.1.txt",
+                "--right_file",
+                "D:\\test\\734\\logs_after_2\\logs\\network.testing.47156.1.txt"
+            ]
+        },
+        {
             "name": "Python: GC unit test",
             "type": "python",
             "request": "launch",

--- a/restler/checkers/invalid_value_checker.py
+++ b/restler/checkers/invalid_value_checker.py
@@ -345,6 +345,6 @@ class InvalidValueChecker(CheckerBase):
             finally:
                 rendered_values[idx] = orig_rendered_values
 
-        self._checker_log.checker_print(f"Tested {fuzzed_combinations} combinations for request"
+        self._checker_log.checker_print(f"Tested {fuzzed_combinations} combinations for request "
                                         f"{last_request.endpoint} {last_request.method}, combination "
                                         f"{last_request._current_combination_id}")

--- a/restler/test_servers/__init__.py
+++ b/restler/test_servers/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+

--- a/restler/utils/network_logs/diff_network_logs.py
+++ b/restler/utils/network_logs/diff_network_logs.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import json
+
+from test_servers.parsed_requests import *
+from test_servers.log_parser import *
+
+if __name__ == '__main__':
+    # Add an argument for the left file and right file
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--left_file', help='Path to left file', type=str, default=None, required=True)
+    parser.add_argument('--right_file', help='Path to right file', type=str, default=None, required=True)
+    parser.add_argument('--output_file',
+                        help='Filename for output file.',
+                        type=str, default=None, required=False)
+    args = parser.parse_args()
+
+    # Compare the two files using NetworkLogParser
+    print("Parsing left file...")
+    left_parser = FuzzingLogParser(args.left_file)
+    # TODO: output a summary of what was found in the left file (# sequences, requests, etc.)
+
+    print("Parsing right file...")
+    right_parser = FuzzingLogParser(args.right_file)
+    # TODO: output a summary of what was found in the left file (# sequences, requests, etc.)
+
+    diff = left_parser.diff_log(right_parser)
+
+    # Write the diff to a file
+    output_file = args.output_file or 'network_log_diffs.json'
+    with open(output_file, 'w') as f_diffs:
+        json.dump(diff, f_diffs, indent=4)


### PR DESCRIPTION
This change adds a script to help diff network logs when updating test baselines.

- improved log parsing to separate out requests and checkers.
- minor clean-up to log parsing

Usage:
a) Add python root directory (`<repo_root_dir>/restler`) to ```PYTHONPATH``` when invoking outside the repo 
b)
> python D:\git\restler-fuzzer\restler\utils\network_logs\diff_network_logs.py --left_file .\logs_before\invalidvalue_testing_log.txt --right_file .\logs_after\invalidvalue_testing_log.txt >diff_out.txt

