### PR TITLE
Take `no_tokens_in_logs` into account in speccov.

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -88,9 +88,10 @@ class RenderedRequestStats(object):
 
             # Remove the value of the Authorization header,
             # so it is not persisted in logs
-            for idx, h in enumerate(self.request_headers):
-                if h.startswith("Authorization:"):
-                    self.request_headers[idx] = "Authorization: _OMITTED_AUTH_TOKEN_"
+            if Settings().no_tokens_in_logs:
+                for idx, h in enumerate(self.request_headers):
+                    if h.startswith("Authorization:"):
+                        self.request_headers[idx] = "Authorization: _OMITTED_AUTH_TOKEN_"
 
             if len(split_body) > 0 and split_body[1]:
                 self.request_body = split_body[1]


### PR DESCRIPTION
This option was being used for network logs only (in `logger.py`), but `speccov.json` was always filtering tokens.  This change fixes the latter to also check the option.