### PR TITLE
Send hashes of the grammar and OpenAPI files in telemetry

### DIFF
--- a/src/ResultsAnalyzer/Common/Http.fs
+++ b/src/ResultsAnalyzer/Common/Http.fs
@@ -220,7 +220,7 @@ module Request =
         }
 
     /// Hash to identify a particular request without having to compare or print the full contents.
-    let hash req = req.ToString() |> Utilities.String.deterministicShortHash
+    let hash req = req.ToString() |> Restler.Utilities.String.deterministicShortHash
 
 module Response =
     /// Parse an HTTP response, where the body is parsed to 'T by bodyParser.

--- a/src/ResultsAnalyzer/Common/Utilities.fs
+++ b/src/ResultsAnalyzer/Common/Utilities.fs
@@ -5,7 +5,6 @@ module Restler.ResultsAnalyzer.Common.Utilities
 
 open System.IO
 open System.Text
-open System.Security.Cryptography
 
 open Newtonsoft.Json
 
@@ -26,20 +25,6 @@ module String =
             .Replace("\\t", "\t")
             .Replace(@"\\", @"\")
             .ToString()
-
-    /// Provide a deterministic hash from a string, because
-    /// F# Operator.hash / C# GetHashCode() are NOT deterministic between runs.
-    /// 32 hex digits = 16 bytes = 128 bits => 2^64 elements before collision with 50% probability.
-    let deterministicShortHash (str:string): string =
-        let hashLength = 16 // bytes
-
-        use sha1 = SHA1.Create()
-        let bytes = Encoding.Default.GetBytes(str)
-        let hashBytes = sha1.ComputeHash(bytes)
-        hashBytes
-        |> Seq.take hashLength
-        |> Seq.map (fun b -> b.ToString("x2"))
-        |> String.concat ""
 
 module Seq =
     /// Generic split on sequences (similar to String.Split).

--- a/src/ResultsAnalyzer/Timing.fs
+++ b/src/ResultsAnalyzer/Timing.fs
@@ -75,7 +75,7 @@ let main args =
             req.uri.path
             |> String.concat "/"
             |> escapeNewlinesQuotes
-        let reqHash = reqAbstracted.ToString() |> String.deterministicShortHash
+        let reqHash = reqAbstracted.ToString() |> Restler.Utilities.String.deterministicShortHash
         printf "%s,%s,%s,%s,\t%s,"
             req.method
             pathAbstracted
@@ -86,7 +86,7 @@ let main args =
         match resp with
         | None -> printfn ",,,"
         | Some (respTime, resp, respAbstracted) ->
-            let respHash = respAbstracted.ToString() |> String.deterministicShortHash
+            let respHash = respAbstracted.ToString() |> Restler.Utilities.String.deterministicShortHash
             let delay = (respTime - reqTime).TotalMilliseconds |> System.Convert.ToInt32
             printfn "%d %s,%s,\t%s,%d"
                 resp.statusCode

--- a/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
+++ b/src/compiler/Restler.Compiler.Test/CodeGeneratorTests.fs
@@ -27,7 +27,7 @@ module CodeGenerator =
         let ``generate code from modified grammar`` () =
 
             let grammarOutputDirectory1 = ctx.testRootDirPath
-            Restler.Workflow.generateRestlerGrammar None
+            Restler.Workflow.generateRestlerGrammar 
                                     { configs.["demo_server"] with
                                        GrammarOutputDirectoryPath = Some grammarOutputDirectory1 }
             let grammar1 = Restler.Utilities.JsonSerialization.deserializeFile<GrammarDefinition>
@@ -127,7 +127,7 @@ module CodeGenerator =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger" , "example_demo1.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarDirectoryPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -136,7 +136,7 @@ module CodeGenerator =
 
             // Now turn on parameter tracking
             let config = { config with TrackFuzzedParameterNames = true }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarDirectoryPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 

--- a/src/compiler/Restler.Compiler.Test/ConfigTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ConfigTests.fs
@@ -54,7 +54,7 @@ module Config =
 
             let newSettingsFilePath = Path.Combine(grammarOutputDirectoryPath, Restler.Workflow.Constants.DefaultEngineSettingsFileName)
 
-            Restler.Workflow.generateRestlerGrammar None multiDictConfig
+            Restler.Workflow.generateRestlerGrammar multiDictConfig
 
             match Restler.Engine.Settings.getEngineSettings newSettingsFilePath with
             | Ok perResourceSettings ->
@@ -101,7 +101,7 @@ module Config =
                 Assert.True(false, sprintf "Engine settings error: %s" msg)
 
             // Check that if an engine settings file is not specified, then a default new one is generated.
-            Restler.Workflow.generateRestlerGrammar None { multiDictConfig with EngineSettingsFilePath = None }
+            Restler.Workflow.generateRestlerGrammar { multiDictConfig with EngineSettingsFilePath = None }
             match Restler.Engine.Settings.getEngineSettings newSettingsFilePath with
             | Ok _ -> ()
             | Error msg ->
@@ -153,14 +153,14 @@ module Config =
             let grammarExternalFilePath = Path.Combine(grammarOutputDirectoryPath, "grammarExternal.py")
             let grammarNoAnnotationsFilePath = Path.Combine(grammarOutputDirectoryPath, "grammarNoAnnotations.py")
 
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             File.Copy(grammarFilePath, grammarInlineFilePath)
             // Delete the grammar file to make sure it gets re-generated
             File.Delete(grammarFilePath)
 
             // As a test sanity check, make sure the config without global annotations does not  the grammar to make sure it gets re-generated
-            Restler.Workflow.generateRestlerGrammar None noAnnotationsConfig
+            Restler.Workflow.generateRestlerGrammar noAnnotationsConfig
             File.Copy(grammarFilePath, grammarNoAnnotationsFilePath)
             // Delete the grammar file to make sure it gets re-generated
             File.Delete(grammarFilePath)
@@ -170,7 +170,7 @@ module Config =
 
             Assert.True(grammarsDiffAfterRemovingAnnotations.IsSome, message)
 
-            Restler.Workflow.generateRestlerGrammar None externalConfig
+            Restler.Workflow.generateRestlerGrammar externalConfig
             File.Copy(grammarFilePath, grammarExternalFilePath)
             // Delete the grammar file to make sure it gets re-generated
             File.Delete(grammarFilePath)
@@ -197,7 +197,7 @@ module Config =
                              UseBodyExamples = Some true
                              GrammarOutputDirectoryPath = Some grammarOutputDirectoryPath
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammar = File.ReadAllLines(grammarFilePath)

--- a/src/compiler/Restler.Compiler.Test/DependencyTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DependencyTests.fs
@@ -71,7 +71,7 @@ module Dependencies =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "put_createorupdate.json"))]
                              CustomDictionaryFilePath = None
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -89,7 +89,7 @@ module Dependencies =
 
             // Compiling with this dictionary should result in the same grammar.
             let config2 = { config with CustomDictionaryFilePath = Some dictionaryFilePath }
-            Restler.Workflow.generateRestlerGrammar None config2
+            Restler.Workflow.generateRestlerGrammar config2
             let grammar2 = File.ReadAllText(grammarFilePath)
             Assert.True((grammar = grammar2))
 
@@ -105,7 +105,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             // TODO: check that dynamic objects are present when 'allowGetProducers' is true, but not when it's false.
             //
@@ -125,7 +125,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -140,7 +140,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config2
+            Restler.Workflow.generateRestlerGrammar config2
             let grammar2 = File.ReadAllText(grammarFilePath)
             Assert.True((grammar = grammar2))
         *)
@@ -158,7 +158,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -173,7 +173,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config2
+            Restler.Workflow.generateRestlerGrammar config2
             let grammar2 = File.ReadAllText(grammarFilePath)
             Assert.True((grammar = grammar2))
 
@@ -190,7 +190,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -205,7 +205,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config2
+            Restler.Workflow.generateRestlerGrammar config2
             let grammar2 = File.ReadAllText(grammarFilePath)
             Assert.True((grammar = grammar2))
 
@@ -222,7 +222,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             // Read the baseline and make sure it matches the expected one
             //
@@ -247,7 +247,7 @@ module Dependencies =
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "dict.json"))
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             // Read the baseline and make sure it matches the expected one
             //
@@ -272,7 +272,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             // Read the baseline and make sure it matches the expected one
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
@@ -297,7 +297,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             // Read the dependencies.json and check that there are 3 producer-consumer dependencies.
             let dependencies =
@@ -323,7 +323,7 @@ module Dependencies =
                              CustomDictionaryFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             //// Read the dependencies and check that there are 3 producer-consumer dependencies.
             let dependencies =
@@ -356,7 +356,7 @@ module Dependencies =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "inconsistent_casing_paths.json"))]
                              CustomDictionaryFilePath = None
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             // Read the dependencies.json and check that there are 3 producer-consumer dependencies.
             let dependencies =
@@ -386,7 +386,7 @@ module Dependencies =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "post_patch_dependency.json"))]
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             // Make sure there are three dynamic objects.
             //
@@ -429,7 +429,7 @@ module Dependencies =
                              UseBodyExamples = None
                          }
 
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             // Make sure the grammar file exists and there is just one dynamic object for the array, regardless of how
             // many elements it had before.
             let grammarFilePath = Path.Combine(grammarOutputDirPath,
@@ -452,7 +452,7 @@ module Dependencies =
                              AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "input_producer_annotations.json"))
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let grammarFilePath = Path.Combine(grammarOutputDirPath,
                                                Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -503,7 +503,7 @@ module Dependencies =
                              CustomDictionaryFilePath = Some dictionaryFilePath
                          }
 
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath,
                                                Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -524,7 +524,7 @@ module Dependencies =
                              AnnotationFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let grammarFilePath = Path.Combine(grammarOutputDirPath,
                                                Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -541,7 +541,7 @@ module Dependencies =
             // Confirm the same works with annotations
             let configWithAnnotations = { config with
                                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "response_headers_annotations.json"))}
-            Restler.Workflow.generateRestlerGrammar None configWithAnnotations
+            Restler.Workflow.generateRestlerGrammar configWithAnnotations
 
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
                                                        "baselines", "dependencyTests", "header_response_writer_annotation_grammar.py")
@@ -563,7 +563,7 @@ module Dependencies =
                              AnnotationFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let actualGrammarFilePath = Path.Combine(grammarOutputDirPath,
                                                      Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -573,13 +573,13 @@ module Dependencies =
             // This scenario should work with annotations only.
             let configWithAnnotations = { config with
                                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "header_deps_annotations.json"))}
-            Restler.Workflow.generateRestlerGrammar None configWithAnnotations
+            Restler.Workflow.generateRestlerGrammar configWithAnnotations
 
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
             let message = sprintf "Grammar (test with annotations) does not match baseline.  First difference: %A" grammarDiff
             Assert.True(grammarDiff.IsNone, message)
 
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
             let message = "Grammar (test without annotations) matches the baseline, this is not expected"
             Assert.True(grammarDiff.IsSome, message)
@@ -602,7 +602,7 @@ module Dependencies =
                              AnnotationFilePath = None
                              AllowGetProducers = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let actualGrammarFilePath = Path.Combine(grammarOutputDirPath,
                                                      Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -611,7 +611,7 @@ module Dependencies =
 
             let configWithAnnotations = { config with
                                             AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "ordering_test_annotations.json"))}
-            Restler.Workflow.generateRestlerGrammar None configWithAnnotations
+            Restler.Workflow.generateRestlerGrammar configWithAnnotations
 
             let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
             let message = sprintf "Grammar (test with annotations) does not match baseline.  First difference: %A" grammarDiff
@@ -631,7 +631,7 @@ module Dependencies =
                              AllowGetProducers = true
                              ResolveQueryDependencies = true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let actualGrammarFilePath = Path.Combine(grammarOutputDirPath,
                                                      Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -661,7 +661,7 @@ module Dependencies =
                                  AllowGetProducers = true
                                  ResolveQueryDependencies = true
                              }
-                Restler.Workflow.generateRestlerGrammar None config
+                Restler.Workflow.generateRestlerGrammar config
 
                 let actualGrammarFilePath = Path.Combine(grammarOutputDirPath,
                                                          Restler.Workflow.Constants.DefaultRestlerGrammarFileName)

--- a/src/compiler/Restler.Compiler.Test/DictionaryTests.fs
+++ b/src/compiler/Restler.Compiler.Test/DictionaryTests.fs
@@ -24,7 +24,7 @@ module Dictionary =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadSwagger.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadDict.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
                                                        "baselines", "dictionaryTests", "quoted_primitives_grammar.py")
@@ -48,7 +48,7 @@ module Dictionary =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "multipleIdenticalUuidSuffix.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "multipleIdenticalUuidSuffixDict.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let grammarFilePath = Path.Combine(grammarOutputDirPath,
                                                Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -80,7 +80,7 @@ module Dictionary =
                          }
 
             let configWithoutDictionary = { config with CustomDictionaryFilePath = None }
-            Restler.Workflow.generateRestlerGrammar None configWithoutDictionary
+            Restler.Workflow.generateRestlerGrammar configWithoutDictionary
 
             let grammarFilePath = Path.Combine(grammarOutputDirPath,
                                                Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -90,7 +90,7 @@ module Dictionary =
             Assert.True((numFuzzableStrings = 4))
 
             // Now generate a grammar with the dictionary
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let grammarFilePath = Path.Combine(grammarOutputDirPath,
                                                Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -139,7 +139,7 @@ module Dictionary =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadSwagger.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadRequestTypeDict.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let grammarFilePath = Path.Combine(grammarOutputDirPath,
                                                Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
@@ -163,7 +163,7 @@ module Dictionary =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadSwagger.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dictionaryTests", "customPayloadDict.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let expectedValueGenTemplatePath = Path.Combine(Environment.CurrentDirectory,
                                                             @"baselines", "dictionaryTests", "customPayloadDict_ValueGeneratorTemplate.py")
@@ -213,7 +213,7 @@ module Dictionary =
             let inputDictionaryString = 
                 File.ReadAllText(dictionaryFilePath)
 
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let outputDictPath = Path.Combine(grammarOutputDirPath,
                                               Restler.Workflow.Constants.NewDictionaryFileName)
             let dictionaryString = 

--- a/src/compiler/Restler.Compiler.Test/ExampleTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ExampleTests.fs
@@ -22,7 +22,7 @@ module Examples =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo1.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -60,7 +60,7 @@ module Examples =
                          }
             // Run the example test using the Swagger example and using the external example.
             let runTest testConfig =
-                Restler.Workflow.generateRestlerGrammar None testConfig
+                Restler.Workflow.generateRestlerGrammar testConfig
                 // Read the baseline and make sure it matches the expected one
                 //
                 let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
@@ -93,7 +93,7 @@ module Examples =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "array_example.json"))]
                              AnnotationFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "array_example_annotations.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarDirectoryPath,
                                                Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammar = File.ReadAllText(grammarFilePath)
@@ -113,7 +113,7 @@ module Examples =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "object_example.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarDirectoryPath,
                                                Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammar = File.ReadAllText(grammarFilePath)
@@ -132,7 +132,7 @@ module Examples =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "secgroup_example.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "dict_secgroup_example.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
         [<Fact>]
         let ``empty array example in grammar`` () =
@@ -155,7 +155,7 @@ module Examples =
             let resolveDependencies = [true; false]
             resolveDependencies
             |> List.iter (fun x ->
-                            Restler.Workflow.generateRestlerGrammar None
+                            Restler.Workflow.generateRestlerGrammar
                                 { config with
                                     ResolveBodyDependencies = x
                                     ResolveQueryDependencies = x }
@@ -164,7 +164,7 @@ module Examples =
             // This is a special case, because empty arrays are represented without a leaf node
             let customDictionary = Some "{ \"restler_custom_payload\": { \"item_descriptions\": [\"zzz\"] }}"
 
-            Restler.Workflow.generateRestlerGrammar None
+            Restler.Workflow.generateRestlerGrammar
                 { config with
                     ResolveBodyDependencies = true
                     ResolveQueryDependencies = true
@@ -181,7 +181,7 @@ module Examples =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "headers.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "headers_dict.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -216,7 +216,7 @@ module Examples =
                                                                             "swagger", sprintf "example_demo1%s" extension))]
                                  CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                              }
-                Restler.Workflow.generateRestlerGrammar None config
+                Restler.Workflow.generateRestlerGrammar config
                 let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
                 let grammar = File.ReadAllText(grammarFilePath)
 
@@ -240,7 +240,7 @@ module Examples =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo1.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
 
             let grammar = File.ReadAllText(grammarFilePath)
@@ -267,7 +267,7 @@ module Examples =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo.json"))]
                              CustomDictionaryFilePath = Some (Path.Combine(Environment.CurrentDirectory, "swagger", "example_demo_dictionary.json"))
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
 
             let grammar = File.ReadAllText(grammarFilePath)
@@ -298,7 +298,7 @@ module Examples =
                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "subnet_id.json"))]
                             CustomDictionaryFilePath = None
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -327,7 +327,7 @@ module Examples =
                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "nested_objects_naming.json"))]
                             CustomDictionaryFilePath = None
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarOutputDirPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -398,7 +398,7 @@ module Examples =
                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "dependencyTests", "frontend_port_id.json"))]
                             CustomDictionaryFilePath = None
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -447,7 +447,7 @@ module Examples =
                             SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "DependencyTests", "ip_configurations_get.json"))]
                             CustomDictionaryFilePath = None
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -465,7 +465,7 @@ module Examples =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "inline_examples.json"))]
                              CustomDictionaryFilePath = None
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -499,13 +499,13 @@ module Examples =
             }
 
             let exactCopyTestConfig = { config with ExampleConfigFiles = Some [ exampleConfigFile ] }
-            Restler.Workflow.generateRestlerGrammar None exactCopyTestConfig
+            Restler.Workflow.generateRestlerGrammar exactCopyTestConfig
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammar = File.ReadAllText(grammarFilePath)
             Assert.True(grammar.Contains("primitives.restler_static_string(\"2020-02-02\")"))
 
             let testConfig = { config with ExampleConfigFiles = Some [ {exampleConfigFile with exactCopy = false }] }
-            Restler.Workflow.generateRestlerGrammar None testConfig
+            Restler.Workflow.generateRestlerGrammar testConfig
 
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammar = File.ReadAllText(grammarFilePath)
@@ -533,7 +533,7 @@ module Examples =
             }
 
             let testConfig = { config with ExampleConfigFiles = Some [ exampleConfigFile ] }
-            Restler.Workflow.generateRestlerGrammar None testConfig
+            Restler.Workflow.generateRestlerGrammar testConfig
 
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath, Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
             let grammar = File.ReadAllText(grammarFilePath)
@@ -562,7 +562,7 @@ module Examples =
             }
 
             let testConfig = { config with ExampleConfigFiles = Some [ exampleConfigFile ] }
-            Restler.Workflow.generateRestlerGrammar None testConfig
+            Restler.Workflow.generateRestlerGrammar testConfig
 
             let expectedGrammarFilePath = Path.Combine(Environment.CurrentDirectory,
                                                         "baselines", "exampleTests", "body_param_exactCopy_grammar.py")
@@ -582,7 +582,7 @@ module Examples =
                              SwaggerSpecFilePath = Some [(Path.Combine(Environment.CurrentDirectory, "swagger", "exampleTests", "example_int_openapi3.yml"))]
                              CustomDictionaryFilePath = None
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarFilePath = Path.Combine(ctx.testRootDirPath, "grammar.py")
             let grammar = File.ReadAllText(grammarFilePath)
 
@@ -620,7 +620,7 @@ module Examples =
         //                     CustomDictionaryFilePath = Some dictionaryFilePath
         //                 }
 
-        //    Restler.Workflow.generateRestlerGrammar None config
+        //    Restler.Workflow.generateRestlerGrammar config
 
         //    let grammarFilePath = Path.Combine(grammarOutputDirectoryPath,
         //                                       Restler.Workflow.Constants.DefaultRestlerGrammarFileName)

--- a/src/compiler/Restler.Compiler.Test/JsonGrammarTests.fs
+++ b/src/compiler/Restler.Compiler.Test/JsonGrammarTests.fs
@@ -28,7 +28,7 @@ module GrammarTests =
 
             // Confirm the baselines match for grammar.json and grammar.py
             for includeOptionalParameters in [true ; false] do
-                Restler.Workflow.generateRestlerGrammar None { config with IncludeOptionalParameters = includeOptionalParameters }
+                Restler.Workflow.generateRestlerGrammar { config with IncludeOptionalParameters = includeOptionalParameters }
 
                 for extension in [".json"; ".py"] do
                     let actualGrammarFileName =

--- a/src/compiler/Restler.Compiler.Test/RealWorldTests.fs
+++ b/src/compiler/Restler.Compiler.Test/RealWorldTests.fs
@@ -14,7 +14,7 @@ module RealWorldTests =
 
         [<Fact>]
         let ``demo_server grammar sanity test`` () =
-            Restler.Workflow.generateRestlerGrammar None
+            Restler.Workflow.generateRestlerGrammar
                 { configs.["demo_server"] with
                       GrammarOutputDirectoryPath = Some ctx.testRootDirPath }
             Assert.True(true)

--- a/src/compiler/Restler.Compiler.Test/ReferencesTests.fs
+++ b/src/compiler/Restler.Compiler.Test/ReferencesTests.fs
@@ -25,7 +25,7 @@ module References =
                              SwaggerSpecFilePath = Some [filePath]
                              CustomDictionaryFilePath = None
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let grammarFilePath = Path.Combine(grammarOutputDirectoryPath.Value, "grammar.py")
             let grammarText = File.ReadAllText(grammarFilePath)

--- a/src/compiler/Restler.Compiler.Test/SchemaTests.fs
+++ b/src/compiler/Restler.Compiler.Test/SchemaTests.fs
@@ -25,7 +25,7 @@ module ApiSpecSchema =
                              SwaggerSpecFilePath = Some [filePath]
                              CustomDictionaryFilePath = None
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarOutputFilePath =
                 config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
 
@@ -56,7 +56,7 @@ module ApiSpecSchema =
                              ExampleConfigFilePath = Some exampleConfigFilePath
                              UseHeaderExamples = Some true
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
 
             let grammarDiff =
                 getLineDifferences
@@ -82,7 +82,7 @@ module ApiSpecSchema =
                              ResolveQueryDependencies = true
                              SwaggerSpecFilePath = Some [specFilePath]
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
             let grammar = File.ReadAllText(grammarOutputFilePath)
             Assert.True(grammar.Contains("restler_custom_payload_uuid4_suffix(\"customerId\", quoted=False)"))
@@ -97,7 +97,7 @@ module ApiSpecSchema =
                              ResolveQueryDependencies = true
                              SwaggerSpecFilePath = Some [specFilePath]
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
             let grammar = File.ReadAllText(grammarOutputFilePath)
             Assert.True(grammar.Contains("\"escape\""))
@@ -115,7 +115,7 @@ module ApiSpecSchema =
                                 ResolveQueryDependencies = true
                                 SwaggerSpecFilePath = Some [specFilePath]
                             }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
             let grammar = File.ReadAllText(grammarOutputFilePath)
             Assert.True(grammar.Contains("\"treeId\":"))
@@ -134,7 +134,7 @@ module ApiSpecSchema =
                              SwaggerSpecFilePath = Some [specFilePath]
                          }
 
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
             let noDepthLimitGrammar = File.ReadAllText(grammarOutputFilePath)
 
@@ -143,7 +143,7 @@ module ApiSpecSchema =
             for depthLimit in lowerLimit..upperLimit do
                 let objectName = sprintf "object_level_%d" depthLimit
                 let nextObjectName = sprintf "object_level_%d" (depthLimit + 1)
-                Restler.Workflow.generateRestlerGrammar None { config with JsonPropertyMaxDepth = Some depthLimit }
+                Restler.Workflow.generateRestlerGrammar { config with JsonPropertyMaxDepth = Some depthLimit }
                 let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
                 let grammar = File.ReadAllText(grammarOutputFilePath)
                 if depthLimit < upperLimit then
@@ -163,7 +163,7 @@ module ApiSpecSchema =
                                 ResolveQueryDependencies = true
                                 SwaggerSpecFilePath = Some [specFilePath]
                          }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
             let grammar = File.ReadAllText(grammarOutputFilePath)
             let expectedProperties = ["supiRanges"; "groupId"; "start"; "end"]
@@ -180,7 +180,7 @@ module ApiSpecSchema =
                                 ResolveQueryDependencies = true
                                 SwaggerSpecFilePath = Some [specFilePath]
                             }
-            Restler.Workflow.generateRestlerGrammar None config
+            Restler.Workflow.generateRestlerGrammar config
             let grammarOutputFilePath = config.GrammarOutputDirectoryPath.Value ++ Restler.Workflow.Constants.DefaultRestlerGrammarFileName
             let grammar = File.ReadAllText(grammarOutputFilePath)
             

--- a/src/compiler/Restler.Compiler/Telemetry.fs
+++ b/src/compiler/Restler.Compiler/Telemetry.fs
@@ -29,7 +29,8 @@ type TelemetryClient(machineId: System.Guid, instrumentationKey: string,
 
     member __.RestlerFinished(version, task, executionId, status,
                               specCoverageCounts,
-                              bugBucketCounts) =
+                              bugBucketCounts, 
+                              featureList) =
         client.TrackEvent("restler finished",
             dict ([
                 "machineId", sprintf "%A" machineId
@@ -37,7 +38,7 @@ type TelemetryClient(machineId: System.Guid, instrumentationKey: string,
                 "task", task
                 "executionId", sprintf "%A" executionId
                 "status", sprintf "%A" status
-            ]@bugBucketCounts@specCoverageCounts))
+            ]@bugBucketCounts@specCoverageCounts@featureList))
 
     member __.ResultsAnalyzerFinished(version, task, executionId, status) =
         client.TrackEvent("results analyzer finished",

--- a/src/compiler/Restler.Compiler/Utilities.fs
+++ b/src/compiler/Restler.Compiler/Utilities.fs
@@ -151,3 +151,33 @@ module Stream =
         fs.Flush()
         fs.Dispose()
 
+module String = 
+    open System.Text
+    open System.Security.Cryptography
+
+    /// Provide a deterministic hash from a string, because
+    /// F# Operator.hash / C# GetHashCode() are NOT deterministic between runs.
+    /// 32 hex digits = 16 bytes = 128 bits => 2^64 elements before collision with 50% probability.
+    let deterministicShortHash (str:string): string =
+        let hashLength = 16 // bytes
+
+        use sha1 = SHA1.Create()
+        let bytes = Encoding.Default.GetBytes(str)
+        let hashBytes = sha1.ComputeHash(bytes)
+        hashBytes
+        |> Seq.take hashLength
+        |> Seq.map (fun b -> b.ToString("x2"))
+        |> String.concat ""
+
+    /// Provide a deterministic hash from a string, because
+    /// F# Operator.hash / C# GetHashCode() are NOT deterministic between runs.
+    /// 32 hex digits = 16 bytes = 128 bits => 2^64 elements before collision with 50% probability.
+    let deterministicShortStreamHash (s:System.IO.Stream): string =
+        let hashLength = 16 // bytes
+
+        use sha1 = SHA1.Create()
+        let hashBytes = sha1.ComputeHash(s)
+        hashBytes
+        |> Seq.take hashLength
+        |> Seq.map (fun b -> b.ToString("x2"))
+        |> String.concat ""

--- a/src/compiler/Restler.CompilerExe/Program.fs
+++ b/src/compiler/Restler.CompilerExe/Program.fs
@@ -40,5 +40,5 @@ let main argv =
             exit 1
 
 
-    Restler.Workflow.generateRestlerGrammar None config
+    Restler.Workflow.generateRestlerGrammar config
     0


### PR DESCRIPTION
This allows aggregating existing telemetry for a particular OpenAPI file