### PR TITLE
Add custom payload header and query to default dictionary

### DIFF
--- a/src/compiler/Restler.Compiler/Dictionary.fs
+++ b/src/compiler/Restler.Compiler/Dictionary.fs
@@ -210,9 +210,9 @@ let DefaultMutationsDictionary =
         restler_custom_payload = Some (Map.empty<string, string list>)
         restler_custom_payload_unquoted = Some (Map.empty<string, string list>)
         restler_custom_payload_uuid4_suffix = Some (Map.empty<string, string>)
-        restler_custom_payload_header = None
+        restler_custom_payload_header = Some (Map.empty<string, string list>)
         restler_custom_payload_header_unquoted = None
-        restler_custom_payload_query = None
+        restler_custom_payload_query = Some (Map.empty<string, string list>)
         shadow_values = None
     } 
 


### PR DESCRIPTION
Per customer feedback, these two options are not easily discoverable.

This change adds them to the default generated dictionary when compiling an OpenAPI spec directly.

Closes #742

Testing:
- Manual testing:
> restler compile --specs ./swagger.json