### PR TITLE
Support parameters embedded in path parts

### DIFF
--- a/src/compiler/Restler.Compiler.Test/JsonGrammarTests.fs
+++ b/src/compiler/Restler.Compiler.Test/JsonGrammarTests.fs
@@ -41,7 +41,8 @@ module GrammarTests =
                     let actualGrammarFilePath = Path.Combine(grammarOutputDirectoryPath,
                                                              actualGrammarFileName + extension)
                     let grammarDiff = getLineDifferences expectedGrammarFilePath actualGrammarFilePath
-                    let message = sprintf "Python grammar Does not match baseline.  First difference: %A" grammarDiff
+                    let grammarName = if extension = ".json" then "Json" else "Python"
+                    let message = sprintf "%s grammar Does not match baseline.  First difference: %A" grammarName grammarDiff
                     Assert.True(grammarDiff.IsNone, message)
 
 

--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -46,7 +46,13 @@
     <Content Include="baselines\schemaTests\xMsPaths_grammar.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="baselines\grammarTests\required_params_grammar.json">
+	  <Content Include="baselines\schemaTests\path_param_substrings_grammar.py">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="baselines\schemaTests\path_param_substrings_grammar.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="baselines\grammarTests\required_params_grammar.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="baselines\grammarTests\required_params_grammar.py">
@@ -211,7 +217,9 @@
 	  <Content Include="swagger\schemaTests\openapi3_examples.json">
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
-
+	  <Content Include="swagger\schemaTests\path_param_substrings.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
     <Content Include="swagger\schemaTests\xMsPaths_annotations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/grammarTests/required_params_grammar.json
@@ -11,6 +11,12 @@
         {
           "Constant": [
             "String",
+            "/"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
             "customers"
           ]
         }
@@ -128,6 +134,12 @@
       "method": "Post",
       "basePath": "/api",
       "path": [
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
         {
           "Constant": [
             "String",

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/path_param_substrings_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/path_param_substrings_grammar.json
@@ -1,0 +1,472 @@
+{
+  "Requests": [
+    {
+      "id": {
+        "endpoint": "/vm:stop{id}",
+        "method": "Post"
+      },
+      "method": "Post",
+      "basePath": "",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "vm:stop"
+          ]
+        },
+        {
+          "Fuzzable": {
+            "primitiveType": "Int",
+            "defaultValue": "1",
+            "exampleValue": "1234"
+          }
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/vm/{param}:cancel",
+        "method": "Post"
+      },
+      "method": "Post",
+      "basePath": "",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "vm"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Fuzzable": {
+            "primitiveType": "Int",
+            "defaultValue": "1",
+            "exampleValue": "1234"
+          }
+        },
+        {
+          "Constant": [
+            "String",
+            ":cancel"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/vm:delete({vmName})/activate",
+        "method": "Post"
+      },
+      "method": "Post",
+      "basePath": "",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "vm:delete("
+          ]
+        },
+        {
+          "Fuzzable": {
+            "primitiveType": "Int",
+            "defaultValue": "1",
+            "exampleValue": "1234"
+          }
+        },
+        {
+          "Constant": [
+            "String",
+            ")"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "activate"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/vm/hello{vmId}/start/{startId}goodbye",
+        "method": "Post"
+      },
+      "method": "Post",
+      "basePath": "",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "vm"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "hello"
+          ]
+        },
+        {
+          "Fuzzable": {
+            "primitiveType": "Int",
+            "defaultValue": "1",
+            "exampleValue": "1234"
+          }
+        },
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "start"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Fuzzable": {
+            "primitiveType": "String",
+            "defaultValue": "fuzzstring",
+            "exampleValue": "ABCDEF"
+          }
+        },
+        {
+          "Constant": [
+            "String",
+            "goodbye"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    },
+    {
+      "id": {
+        "endpoint": "/vm{vmId}:cancel{startId}/pause",
+        "method": "Post"
+      },
+      "method": "Post",
+      "basePath": "",
+      "path": [
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "vm"
+          ]
+        },
+        {
+          "Fuzzable": {
+            "primitiveType": "Int",
+            "defaultValue": "1",
+            "exampleValue": "1234"
+          }
+        },
+        {
+          "Constant": [
+            "String",
+            ":cancel"
+          ]
+        },
+        {
+          "Fuzzable": {
+            "primitiveType": "String",
+            "defaultValue": "fuzzstring",
+            "exampleValue": "ABCDEF"
+          }
+        },
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
+          "Constant": [
+            "String",
+            "pause"
+          ]
+        }
+      ],
+      "queryParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "bodyParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "headerParameters": [
+        [
+          "Schema",
+          {
+            "ParameterList": []
+          }
+        ],
+        [
+          "DictionaryCustomPayload",
+          {
+            "ParameterList": []
+          }
+        ]
+      ],
+      "token": "Refreshable",
+      "headers": [
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "Host",
+          ""
+        ]
+      ],
+      "httpVersion": "1.1",
+      "requestMetadata": {
+        "isLongRunningOperation": false
+      }
+    }
+  ]
+}

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/path_param_substrings_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/path_param_substrings_grammar.py
@@ -1,0 +1,113 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+req_collection = requests.RequestCollection([])
+# Endpoint: /vm:stop{id}, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("vm:stop"),
+    primitives.restler_fuzzable_int("1", examples=["1234"]),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/vm:stop{id}"
+)
+req_collection.add_request(request)
+
+# Endpoint: /vm/{param}:cancel, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("vm"),
+    primitives.restler_static_string("/"),
+    primitives.restler_fuzzable_int("1", examples=["1234"]),
+    primitives.restler_static_string(":cancel"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/vm/{param}:cancel"
+)
+req_collection.add_request(request)
+
+# Endpoint: /vm:delete({vmName})/activate, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("vm:delete("),
+    primitives.restler_fuzzable_int("1", examples=["1234"]),
+    primitives.restler_static_string(")"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("activate"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/vm:delete({vmName})/activate"
+)
+req_collection.add_request(request)
+
+# Endpoint: /vm/hello{vmId}/start/{startId}goodbye, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("vm"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("hello"),
+    primitives.restler_fuzzable_int("1", examples=["1234"]),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("start"),
+    primitives.restler_static_string("/"),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False, examples=["ABCDEF"]),
+    primitives.restler_static_string("goodbye"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/vm/hello{vmId}/start/{startId}goodbye"
+)
+req_collection.add_request(request)
+
+# Endpoint: /vm{vmId}:cancel{startId}/pause, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath(""),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("vm"),
+    primitives.restler_fuzzable_int("1", examples=["1234"]),
+    primitives.restler_static_string(":cancel"),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False, examples=["ABCDEF"]),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("pause"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: \r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/vm{vmId}:cancel{startId}/pause"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
+++ b/src/compiler/Restler.Compiler.Test/baselines/schemaTests/xMsPaths_grammar.json
@@ -116,6 +116,12 @@
       "basePath": "",
       "path": [
         {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
           "Custom": {
             "payloadType": "UuidSuffix",
             "primitiveType": "String",
@@ -317,6 +323,12 @@
       "basePath": "",
       "path": [
         {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
           "Custom": {
             "payloadType": "UuidSuffix",
             "primitiveType": "String",
@@ -477,6 +489,12 @@
       "basePath": "",
       "path": [
         {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
           "DynamicObject": {
             "primitiveType": "String",
             "variableName": "__resourceName__type_file_put_resourceName_path",
@@ -610,11 +628,23 @@
       "basePath": "",
       "path": [
         {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
           "DynamicObject": {
             "primitiveType": "String",
             "variableName": "__resourceName__type_file_put_resourceName_path",
             "isWriter": false
           }
+        },
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
         },
         {
           "Fuzzable": {
@@ -704,11 +734,23 @@
       "basePath": "",
       "path": [
         {
+          "Constant": [
+            "String",
+            "/"
+          ]
+        },
+        {
           "DynamicObject": {
             "primitiveType": "String",
             "variableName": "__resourceName__type_file_put_resourceName_path",
             "isWriter": false
           }
+        },
+        {
+          "Constant": [
+            "String",
+            "/"
+          ]
         },
         {
           "Fuzzable": {

--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/path_param_substrings.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/path_param_substrings.json
@@ -1,0 +1,136 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Simple OpenAPI spec with paths that have embedded parameters in each part of the path",
+    "version": "1"
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "paths": {
+    "/vm:stop{id}": {
+      "post": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1234
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/vm/{param}:cancel": {
+      "post": {
+        "parameters": [
+          {
+            "name": "param",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1234
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/vm:delete({vmName})/activate": {
+      "post": {
+        "parameters": [
+          {
+            "name": "vmName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1234
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/vm/hello{vmId}/start/{startId}goodbye": {
+      "post": {
+        "parameters": [
+          {
+            "name": "vmId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1234
+          },
+          {
+            "name": "startId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "ABCDEF"
+          }
+
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/vm{vmId}:cancel{startId}/pause": {
+      "post": {
+        "parameters": [
+          {
+            "name": "vmId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1234
+          },
+          {
+            "name": "startId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "ABCDEF"
+          }
+
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+
+  },
+  "components": {}
+}

--- a/src/compiler/Restler.Compiler/CodeGenerator.fs
+++ b/src/compiler/Restler.Compiler/CodeGenerator.fs
@@ -463,17 +463,8 @@ let generatePythonFromRequestElement includeOptionalParameters (requestId:Reques
             | None -> parts.Length
             | Some _ -> parts |> List.findIndex(fun x -> x = Constant (PrimitiveType.String, "?"))
         let x = parts
-                |> List.mapi(fun idx p ->
-                                idx, getRestlerPythonPayload p false (*isQuoted*))
-                |> (fun xs ->
-                    [
-                        for (idx,primitive) in xs do
-                            if idx < queryStartIndex then
-                                // Only add path delimiters in the path part
-                                yield Restler_static_string_constant "/"
-                            yield! primitive
-                    ]
-                )
+                |> List.map(fun p -> getRestlerPythonPayload p false (*isQuoted*))
+                |> List.concat
         // Handle the case of '/'
         if x |> List.isEmpty || queryStartIndex = 0 then
             [ Restler_static_string_constant "/" ] @ x

--- a/src/compiler/Restler.Compiler/Dependencies.fs
+++ b/src/compiler/Restler.Compiler/Dependencies.fs
@@ -924,6 +924,7 @@ let getParameterDependencies parameterKind globalAnnotations
                           |> Seq.collect (fun (requestId, requestData) ->
                               requestData.linkAnnotations
                           )
+    let path = Paths.getPathFromString requestId.endpoint false (*includeSeparators*)
     let getConsumer (resourceName:string) (resourceAccessPath:string list) (primitiveType:PrimitiveType option) =
         if String.IsNullOrEmpty resourceName then
             failwith "[getConsumer] invalid usage"
@@ -934,11 +935,7 @@ let getParameterDependencies parameterKind globalAnnotations
                 HeaderResource resourceName
             | ParameterKind.Path ->
 
-                let pathToParameter =
-                    let x = requestId.endpoint.Split("/", StringSplitOptions.RemoveEmptyEntries)
-                    let pathParamIndex =
-                        x |> Array.findIndex (fun x -> x = sprintf "{%s}" parameterName)
-                    x |> Array.take (pathParamIndex)
+                let pathToParameter = path.getPathPartsBeforeParameter parameterName |> List.toArray
                 PathResource { name = resourceName ;
                                PathParameterReference.responsePath = { path = Array.empty }
                                PathParameterReference.pathToParameter = pathToParameter }


### PR DESCRIPTION
Previously, RESTler only supported path parameters where the parameter fills the entire path part.

However, OpenAPI specs allow parameters to only take up part of the path, for example,  ```/vm({id})/deployment{id}{operation}cancel```

This change supports such patterns in the compiler.

Closes #705
Also partially fixes #141

Testing:
- added new compiler test
- there is no impact to the engine, because the Path part of the grammar.json is not used in the engine, and the invalid dynamic object checker explicitly searches for dynamic object delimiters