### PR TITLE
Enable setting equality constraints on uuid4 suffix payloads

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -94,7 +94,13 @@
     <Content Include="swagger\dependencyTests\post_patch_dependency.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="swagger\dependencyTests\input_producer_spec.json">
+	  <Content Include="swagger\dependencyTests\same_body_dep.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\dependencyTests\same_body_dep_annotations.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\dependencyTests\input_producer_spec.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\dependencyTests\input_producer_dict.json">

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/same_body_dep.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/same_body_dep.json
@@ -1,0 +1,92 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "host": "localhost:8888",
+  "info": {
+    "description": "Small example for PUT with input producer in path and equal property in the body",
+    "title": "Input producer test case",
+    "version": "1.0.0"
+  },
+  "definitions": {
+    "fileId":{
+        "type": "String",
+        "description":  "the file id"
+    },
+    "Archive": {
+      "properties": {
+        "tags": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        }
+      }
+    }
+  },
+  "paths": {
+    "/archive/{archiveId}/{label}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "archiveId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "in": "path",
+            "name": "label",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/archive/{archiveId}": {
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "archiveId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "archiveName",
+            "required": true,
+            "type": "string"
+          },
+
+          {
+            "in": "body",
+            "name": "bodyParam",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Archive"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Archive"
+            }
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/same_body_dep_annotations.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dependencyTests/same_body_dep_annotations.json
@@ -1,0 +1,20 @@
+{
+  "x-restler-global-annotations": [
+    {
+      "producer_endpoint": "/archive/{archiveId}",
+      "producer_method": "PUT",
+      "consumer_endpoint": "/archive/{archiveId}",
+      "consumer_method": "PUT",
+      "producer_resource_name": "archiveId",
+      "consumer_param": "/id"
+    },
+    {
+      "producer_endpoint": "/archive/{archiveId}",
+      "producer_method": "PUT",
+      "consumer_endpoint": "/archive/{archiveId}",
+      "consumer_method": "PUT",
+      "producer_resource_name": "archiveName",
+      "consumer_param": "/name"
+    }
+  ]
+}


### PR DESCRIPTION
Some request types have payloads with a unique value generated via ```uuid4_suffix``` (e.g. a PUT request that must create a new ID every time), and require the same value to be passed in multiple places in the payload. RESTler did not previously have a way to specify the equality constraints on such payload parameters or properties.

This change enables another property to be assigned the same value as the uuid4 suffix via an annotation, for example:

```
    {
      "producer_endpoint": "/archive/{archiveId}",
      "producer_method": "PUT",
      "consumer_endpoint": "/archive/{archiveId}",
      "consumer_method": "PUT",
      "producer_resource_name": "archiveId",
      "consumer_param": "/id"
    }
```

Testing:
- added new unit test

Partially implements #89