### PR TITLE
Fix python grammar error when the request path has a colon

### DIFF
--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -454,7 +454,7 @@ type GrammarDefinition =
     }
 
 module DynamicObjectNaming =
-    let ReplaceTargets = [|"/"; "."; "__"; "{"; "}"; "$"; "-" |]
+    let ReplaceTargets = [|"/"; "."; "__"; "{"; "}"; "$"; "-"; ":" |]
 
     /// Returns the string with all characters that are invalid in
     /// a Python function replaced with 'delimiter'


### PR DESCRIPTION
The colon needs to be filtered in order to generate valid python identifiers.