### PR TITLE
Update RESTler version to 9.2.1

### DIFF
--- a/ci_build_pipelines/variables/version-variables.yml
+++ b/ci_build_pipelines/variables/version-variables.yml
@@ -4,7 +4,7 @@ variables:
   - name: version.minor
     value: 2
   - name: devRevision
-    value: 0
+    value: 1
   - name: buildPlatform
     value: 'Any CPU'
   - name: buildConfiguration

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -14,7 +14,7 @@ open Microsoft.FSharpLu.Diagnostics.Process
 open Restler.Telemetry
 
 [<Literal>]
-let CurrentVersion = "9.2.0"
+let CurrentVersion = "9.2.1"
 let EngineErrorCode = -2
 
 let exitRestler status =
@@ -524,7 +524,7 @@ module Config =
         // in the list
         let configParameters = parseGenerateConfigParameters
                                     { specFilesOrDirs = []
-                                      outputDir = None 
+                                      outputDir = None
                                       relativePath = None }
                                     generateConfigParameters
         let configDirPath = configParameters.outputDir.Value
@@ -933,7 +933,7 @@ let main argv =
                     let! result = Compile.invokeCompiler taskWorkingDirectory compilerConfigPath compilerOutputDirPath
                     let grammarFileStatistics =
                         match result with
-                        | 0 -> 
+                        | 0 ->
                             Fuzz.getGrammarFileStatistics (compilerOutputDirPath ++
                                                            Restler.Workflow.Constants.DefaultRestlerGrammarFileName)
                         | _ -> []


### PR DESCRIPTION
Changes in this version:

- support path parameters embedded in
- support equality constraint for uuid4_suffixes in the same request payload
- allow specifying a custom User-Agent
- minor improvements / bug fixes