### PR TITLE
Remove debug output containing token data from invalid value checker

### DIFF
--- a/restler/checkers/invalid_value_checker.py
+++ b/restler/checkers/invalid_value_checker.py
@@ -308,7 +308,6 @@ class InvalidValueChecker(CheckerBase):
                     if not isinstance(fuzzed_value, str):
                         print("not a string!")
                     rendered_data = "".join(rendered_values)
-                    self._checker_log.checker_print(f"+++payload: {rendered_data}.+++")
 
                     # Check time budget
                     if Monitor().remaining_time_budget <= 0:


### PR DESCRIPTION
The checker was logging tokens to its checker log.  This change removes the statement that logged the payload separately in this checker log, which is not necessary.  The payloads are already logged to the network log, which can be used for debugging the sent requests.
