### PR TITLE
Fix crash when configuring test all combinations

### DIFF
--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -789,21 +789,21 @@ class Request(object):
 
         tested_example_payloads = False
         if Settings().example_payloads is not None:
-            tested_example_payloads = True
             for ex in get_all_example_schemas():
+                tested_example_payloads = True
                 yield ex, True
 
         tested_param_combinations = False
         header_param_combinations = Settings().header_param_combinations
         if header_param_combinations is not None:
-            tested_param_combinations = True
             for hpc in self.get_header_param_combinations(header_param_combinations):
+                tested_param_combinations = True
                 yield hpc, False
 
         query_param_combinations = Settings().query_param_combinations
         if query_param_combinations is not None:
-            tested_param_combinations = True
             for hpc in self.get_query_param_combinations(query_param_combinations):
+                tested_param_combinations = True
                 yield hpc, False
 
         if not (tested_param_combinations or tested_example_payloads):


### PR DESCRIPTION
When one of the requests (e.g. DELETE) does not have an example payload, and testing all example payloads is configured in the engine settings, RESTler crashes [1].

The fix is to only mark combinations tested after at least one combination was found.

Exception in thread Garbage Collector:
Traceback (most recent call last):
  File "C:\Users\marinapo\AppData\Local\Programs\Python\Python39\lib\threading.py", line 980, in _bootstrap_inner
    self.run()
  File "D:\restlerdrop\main\engine\engine\dependencies.py", line 627, in run
    self._garbage_collector.run()
  File "D:\restlerdrop\main\engine\engine\dependencies.py", line 339, in run
    self.do_garbage_collection()
  File "D:\restlerdrop\main\engine\engine\dependencies.py", line 429, in do_garbage_collection
    self.apply_destructors(destructors)
  File "D:\restlerdrop\main\engine\engine\dependencies.py", line 562, in apply_destructors
    deleted_list = process_overflowing()
  File "D:\restlerdrop\main\engine\engine\dependencies.py", line 514, in process_overflowing
    rendered_data, _ , _, _ = destructor.\
  File "D:\restlerdrop\main\engine\engine\core\requests.py", line 1276, in render_current
    return next(self.render_iter(candidate_values_pool,

Testing: manual testing