### PR TITLE
Enable consistently setting the random seed

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -501,6 +501,16 @@ For instance, any custom payloads
 or fuzzable values for this endpoint will be taken from the specified custom dictionary
 instead of the default dictionary.
 
+### random_seed: int (default 12345)
+The random seed to use for the RESTler invocation.  The same random seed will
+always be used if none is specified and `generate_random_seed` is `False`.  Checkers may have a separate `random_seed` setting that overrides this setting.
+
+### generate_random_seed: bool (default False)
+When `True`, generate a new random seed instead of using the default or user-specified
+`random_seed`.  This setting also overrides any `random_seed` checker settings.
+The random seed that was used for the run is logged in main.txt as well as in the
+testing summary.
+
 ### custom_value_generators: string (default None)
 If this setting is set to a valid path with a ```.py``` extension,
 RESTler will try to import the contents of this

--- a/restler/checkers/body_schema_fuzzer.py
+++ b/restler/checkers/body_schema_fuzzer.py
@@ -8,9 +8,10 @@ import itertools
 import json
 import random
 
+from restler_settings import Settings
+
 from engine.fuzzing_parameters.fuzzing_utils import *
 from engine.fuzzing_parameters.request_params import *
-
 from engine.fuzzing_parameters.param_combinations import JsonBodySchemaFuzzerBase
 
 class BodySchemaStructuralFuzzer(JsonBodySchemaFuzzerBase):
@@ -65,6 +66,8 @@ class BodySchemaStructuralFuzzer(JsonBodySchemaFuzzerBase):
             self._shuffle_combination = config['shuffle_combination']
         if 'random_seed' in config:
             self._random_seed = config['random_seed']
+        else:
+            self._random_seed = Settings().random_seed
 
         # overwrite fuzzer-specific configuration
         self._set_fuzzer_config()

--- a/restler/checkers/invalid_value_checker.py
+++ b/restler/checkers/invalid_value_checker.py
@@ -178,6 +178,8 @@ class InvalidValueChecker(CheckerBase):
             self._value_generators_file_path = default_value_generators_file_path
 
         self._override_random_seed = Settings().get_checker_arg(self._friendly_name, 'random_seed')
+        if self._override_random_seed is None:
+            self._override_random_seed = Settings().random_seed
 
     def apply(self, rendered_sequence, lock):
         """ Fuzzes each value in the parameters of this request as specified by

--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -5,8 +5,6 @@
 from __future__ import print_function
 import time
 import types
-import random
-random.seed(12345)
 import itertools
 import functools, operator
 import collections
@@ -14,6 +12,8 @@ import datetime
 import copy
 
 from restler_settings import Settings
+from random import Random
+
 import engine.core.request_utilities as request_utilities
 from engine.core.request_utilities import str_to_hex_def
 from engine.fuzzing_parameters.request_examples import RequestExamples
@@ -304,6 +304,8 @@ class Request(object):
         self._rendered_values_cache = RenderedValuesCache()
         self._last_rendered_schema_request = None
         self._is_resource_generator = None
+
+        self._random = Random(Settings().random_seed)
 
         # Check for empty request before assigning ids
         if self._definition:
@@ -1007,7 +1009,7 @@ class Request(object):
                     values = [(values, quoted, writer_variable)]
 
             if Settings().fuzzing_mode == 'random-walk' and not preprocessing:
-                random.shuffle(values)
+                self._random.shuffle(values)
 
             if len(values) == 0:
                 _raise_dict_err(primitive_type, "empty value list")

--- a/restler/restler.py
+++ b/restler/restler.py
@@ -442,6 +442,10 @@ if __name__ == '__main__':
         }
         )
 
+    # Write the random seed to main in case the run exits in the middle and needs to be
+    # restarted with the same seed
+    logger.write_to_main(f"Random seed: {Settings().random_seed}")
+
     # Initialize the fuzzing monitor
     monitor = fuzzing_monitor.FuzzingMonitor()
 

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -8,6 +8,7 @@ import os
 import json
 import sys
 import re
+import time
 
 class TokenAuthMethod(Enum):
     """ Enum of token auth methods """
@@ -508,6 +509,14 @@ class RestlerSettings(object):
         ## If set, poll for async resource creation before continuing
         self._wait_for_async_resource_creation = SettingsArg('wait_for_async_resource_creation', bool, True, user_args)
 
+        ## The random seed to use (may be overridden by checker-specific random seeds)
+        self._random_seed = SettingsArg('random_seed', int, 12345, user_args, minval=0)
+        ## Generate a new random seed instead of using the one specified
+        ## When specified, the seed will be used for all of the checkers as well.
+        self._generate_random_seed = SettingsArg('generate_random_seed', bool, False, user_args)
+        if self._generate_random_seed.val:
+            self._random_seed.val = time.time()
+
         self._connection_settings = ConnectionSettings(self._target_ip.val,
                                                        self._target_port.val,
                                                        not self._no_ssl.val,
@@ -666,6 +675,14 @@ class RestlerSettings(object):
     @property
     def max_sequence_length(self):
         return self._max_sequence_length.val
+
+    @property
+    def random_seed(self):
+        return self._random_seed.val
+
+    @property
+    def generate_random_seed(self):
+        return self._generate_random_seed.val
 
     @property
     def no_tokens_in_logs(self):

--- a/restler/utils/logger.py
+++ b/restler/utils/logger.py
@@ -1027,7 +1027,9 @@ def print_generation_stats(req_collection, fuzzing_monitor, global_lock, final=F
         testing_summary['total_requests_sent'] = total_requests_sent
         testing_summary['bug_buckets'] = bug_buckets
         testing_summary['reproducible_bug_buckets'] = BugBuckets.Instance().repro_bug_buckets()
-
+        settings_summary = OrderedDict()
+        settings_summary['random_seed'] = Settings().random_seed
+        testing_summary['settings'] = settings_summary
         with open(os.path.join(LOGS_DIR, "testing_summary.json"), "w+", encoding='utf-8') as summary_json:
             json.dump(testing_summary, summary_json, indent=4)
 

--- a/src/driver/Types.fs
+++ b/src/driver/Types.fs
@@ -182,6 +182,7 @@ module Engine =
             total_requests_sent : Dictionary<string, int>
             bug_buckets : Dictionary<string, int>
             reproducible_bug_buckets : Dictionary<string, int>
+            settings : Dictionary<string, obj>
         }
 
 /// Helper module to produce compact messages in the console, but more


### PR DESCRIPTION
This change adds two new settings, as specified in #780.

- A specific `random_seed` may now be set in the engine settings, which will be used everywhere random values are generated, except where a different random_seed is specified to checkers through the checker settings.

- An option to generate a new random seed `generate_random_seed`, which is helpful for CI/CD cases that run in `random-walk` mode and would like to get different sequences exercised on every run

Testing:
- adding new test