### PR TITLE
Enable wildcard '*' for include_requests and exclude_requests

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -293,6 +293,9 @@ such requests from fuzzing, but currently they will be fuzzed as well.
   "include_requests": [
     {
       "endpoint": "/api/blog/posts/{postId}",
+    },
+    {
+      "endpoint": "/api/blog/posts/*",
     }
   ]
 ```

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -814,6 +814,9 @@ class RestlerSettings(object):
             for req in req_list:
                 if endpoint == req["endpoint"]:
                     return "methods" not in req or method in req["methods"]
+                elif req["endpoint"].endswith('*'):
+                    if endpoint.startswith(req["endpoint"][:-1]):
+                        return "methods" not in req or method in req["methods"]
             return False
 
         def exclude_req():


### PR DESCRIPTION
The endpoints may now use the format:

'/blog/posts/*'

Testing:
- manual testing with demo_server