### PR TITLE
optionally use garbage collector

### DIFF
--- a/restler/restler.py
+++ b/restler/restler.py
@@ -535,9 +535,10 @@ if __name__ == '__main__':
 
     # Set up garbage collection
     gc_thread = None
-    garbage_collector = dependencies.GarbageCollector(req_collection, monitor)
+    garbage_collector = None
 
     if args.garbage_collection_interval or Settings().run_gc_after_every_sequence:
+        garbage_collector = dependencies.GarbageCollector(req_collection, monitor)
         gc_message = "after every test sequence. " \
                         if Settings().run_gc_after_every_sequence else f"every {settings.garbage_collection_interval} seconds."
         print(f"{formatting.timestamp()}: Initializing: Garbage collection {gc_message}")


### PR DESCRIPTION
 Use the existing run_gc_after_every_sequence setting to skip creation of the GarbageCollector class.

The constructor for this class calls multiprocessing.Lock() which requires the /dev/shm device file. If you want to run restler on a machine which doesn't have this device file you should be able to disable the garbage collector. in v9.0.0 this was possible by setting garbage_collection_interval to 0 but v9.0.1 was changed to always run the GarbageCollector constructor, which then calls multiprocessing.Lock() and crashes the program if /dev/shm does not exist.