### PR TITLE
Fix Dockerfile

### DIFF
--- a/demo_server/Dockerfile
+++ b/demo_server/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-alpine
 RUN apk add --no-cache build-base
 
 COPY demo_server/  /app/demo_server
-COPY requirements.txt logging.conf swagger.json /app/
+COPY requirements.txt swagger.json /app/
 
 WORKDIR /app
 


### PR DESCRIPTION
* The logging.conf file is not there by default

Hi, just found this problem in the demo server, removing the logging.conf file from the demo server Dockerfile so it builds 