### PR TITLE
Enable generating unique sequence IDs.

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -190,6 +190,10 @@ Example: `/api/v2`
 ### include_user_agent: bool (default True)
 Set to false to disable sending user agent with requests.
 
+### include_unique_sequence_id: bool (default True)
+When set, adds a header `x-restler-sequence-id` to each request sent.  The header value is
+a unique GUID that identifies the current request sequence.
+
 ### user_agent: string (default None)
 Set to send a custom user agent with requests.
 When specified, overrides the default user agent sent when ```include_user_agent``` is enabled.

--- a/restler/checkers/checker_base.py
+++ b/restler/checkers/checker_base.py
@@ -19,7 +19,7 @@ from engine.core.fuzzing_monitor import Monitor
 import engine.dependencies as dependencies
 
 from utils.logger import raw_network_logging as RAW_LOGGING
-from utils.logging.trace_db import DB as TraceDatabase
+from utils.logging.trace_db import SequenceTracker
 threadLocal = threading.local()
 
 class CheckerBase:
@@ -124,10 +124,9 @@ class CheckerBase:
 
         # We need to record that the request originates from the checker, but
         # there is not a clear sequence origin.
-        if Settings().use_trace_database:
-            TraceDatabase().initialize_sequence_trace(combination_id=seq.combination_id,
-                                                tags={'hex_definition': seq.hex_definition})
-            TraceDatabase().initialize_request_trace(combination_id=seq.combination_id,
+        SequenceTracker.initialize_sequence_trace(combination_id=seq.combination_id,
+                                            tags={'hex_definition': seq.hex_definition})
+        SequenceTracker.initialize_request_trace(combination_id=seq.combination_id,
                                             request_id=request.hex_definition)
 
         response = self._send_request(parser, rendered_data)
@@ -143,8 +142,7 @@ class CheckerBase:
                 rendered_data, response, async_wait)
         request_utilities.call_response_parser(parser, None, responses=responses_to_parse)
         seq.append_data_to_sent_list(rendered_data, parser, response, producer_timing_delay=0, max_async_wait_time=async_wait)
-        if Settings().use_trace_database:
-            TraceDatabase().clear_sequence_trace()
+        SequenceTracker.clear_sequence_trace()
         return response, response_to_parse
 
     def _rule_violation(self, seq, response, valid_response_is_violation=True):

--- a/restler/engine/core/driver.py
+++ b/restler/engine/core/driver.py
@@ -18,7 +18,7 @@ from random import Random
 
 from restler_settings import Settings
 import utils.logger as logger
-from utils.logging.trace_db import DB as TraceDatabase
+from utils.logging.trace_db import SequenceTracker
 import utils.saver as saver
 import utils.formatting as formatting
 import engine.dependencies as dependencies
@@ -149,18 +149,15 @@ def apply_checkers(checkers, renderings, global_lock):
         try:
             if checker.enabled:
                 RAW_LOGGING(f"Checker: {checker.__class__.__name__} kicks in\n")
-                if Settings().use_trace_database:
-
-                    TraceDatabase().set_origin(checker.__class__.__name__)
+                SequenceTracker.set_origin(checker.__class__.__name__)
                 checker.apply(renderings, global_lock)
                 RAW_LOGGING(f"Checker: {checker.__class__.__name__} kicks out\n")
         except Exception as error:
             print(f"Exception {error!s} applying checker {checker}")
             raise
         finally:
-            if Settings().use_trace_database:
-                TraceDatabase().clear_origin()
-                TraceDatabase().clear_sequence_trace()
+            SequenceTracker.clear_origin()
+            SequenceTracker.clear_sequence_trace()
 
 
 def render_one(seq_to_render, ith, checkers, generation, global_lock, garbage_collector):
@@ -580,8 +577,7 @@ def generate_sequences(fuzzing_requests, checkers, fuzzing_jobs=1, garbage_colle
         return
 
     logger.create_network_log(logger.LOG_TYPE_TESTING)
-    if Settings().use_trace_database:
-        TraceDatabase().set_origin('main_driver')
+    SequenceTracker.set_origin('main_driver')
 
     fuzzing_mode = Settings().fuzzing_mode
     max_len = Settings().max_sequence_length
@@ -773,8 +769,7 @@ def generate_sequences(fuzzing_requests, checkers, fuzzing_jobs=1, garbage_colle
         fuzzing_pool.close()
         fuzzing_pool.join()
 
-    if Settings().use_trace_database:
-        TraceDatabase().clear_origin()
+    SequenceTracker.clear_origin()
     return num_total_sequences
 
 def get_host_and_port(hostname):

--- a/restler/engine/core/postprocessing.py
+++ b/restler/engine/core/postprocessing.py
@@ -9,7 +9,7 @@ import engine.core.status_codes_monitor as status_codes_monitor
 from engine.core.requests import GrammarRequestCollection
 from restler_settings import Settings
 import utils.logger as logger
-from utils.logging.trace_db import DB as TraceDatabase
+from utils.logging.trace_db import SequenceTracker
 import utils.formatting as formatting
 from engine.errors import TransportLayerException
 from engine.transport_layer import messaging as messaging
@@ -33,8 +33,7 @@ def delete_create_once_resources(destructors, fuzzing_requests):
     candidate_values_pool = GrammarRequestCollection().candidate_values_pool
 
     logger.write_to_main("\nRendering for create-once resource destructors:\n")
-    if Settings().use_trace_database:
-        TraceDatabase().set_origin('preprocessing')
+    SequenceTracker.set_origin('preprocessing')
 
     for destructor in destructors:
         status_codes = []
@@ -80,5 +79,4 @@ def delete_create_once_resources(destructors, fuzzing_requests):
         logger.POSTPROCESSING_GENERATION,
         None
     )
-    if Settings().use_trace_database:
-        TraceDatabase().clear_origin()
+    SequenceTracker.clear_origin()

--- a/restler/engine/core/preprocessing.py
+++ b/restler/engine/core/preprocessing.py
@@ -9,7 +9,7 @@ import engine.core.driver as driver
 import engine.core.fuzzing_requests as fuzzing_requests
 
 import utils.logger as logger
-from utils.logging.trace_db import DB as TraceDatabase
+from utils.logging.trace_db import SequenceTracker
 import utils.formatting as formatting
 import engine.dependencies as dependencies
 import engine.core.sequences as sequences
@@ -218,8 +218,7 @@ def apply_create_once_resources(fuzzing_requests):
         return
 
     logger.create_network_log(logger.LOG_TYPE_PREPROCESSING)
-    if Settings().use_trace_database:
-        TraceDatabase().set_origin('preprocessing')
+    SequenceTracker.set_origin('preprocessing')
 
     destructors = set()
     exclude_reqs = set()
@@ -314,8 +313,7 @@ def apply_create_once_resources(fuzzing_requests):
         logger.PREPROCESSING_GENERATION,
         None
     )
-    if Settings().use_trace_database:
-        TraceDatabase().clear_origin()
+    SequenceTracker.clear_origin()
 
     # Return the list of destructors that were removed from the request collection.
     # These will be used to cleanup the create_once resources created during preprocessing.

--- a/restler/engine/dependencies.py
+++ b/restler/engine/dependencies.py
@@ -12,7 +12,7 @@ import multiprocessing
 from multiprocessing.dummy import Pool as ThreadPool
 
 import utils.formatting as formatting
-from utils.logging.trace_db import DB as TraceDatabase
+from utils.logging.trace_db import SequenceTracker
 from restler_settings import Settings
 
 class ResourceTypeQuotaExceededException(Exception):
@@ -614,8 +614,7 @@ class GarbageCollectorThread(threading.Thread):
         @rtype : None
 
         """
-        if Settings().use_trace_database:
-            TraceDatabase().set_origin('gc')
+        SequenceTracker.set_origin('gc')
         def _should_stop():
             if self._finishing:
                 elapsed_time = time.time() - self._cleanup_start_time

--- a/restler/engine/transport_layer/messaging.py
+++ b/restler/engine/transport_layer/messaging.py
@@ -8,7 +8,8 @@ import socket
 import time
 import threading
 from importlib import util
-from utils.logging.trace_db import DB as TraceDatabase
+from utils.logging.trace_db import (DB as TraceDatabase,
+                                    SequenceTracker)
 from utils.formatting import iso_timestamp
 from utils.logger import raw_network_logging as RAW_LOGGING
 from engine.errors import TransportLayerException
@@ -200,6 +201,10 @@ class HttpSock(object):
         elif self.connection_settings.include_user_agent:
             # Send the RESTler user agent only if a custom user agent is not specified
             message = _append_to_header(message, f"User-Agent: restler/{Settings().version}")
+        if self.connection_settings.include_unique_sequence_id:
+            sequence_id = SequenceTracker().get_sequence_id()
+            if sequence_id is not None:
+                message = _append_to_header(message, f"x-restler-sequence-id: {sequence_id}")
 
         # Attempt to throttle the request if necessary
         self._begin_throttle_request()

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -30,7 +30,7 @@ class OptionValidationError(Exception):
 
 class ConnectionSettings(object):
     def __init__(self, target_ip, target_port, use_ssl=True, include_user_agent=False, disable_cert_validation=False,
-                 user_agent=None):
+                 user_agent=None, include_unique_sequence_id=False):
         """ Initializes an object that contains the connection settings for the socket
         @param target_ip: The ip of the target service.
         @type  target_ip: Str
@@ -54,6 +54,7 @@ class ConnectionSettings(object):
         self.use_ssl = use_ssl
         self.include_user_agent = include_user_agent
         self.user_agent = user_agent
+        self.include_unique_sequence_id = include_unique_sequence_id
         self.disable_cert_validation = disable_cert_validation
 
 class SettingsArg(object):
@@ -444,6 +445,8 @@ class RestlerSettings(object):
         self._ignore_feedback = SettingsArg('ignore_feedback', bool, False, user_args)
         ## Include user agent in requests sent
         self._include_user_agent = SettingsArg('include_user_agent', bool, True, user_args)
+        ## Include a unique sequence ID in requests sent
+        self._include_unique_sequence_id = SettingsArg('include_unique_sequence_id', bool, True, user_args)
         ## The user agent to include in requests sent
         self._user_agent = SettingsArg('user_agent', str, None, user_args)
         ## Maximum time to wait for an asynchronous resource to be created before continuing (seconds)
@@ -527,7 +530,8 @@ class RestlerSettings(object):
                                                        not self._no_ssl.val,
                                                        self._include_user_agent.val,
                                                        self._disable_cert_validation.val,
-                                                       self._user_agent.val)
+                                                       self._user_agent.val,
+                                                       self._include_unique_sequence_id.val)
 
         # Set per resource arguments
         if 'per_resource_settings' in user_args:


### PR DESCRIPTION
Add a setting that, when true, sends a header `x-restler-sequence-id` with each request containing a unique GUID that identifies the RESTler sequence.  

This setting is enabled by default.

Testing:
- manual testing