### PR TITLE
Support replay mode with garbage collection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             "request": "launch",
             "program": "${workspaceFolder}\\restler\\end_to_end_tests\\test_quick_start.py",
             "args": [
-                "d:\\restlerdrop\\main",
+                "d:\\restlerdrop\\tracedb2",
             ]
         },
         {
@@ -96,6 +96,48 @@
                 "d:\\test\\demo_server\\Compile\\dict.json",
                 "--settings",
                 "d:\\test\\demo_server\\Compile\\engine_settings.json",
+                "--no_ssl",
+                "--host",
+                "localhost",
+                "--target_port",
+                "8888",
+                "--garbage_collection_interval",
+                "30"
+            ],
+            "justMyCode": false
+        },
+        {
+            "name": "Python: replay mode with grammar",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}\\restler\\restler.py",
+            "args": [
+                "--replay_log",
+                "D:\\test\\demo_server\\replaytests3\\replay_trace_data.ndjson",
+                "--restler_grammar",
+                "d:\\test\\demo_server\\replaytests3\\Compile\\grammar.py",
+                "--custom_mutations",
+                "d:\\test\\demo_server\\replaytests3\\Compile\\dict.json",
+                "--settings",
+                "d:\\test\\demo_server\\replaytests3\\Compile\\engine_settings.json",
+                "--no_ssl",
+                "--host",
+                "localhost",
+                "--target_port",
+                "8888",
+                "--garbage_collection_interval",
+                "30"
+            ],
+            "justMyCode": false
+        },
+        {
+            "name": "Python: replay mode no grammar",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}\\restler\\restler.py",
+            "args": [
+                "--replay_log",
+                "D:\\test\\demo_server\\replaytests\\replay_trace_data.ndjson",
                 "--no_ssl",
                 "--host",
                 "localhost",

--- a/restler/checkers/checker_base.py
+++ b/restler/checkers/checker_base.py
@@ -119,7 +119,8 @@ class CheckerBase:
         @rtype : Tuple(HttpResponse, HttpResponse)
 
         """
-        rendered_data, parser, tracked_parameters, updated_writer_variables = request.render_current(self._req_collection.candidate_values_pool)
+        rendered_data, parser, tracked_parameters, updated_writer_variables, replay_blocks =\
+             request.render_current(self._req_collection.candidate_values_pool)
         rendered_data = seq.resolve_dependencies(rendered_data)
 
         # We need to record that the request originates from the checker, but
@@ -127,7 +128,8 @@ class CheckerBase:
         SequenceTracker.initialize_sequence_trace(combination_id=seq.combination_id,
                                             tags={'hex_definition': seq.hex_definition})
         SequenceTracker.initialize_request_trace(combination_id=seq.combination_id,
-                                            request_id=request.hex_definition)
+                                                 request_id=request.hex_definition,
+                                                 replay_blocks=replay_blocks)
 
         response = self._send_request(parser, rendered_data)
         if response.has_valid_code():

--- a/restler/checkers/demo_checker.py
+++ b/restler/checkers/demo_checker.py
@@ -74,7 +74,7 @@ class DemoChecker(CheckerBase):
         checked_seq.append_data_to_sent_list("GET /", None,  HttpResponse(), max_async_wait_time=req_async_wait)
 
         # Render the current request combination
-        rendered_data, parser, tracked_parameters, updated_writer_variables = \
+        rendered_data, parser, tracked_parameters, updated_writer_variables, replay_blocks = \
             next(last_request.render_iter(self._req_collection.candidate_values_pool,
                                           skip=last_request._current_combination_id - 1,
                                           preprocessing=False))

--- a/restler/checkers/invalid_dynamic_object_checker.py
+++ b/restler/checkers/invalid_dynamic_object_checker.py
@@ -58,7 +58,7 @@ class InvalidDynamicObjectChecker(CheckerBase):
         InvalidDynamicObjectChecker.generation_executed_requests[generation].add(last_request.hex_definition)
 
         # Get the current rendering of the sequence, which will be the valid rendering of the last request
-        last_rendering, last_request_parser, tracked_parameters, updated_writer_variables =\
+        last_rendering, last_request_parser, tracked_parameters, updated_writer_variables, replay_blocks =\
             last_request.render_current(self._req_collection.candidate_values_pool)
 
         # Execute the sequence up until the last request

--- a/restler/checkers/invalid_value_checker.py
+++ b/restler/checkers/invalid_value_checker.py
@@ -249,7 +249,7 @@ class InvalidValueChecker(CheckerBase):
 
         # Render the current request combination, but get the list of primitive
         # values before they are concatenated.
-        rendered_values, parser, tracked_parameters, updated_writer_variables = \
+        rendered_values, parser, tracked_parameters, updated_writer_variables, replay_blocks = \
             next(last_request.render_iter(self._req_collection.candidate_values_pool,
                                            skip=last_request._current_combination_id - 1,
                                            preprocessing=False,

--- a/restler/checkers/payload_body_checker.py
+++ b/restler/checkers/payload_body_checker.py
@@ -1122,7 +1122,7 @@ class PayloadBodyChecker(CheckerBase):
         cnt = 0
 
         # iterate through different value combinations
-        for rendered_data, parser,_,updated_writer_variables in new_request.render_iter(
+        for rendered_data, parser,_,updated_writer_variables, replay_blocks in new_request.render_iter(
             self._req_collection.candidate_values_pool
         ):
             # check time budget

--- a/restler/checkers/use_after_free_checker.py
+++ b/restler/checkers/use_after_free_checker.py
@@ -109,7 +109,7 @@ class UseAfterFreeChecker(CheckerBase):
 
         """
         request = seq.last_request
-        for rendered_data, parser,_,updated_writer_variables in\
+        for rendered_data, parser,_,updated_writer_variables, replay_blocks in\
             request.render_iter(self._req_collection.candidate_values_pool,
                                 skip=request._current_combination_id):
             # Hold the lock (because other workers may be rendering the same

--- a/restler/engine/core/request_utilities.py
+++ b/restler/engine/core/request_utilities.py
@@ -11,6 +11,7 @@ import uuid
 import types
 import threading
 import os
+import copy
 
 from engine.errors import ResponseParsingException
 from engine.errors import TransportLayerException
@@ -332,6 +333,81 @@ def resolve_dynamic_primitives(values, candidate_values_pool):
                 values[i] = ""
 
     return values
+
+def get_replay_blocks(req_definition, rendered_values):
+    """ After dynamic primitives are resolved, get the blocks that should be saved for replay.
+        The following modifications should be made to the original request definition:
+        - all primitives must be replaced with a static string containing the payload value.
+        In particular, values obtained from value generators should be constants,
+        since those specific values may have triggered bugs that are being reproduced.
+        - dynamic objects must be tracked (to enable generating unique IDs and in
+        order for GC to work).
+
+    @param req_definition: The pool of values for primitive types.
+    @type  req_definition: List [Tuple]
+    @param rendered_values: List of primitive type payloads.
+    @type rendered_values: List
+
+    @return: List of definition blocks that should be used for replay.
+    @rtype : List [Tuple]
+
+    """
+    # Only generate the replay blocks if writing the trace database
+    if not Settings().use_trace_database:
+        return None
+
+    if len(rendered_values) != len(req_definition):
+        raise Exception("The value list does not match the request definition.")
+
+    req_definition_copy=copy.copy(req_definition)
+    for i in range(len(rendered_values)):
+        request_block = req_definition_copy[i]
+        request_block = list(request_block)
+        block_value = rendered_values[i]
+        primitive_type = request_block[0]
+
+        # Handling dynamic primitives that need fresh rendering every time
+        if primitive_type == primitives.FUZZABLE_UUID4:
+            # No change needed - new GUID should be generated.
+            pass
+        # Handle enums that have a list of values instead of one default val
+        elif primitive_type == primitives.FUZZABLE_GROUP:
+            # replace default with concrete rendered value
+            request_block[2] = [block_value]
+            # Remove examples
+            request_block[4] = None
+        # Handle static whose value is the field name
+        elif primitive_type == primitives.STATIC_STRING:
+            # keep the element the same
+            pass
+        # Handle multipart form data
+        elif primitive_type == primitives.FUZZABLE_MULTIPART_FORMDATA:
+            # replace the default with the concrete rendered value
+            request_block[1] = block_value
+        # Handle custom (user defined) payloads
+        elif primitive_type == primitives.CUSTOM_PAYLOAD or\
+                primitive_type == primitives.CUSTOM_PAYLOAD_HEADER or\
+                primitive_type == primitives.CUSTOM_PAYLOAD_QUERY:
+            # Change it to a static string, leaving everything else the same
+            request_block[0] = primitives.STATIC_STRING
+            request_block[1] = block_value
+
+        # Handle custom (user defined) static payload with uuid4 suffix
+        elif primitive_type == primitives.CUSTOM_PAYLOAD_UUID4_SUFFIX:
+            # Leave as is - a new unique name should be generated.
+            pass
+        elif primitive_type == primitives.REFRESHABLE_AUTHENTICATION_TOKEN:
+            values = [primitives.restler_refreshable_authentication_token]
+        # Handle all the rest
+        else:
+            # Make it a static string with the concrete rendered value
+            request_block[0] = primitives.STATIC_STRING
+            request_block[1] = block_value
+            # Because the rendered value is already quoted, set 'is_quoted' to False
+            request_block[2] = False
+
+        req_definition_copy[i] = tuple(request_block)
+    return req_definition_copy
 
 def send_request_data(rendered_data, req_timeout_sec=None, reconnect=None, http_sock=None):
     """ Helper that sends a request's rendered data to the server

--- a/restler/engine/core/requests.py
+++ b/restler/engine/core/requests.py
@@ -313,7 +313,7 @@ class Request(object):
         else:
             raise EmptyRequestException
 
-        if Settings().in_smoke_test_mode():
+        if Settings().in_smoke_test_mode() or Settings().in_scenario_replay_mode():
             self.stats = SmokeTestStats()
 
     def __iter__(self):
@@ -1045,7 +1045,8 @@ class Request(object):
                 value_generators[idx] = tuple(tmp_list)
         return value_generators
 
-    def render_iter(self, candidate_values_pool, skip=0, preprocessing=False, prev_rendered_values=None, value_list=False):
+    def render_iter(self, candidate_values_pool, skip=0, preprocessing=False, prev_rendered_values=None,
+                    value_list=False, replay_blocks=False):
         """ This is the core method that renders values combinations in a
         request template. It basically is a generator which lazily iterates over
         a pool of possible combination of values that fit the template of the
@@ -1070,9 +1071,15 @@ class Request(object):
                            corresponding to the request definition.  If False,
                            the rendered request is returned as a string.
         @type  value_list: Bool
+        @param replay_blocks: Set to True to return the list of request blocks that should be used to replay the
+                              request.  If 'False', an empty list is returned.
+                              The replay blocks should preserve all dynamic objects.
+                              However, they currently do not support replay with custom payloads from a different
+                              dictionary (this is future work).
+        @type  replay_blocks: Bool
 
-        @return: (rendered request's payload, response's parser function, request's tracked parameter values)
-        @rtype : (Str, Function Pointer, List[Str])
+        @return: (rendered request's payload, response's parser function, request's tracked parameter values, replay blocks)
+        @rtype : (Str, Function Pointer, List[Str], List[List[Str]])
 
         """
         from engine.core.request_utilities import replace_auth_token
@@ -1102,9 +1109,13 @@ class Request(object):
         # constructed, since not all of them may be needed, e.g. during smoke test mode.
         next_combination = 0
         schema_idx = -1
-        schema_combinations = itertools.islice(self.get_schema_combinations(
-                                                    use_grammar_py_schema=Settings().allow_grammar_py_user_update),
-                                               Settings().max_schema_combinations)
+        if Settings().in_scenario_replay_mode():
+            # Just testing the grammar.py schema with replayed payloads, example payloads are not applicable
+            schema_combinations = itertools.islice([(self, False)], Settings().max_schema_combinations)
+        else:
+            schema_combinations = itertools.islice(self.get_schema_combinations(
+                                                        use_grammar_py_schema=Settings().allow_grammar_py_user_update),
+                                                Settings().max_schema_combinations)
         remaining_combinations_count = Settings().max_combinations - skip
 
         for (req, is_example) in schema_combinations:
@@ -1182,6 +1193,11 @@ class Request(object):
                         values[idx] = val
 
                 values = request_utilities.resolve_dynamic_primitives(values, candidate_values_pool)
+                # Get the replay blocks
+
+                # This must be done after resolving dynamic primitives, because concrete values generated
+                # via value generators must be used for replay
+                replay_blocks = request_utilities.get_replay_blocks(req.definition, values)
 
                 # If all the value generators are done, and the combination pool is exhausted, exit
                 # the loop.  Note: this check must be made after resolving dynamic primitives,
@@ -1250,7 +1266,7 @@ class Request(object):
                 # Save the schema for this combination.
                 self._last_rendered_schema_request = (req, is_example)
 
-                yield rendered_data, parser, tracked_parameter_values, dynamic_object_variables_to_update
+                yield rendered_data, parser, tracked_parameter_values, dynamic_object_variables_to_update, replay_blocks
 
                 next_combination = next_combination + 1
                 remaining_combinations_count = remaining_combinations_count - 1

--- a/restler/engine/core/sequences.py
+++ b/restler/engine/core/sequences.py
@@ -389,7 +389,7 @@ class Sequence(object):
             for i in range(len(self.requests) - 1):
                 last_tested_request_idx = i
                 prev_request = self.requests[i]
-                prev_rendered_data, prev_parser, tracked_parameters, updated_writer_variables =\
+                prev_rendered_data, prev_parser, tracked_parameters, updated_writer_variables, replay_blocks =\
                     prev_request.render_current(candidate_values_pool,
                     preprocessing=preprocessing, use_last_cached_rendering=True)
 
@@ -404,7 +404,8 @@ class Sequence(object):
                 prev_producer_timing_delay = Settings().get_producer_timing_delay(prev_request.request_id)
 
                 SequenceTracker.initialize_request_trace(combination_id=self.combination_id,
-                                                         request_id=request.hex_definition)
+                                                         request_id=request.hex_definition,
+                                                         replay_blocks=replay_blocks)
 
                 prev_response = request_utilities.send_request_data(prev_rendered_data)
                 if prev_response.has_valid_code():
@@ -521,7 +522,7 @@ class Sequence(object):
         datetime_format = "%Y-%m-%d %H:%M:%S"
         response_datetime_str = None
         timestamp_micro = None
-        for rendered_data, parser, tracked_parameters, updated_writer_variables in\
+        for rendered_data, parser, tracked_parameters, updated_writer_variables, replay_blocks in\
                 request.render_iter(candidate_values_pool,
                                     skip=request._current_combination_id,
                                     preprocessing=preprocessing):
@@ -580,7 +581,8 @@ class Sequence(object):
             req_async_wait = Settings().get_max_async_resource_creation_time(request.request_id)
             req_producer_timing_delay = Settings().get_producer_timing_delay(request.request_id)
             SequenceTracker.initialize_request_trace(combination_id=self.combination_id,
-                                                     request_id=request.hex_definition)
+                                                     request_id=request.hex_definition,
+                                                     replay_blocks=replay_blocks)
 
             response = request_utilities.send_request_data(rendered_data)
             if response.has_valid_code():

--- a/restler/engine/dependencies.py
+++ b/restler/engine/dependencies.py
@@ -512,7 +512,7 @@ class GarbageCollector:
 
             # Iterate in reverse to give priority to the newest resources
             for value in reversed(self.overflowing[type]):
-                rendered_data, _ , _, _ = destructor.\
+                rendered_data, _ , _, _, _ = destructor.\
                     render_current(self.req_collection.candidate_values_pool)
 
                 # replace dynamic parameters

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -418,6 +418,12 @@ class RestlerSettings(object):
         self._garbage_collection_interval = SettingsArg('garbage_collection_interval', int, None, user_args, minval=0)
         ## Trace database settings
         self._trace_db_settings = SettingsArg('trace_database', dict, {}, user_args)
+        ## Replay settings
+        self._replay_settings = SettingsArg('replay', dict, {}, user_args)
+        # The command line replay database overrides the one specified in the settings file
+        if 'replay_log' in user_args:
+            self._replay_settings.set_val({'trace_database_file_path': user_args['replay_log']})
+
         ## Length of time the garbage collector will attempt to cleanup remaining resources at the end of fuzzing (seconds)
         self._garbage_collector_cleanup_time = SettingsArg('garbage_collector_cleanup_time', int, MAX_GC_CLEANUP_TIME_SECONDS_DEFAULT, user_args, minval=0)
         ## Perform garbage collection of all dynamic objects after each sequence
@@ -621,6 +627,10 @@ class RestlerSettings(object):
         if 'file_path' in self._trace_db_settings.val:
             return self._trace_db_settings.val['file_path']
         return None
+
+    @property
+    def trace_db_replay_file(self):
+        return self._replay_settings.val.get('trace_database_file_path')
 
     @property
     def trace_db_root_dir(self):
@@ -1002,6 +1012,14 @@ class RestlerSettings(object):
         """
         return self._fuzzing_mode.val == 'directed-smoke-test' or \
                self._fuzzing_mode.val == 'test-all-combinations'
+
+    def in_scenario_replay_mode(self) -> bool:
+        """ Returns whether or not this run is replaying specific scenarios
+
+        @return: True if this run is replaying specific scenarios
+
+        """
+        return self.trace_db_replay_file is not None
 
     def get_endpoint_custom_mutations_paths(self) -> dict:
         """ Returns the dict containing the endpoint specific custom mutations

--- a/restler/unit_tests/log_baseline_test_files/abc_smoke_test_trace_data_baseline.txt
+++ b/restler/unit_tests/log_baseline_test_files/abc_smoke_test_trace_data_baseline.txt
@@ -10,6 +10,7 @@ tags:
 	combination_id:		'23db74a21a5b43c1601d160252a5cd1b7ae89805_1'
 	origin:		'main_driver'
 	hex_definition:		'd794089848f926a2adb6c0d064087030b7fe0a76'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -23,6 +24,7 @@ tags:
 	combination_id:		'23db74a21a5b43c1601d160252a5cd1b7ae89805_1'
 	origin:		'main_driver'
 	hex_definition:		'd794089848f926a2adb6c0d064087030b7fe0a76'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -36,6 +38,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1'
 	origin:		'main_driver'
 	hex_definition:		'71777e3a6f5ed880f522a42ebaa81807f665dac6'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -49,6 +52,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1'
 	origin:		'main_driver'
 	hex_definition:		'71777e3a6f5ed880f522a42ebaa81807f665dac6'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -62,6 +66,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_2d217a8041860f0742efe1b22a09893cd0e89ca5_1'
 	origin:		'main_driver'
 	hex_definition:		'ce6ebbe39cfd6f5a7d19214b17ae4c20a8120e3e'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -75,6 +80,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_2d217a8041860f0742efe1b22a09893cd0e89ca5_1'
 	origin:		'main_driver'
 	hex_definition:		'ce6ebbe39cfd6f5a7d19214b17ae4c20a8120e3e'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -88,6 +94,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_2d217a8041860f0742efe1b22a09893cd0e89ca5_1'
 	origin:		'main_driver'
 	hex_definition:		'ce6ebbe39cfd6f5a7d19214b17ae4c20a8120e3e'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -101,6 +108,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_2d217a8041860f0742efe1b22a09893cd0e89ca5_1'
 	origin:		'main_driver'
 	hex_definition:		'ce6ebbe39cfd6f5a7d19214b17ae4c20a8120e3e'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -114,6 +122,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_2d217a8041860f0742efe1b22a09893cd0e89ca5_1'
 	origin:		'main_driver'
 	hex_definition:		'ce6ebbe39cfd6f5a7d19214b17ae4c20a8120e3e'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -127,6 +136,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_2d217a8041860f0742efe1b22a09893cd0e89ca5_1'
 	origin:		'main_driver'
 	hex_definition:		'ce6ebbe39cfd6f5a7d19214b17ae4c20a8120e3e'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -140,6 +150,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1'
 	origin:		'main_driver'
 	hex_definition:		'235a70567f6e60282168ed67f260914690d4c144'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -153,6 +164,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1'
 	origin:		'main_driver'
 	hex_definition:		'235a70567f6e60282168ed67f260914690d4c144'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -166,6 +178,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1'
 	origin:		'main_driver'
 	hex_definition:		'235a70567f6e60282168ed67f260914690d4c144'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -179,6 +192,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1'
 	origin:		'main_driver'
 	hex_definition:		'235a70567f6e60282168ed67f260914690d4c144'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -192,6 +206,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1'
 	origin:		'main_driver'
 	hex_definition:		'235a70567f6e60282168ed67f260914690d4c144'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -205,6 +220,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1'
 	origin:		'main_driver'
 	hex_definition:		'235a70567f6e60282168ed67f260914690d4c144'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -218,6 +234,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1_fb149c026c182b9719b5b5b37ef0ef3f0950c55a_1'
 	origin:		'main_driver'
 	hex_definition:		'39d0a4e14ba2a123a77d6fe4155ff0dfb89883b2'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -231,6 +248,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1_fb149c026c182b9719b5b5b37ef0ef3f0950c55a_1'
 	origin:		'main_driver'
 	hex_definition:		'39d0a4e14ba2a123a77d6fe4155ff0dfb89883b2'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -244,6 +262,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1_fb149c026c182b9719b5b5b37ef0ef3f0950c55a_1'
 	origin:		'main_driver'
 	hex_definition:		'39d0a4e14ba2a123a77d6fe4155ff0dfb89883b2'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -257,6 +276,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1_fb149c026c182b9719b5b5b37ef0ef3f0950c55a_1'
 	origin:		'main_driver'
 	hex_definition:		'39d0a4e14ba2a123a77d6fe4155ff0dfb89883b2'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -270,6 +290,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1_fb149c026c182b9719b5b5b37ef0ef3f0950c55a_1'
 	origin:		'main_driver'
 	hex_definition:		'39d0a4e14ba2a123a77d6fe4155ff0dfb89883b2'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -283,6 +304,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1_fb149c026c182b9719b5b5b37ef0ef3f0950c55a_1'
 	origin:		'main_driver'
 	hex_definition:		'39d0a4e14ba2a123a77d6fe4155ff0dfb89883b2'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -296,6 +318,7 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1_fb149c026c182b9719b5b5b37ef0ef3f0950c55a_1'
 	origin:		'main_driver'
 	hex_definition:		'39d0a4e14ba2a123a77d6fe4155ff0dfb89883b2'
+replay_blocks:	None
 sequence_id:	None
 sent_timestamp:	None
 received_timestamp:	None
@@ -309,4 +332,5 @@ tags:
 	combination_id:		'44414ad093616e18a9e2f845ae9d453eb6e4c8bc_1_23db74a21a5b43c1601d160252a5cd1b7ae89805_1_a3b2722ed766df82f0d1d1aafd2e81f23d4a0aa2_1_fb149c026c182b9719b5b5b37ef0ef3f0950c55a_1'
 	origin:		'main_driver'
 	hex_definition:		'39d0a4e14ba2a123a77d6fe4155ff0dfb89883b2'
+replay_blocks:	None
 sequence_id:	None

--- a/restler/unit_tests/log_baseline_test_files/trace_db_text_serializer.py
+++ b/restler/unit_tests/log_baseline_test_files/trace_db_text_serializer.py
@@ -25,6 +25,7 @@ class TraceDbTextWriter(TraceLogWriterBase):
         data["sent_timestamp"]=None
         data["received_timestamp"]=None
         data["sequence_id"]=None
+        data["replay_blocks"]=None
         if "tags" in data:
             x = data["tags"]
             x["sequence_id"]=None

--- a/restler/unit_tests/test_grammar_schema_parser.py
+++ b/restler/unit_tests/test_grammar_schema_parser.py
@@ -104,8 +104,8 @@ class SchemaParserTest(unittest.TestCase):
         # TODO: enums equal
 
         # Payloads equal
-        original_rendered_data,_,_,_ = next(original_req.render_iter(req_collection.candidate_values_pool))
-        generated_rendered_data,_,_,_ = next(generated_req.render_iter(req_collection.candidate_values_pool))
+        original_rendered_data,_,_,_,_ = next(original_req.render_iter(req_collection.candidate_values_pool))
+        generated_rendered_data,_,_,_,_ = next(generated_req.render_iter(req_collection.candidate_values_pool))
 
         original_rendered_data = original_rendered_data.replace("\r\n", "")
 
@@ -370,7 +370,7 @@ class SchemaParserTest(unittest.TestCase):
 
         combinations_count = 0
         for x, is_example in req_with_body.get_schema_combinations(use_grammar_py_schema=False):
-            rendered_data,_,_,_ = next(x.render_iter(request_collection.candidate_values_pool))
+            rendered_data,_,_,_,_ = next(x.render_iter(request_collection.candidate_values_pool))
             self.assertTrue("\"id\"" not in rendered_data)
             self.assertTrue("\"person\"" in rendered_data)
             self.assertTrue("\"name\"" in rendered_data)

--- a/restler/utils/logging/ndjson_serializer.py
+++ b/restler/utils/logging/ndjson_serializer.py
@@ -25,10 +25,12 @@ class CustomRotatingFileHandler(RotatingFileHandler):
         return base_name + count_ext + type_ext
 
 class RequestTraceLog():
-    def __init__(self, request_id=None, sequence_id=None, combination_id=None, tags={}, sequence_tags={}):
+    def __init__(self, request_id=None, sequence_id=None, combination_id=None, tags={}, sequence_tags={},
+                 replay_blocks=None):
         self.request_id = request_id
         self.sequence_id = sequence_id
         self.tags = tags
+        self.replay_blocks = replay_blocks
         self.origin = None
         self.sequence_tags = sequence_tags
         self.combination_id = combination_id
@@ -42,9 +44,6 @@ class RequestTraceLog():
     @classmethod
     def from_dict(cls, log_dict):
         instance = cls()
-        instance.request_id = log_dict.get('request_id')
-        instance.sequence_id = log_dict.get('sequence_id')
-        instance.combination_id = log_dict.get('combination_id')
         instance.sent_timestamp = log_dict.get('sent_timestamp')
         instance.received_timestamp = log_dict.get('received_timestamp')
         instance.tags = log_dict.get('tags', {})
@@ -56,6 +55,17 @@ class RequestTraceLog():
         instance.request_json = None if request_json is None else json.loads(request_json)
         instance.response_json = None if response_json is None else json.loads(response_json)
         instance.origin = None if 'origin' not in instance.tags else instance.tags['origin']
+
+        instance.sequence_id = None if 'sequence_id' not in instance.tags else instance.tags['sequence_id']
+        instance.combination_id = None if 'combination_id' not in instance.tags else instance.tags['combination_id']
+        instance.request_id = None if 'request_id' not in instance.tags else instance.tags['request_id']
+        instance.origin = None if 'origin' not in instance.tags else instance.tags['origin']
+        instance.hex_definition = None if 'hex_definition' not in instance.tags else instance.tags['hex_definition']
+
+        replay_blocks = log_dict.get('replay_blocks')
+        if replay_blocks is not None:
+            replay_blocks = [tuple(block) for block in replay_blocks]
+        instance.replay_blocks = replay_blocks
         return instance
 
     def normalize(self):
@@ -67,6 +77,7 @@ class RequestTraceLog():
         self.sequence_id = None
         self.tags = {}
         self.sequence_tags = {}
+        self.replay_blocks = None
         return self
 
     def __eq__(self, other):
@@ -106,6 +117,7 @@ class RequestTraceLog():
             tags["combination_id"] = self.combination_id
         if self.origin is not None:
             tags["origin"] = self.origin
+
         tags.update(self.tags)
         tags.update(self.sequence_tags)
         return {
@@ -113,9 +125,12 @@ class RequestTraceLog():
             'received_timestamp': self.received_timestamp,
             'request': self.request,
             'response': self.response,
-            'request_json': None if self.request_json == None else json.dumps(self.request_json),
-            'response_json': None if self.request_json == None else json.dumps(self.response_json),
-            'tags': tags
+            'request_json': None if self.request_json is None else json.dumps(self.request_json),
+            'response_json': None if self.request_json is None else json.dumps(self.response_json),
+            'tags': tags,
+            # replay blocks contain a list of tuples.  Each tuple contains strings or None,
+            # so it should be safe to serialize directly to JSON
+            'replay_blocks': None if self.replay_blocks is None else self.replay_blocks
         }
 
 class JsonTraceLogReader(TraceLogReaderBase):

--- a/restler/utils/logging/trace_db.py
+++ b/restler/utils/logging/trace_db.py
@@ -4,6 +4,7 @@
 """ Trace database for REST API request/response sequences. """
 
 from restler_settings import Settings
+#from engine.core.requests import Request
 from utils.logging.ndjson_serializer import *
 import time
 import queue
@@ -56,7 +57,7 @@ class SequenceTracker:
                                             sequence_tags=tags)
 
     @staticmethod
-    def initialize_request_trace(request_id=None, combination_id=None, tags={}):
+    def initialize_request_trace(request_id=None, combination_id=None, tags={}, replay_blocks=None):
         """Initialize trace log for the request."""
         trace = _get_trace()
 
@@ -71,6 +72,7 @@ class SequenceTracker:
 
         sequence_trace.request_id = request_id
         sequence_trace.tags = tags
+        sequence_trace.replay_blocks = replay_blocks
 
     @staticmethod
     def clear_sequence_trace():
@@ -107,6 +109,48 @@ class SequenceTracker:
             return None
         return trace['origin']
 
+def get_sequences_from_db(db_file_path, origin_filter='main_driver'):
+    """Gets the sequences from the trace database.
+    @param db_file_path: The path to the trace database.
+    @type  db_file_path: String
+    @param origin_filter: The origin to filter by.  If None, no filtering is done.
+    @type  origin_filter: String
+
+    @return: The sequences from the trace database.  Each sequence contains a list of requests.  Each request is
+                a dictionary containing the request text and replay blocks, if available.
+    @rtype : List[List[Dict]]
+    """
+    log_reader = JsonTraceLogReader(log_file_paths=[db_file_path])
+    trace_messages = log_reader.load()
+    sequences = [] # the sequences should be replayed in the same order as they were generated
+    current_sequence_id = None
+    current_req_list = []
+    # First, collect the requests by sequence ID.  For a particular origin, they should not be interleaved.
+    for i, x in enumerate(trace_messages):
+        if x.request is not None:
+            if origin_filter is not None and x.origin != origin_filter:
+                continue
+            if current_sequence_id is None:
+                current_sequence_id = x.sequence_id
+            elif current_sequence_id != x.sequence_id:
+                # This is a new sequence
+                sequences.append(current_req_list)
+                current_req_list = []
+                current_sequence_id = x.sequence_id
+
+            # Handle cases where data in the database may have been written during multiple runs,
+            # only some of which supplied 'replay_blocks'.
+            replay_data={}
+            # Always save the request text, since it is used to find the request ID
+            replay_data['request_text'] = x.request
+            if hasattr(x, 'replay_blocks') and x.replay_blocks is not None:
+                replay_data['request_blocks'] = x.replay_blocks
+            current_req_list.append(replay_data)
+
+    # Append the last sequence
+    if len(current_req_list) > 0:
+        sequences.append(current_req_list)
+    return sequences
 
 class TraceDatabase:
     """ This class enables structured storage and retrieval of RESTler logs.
@@ -137,7 +181,10 @@ class TraceDatabase:
                                             sequence_id=tls_trace_log.sequence_id,
                                             combination_id=tls_trace_log.combination_id,
                                             sequence_tags=tls_trace_log.sequence_tags,
-                                            tags=tls_trace_log.tags)
+                                            tags=tls_trace_log.tags,
+                                            # Only log the replay blocks for sent requests
+                                            replay_blocks=None if request is None else tls_trace_log.replay_blocks)
+
             trace_log.origin = SequenceTracker.get_origin()
             if request:
                 trace_log.request = request
@@ -149,9 +196,11 @@ class TraceDatabase:
                     trace_log.received_timestamp = timestamp
             if tags:
                 trace_log.tags.update(tags)
-            if 'origin' not in trace_log.tags and trace_log.origin is None:
+
+            if 'origin' not in trace_log.tags and 'origin' not in trace_log.sequence_tags and trace_log.origin is None:
                 raise Exception(f"Missing origin: request: {trace_log.request_id}, sequence: {trace_log.sequence_id}")
-            self.log(trace_log.to_dict())
+            record = trace_log.to_dict()
+            self.log(record)
         except Exception as error:
             # print the callstack
             import traceback

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -33,7 +33,8 @@ let usage() =
           [ compile <compile options> |
             test <test options> |
             fuzz-lean <test options> |
-            fuzz <fuzz options> ]
+            fuzz <fuzz options> ] |
+            replay <replay options>
 
     global options:
         --disable_log_upload
@@ -101,9 +102,16 @@ let usage() =
         --search_strategy [bfs-fast(default),bfs,bfs-cheap,random-walk]
 
     replay options:
-        <Required options from 'test' mode as above:
-            --token_refresh_cmd. >
-        --replay_log <path to the RESTler bug bucket repro file>. "
+        <The following options are the same as in 'test' mode:
+            --dictionary_file
+            --token_refresh_interval
+            --token_refresh_command
+            --no_ssl
+            --host
+            --settings
+
+        --replay_log <path to the RESTler bug bucket repro file or replay file>.
+            The replay file extension may be either '.replay.txt' or '.ndjson'."
     exitRestler 1
 
 module Paths =
@@ -805,7 +813,7 @@ let rec parseArgs (args:DriverArgs) = function
     | "replay"::rest ->
         let engineParameters = parseEngineArgs RestlerTask.Replay DefaultEngineParameters rest
         let engineParameters = { engineParameters with
-                                    checkerOptions = getCheckerOptions Fuzz.DefaultFuzzModeCheckerOptions engineParameters.checkerOptions }
+                                    checkerOptions = getCheckerOptions [] engineParameters.checkerOptions }
         { args with task = Replay
                     taskParameters = EngineParameters engineParameters}
     | invalidArgument::_ ->


### PR DESCRIPTION
This change enables a new 'replay' mode option that replays requests from the trace database.

Changes include:

- Refactor driver to consume sequences from different sources (with trace database another supported source of specific sequences, similar to the existing smoke test mode)

- Generate 'replay blocks' as part of payload rendering.  Replay blocks contain dynamic objects, but do not support custom payloads (this is future work).

- Generate sequences from replay blocks if available, or from raw request/responses (similar to the existing replay mode)

Testing:
- manual testing of demo_server replay as follows:

1) Run 'test' task and generate trace database
>restler.exe test --grammar_file .\Compile\grammar.py --dictionary_file .\Compile\dict.json --host localhost --target_port 8888  --settings .\compile\engine_settings.json --no_ssl

Engine settings:
{
  "use_trace_database": true, "trace_database": { "root_dir": "d:\\demo_server\\trace_databases", }, }

2) Run 'replay' task from above trace database

>restler.exe replay --replay_log ./trace_data.ndjson --grammar_file .\Compile\grammar.py --dictionary_file .\Compile\dict.json --host localhost --target_port 8888  --settings .\compile\engine_settings.json --no_ssl

TODO:
- add unit tests
- documentation