### PR TITLE
Compiler: fix ref unescaping

### DIFF
--- a/src/compiler/Restler.Compiler.Test/swagger/schemaTests/swagger_escape_characters.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/schemaTests/swagger_escape_characters.json
@@ -14,7 +14,7 @@
             "required": true,
             "in": "body",
             "schema": {
-              "$ref": "#/definitions~1Escape~0Characters"
+              "$ref": "#/definitions/Escape~0Characters"
             }
           }
         ],
@@ -22,7 +22,7 @@
           "200": {
             "description": "Success",
             "schema": {
-              "$ref": "#/definitions~1Escape~0Characters"
+              "$ref": "#/definitions/Escape~0Characters"
             }
           }
         }
@@ -45,7 +45,7 @@
           "200": {
             "description": "Success",
             "schema": {
-              "$ref": "#/definitions/~01EscapeCharacters"
+              "$ref": "#/definitions/~1Escape~1Characters"
             }
           }
         }
@@ -96,6 +96,13 @@
     "~1EscapeCharacters": {
       "properties": {
         "escape_characters2": {
+          "type": "string"
+        }
+      }
+    },
+    "/Escape/Characters": {
+      "properties": {
+        "escape_characters3": {
           "type": "string"
         }
       }

--- a/src/compiler/Restler.Compiler/SwaggerSpecPreprocessor.fs
+++ b/src/compiler/Restler.Compiler/SwaggerSpecPreprocessor.fs
@@ -86,8 +86,7 @@ module EscapeCharacters =
     let refRegex = Regex("(?<![/])/")
 
     let getRefParts refPath =
-        let r = replaceSwaggerEscapeCharacters refPath
-        refRegex.Split(r) |> Array.skip 1
+        refRegex.Split(refPath) |> Array.skip 1 |> Array.map replaceSwaggerEscapeCharacters
 
 /// Find the object at 'refPath' in the specified file.
 let getObjInFile filePath (refPath:string) (jsonSpecs:Dictionary<string, JObject>) =


### PR DESCRIPTION
Reference to path works incorrectly when path contains more than one slash (see example below), compiler cannot find such path:
```log
Unhandled exception. System.InvalidOperationException: Reference path "/paths/~1xxx~1ab" not found
```

Also current unescaping breaks reference part into an extra level i.e. reference `#/definitions~1Escape~0Characters` points to
`Escape~Characters` inside `definitions` while it should point to `definitions/Escape~Characters` in the root.

This PR fixes the issue by performing unescaping after splitting path to parts.

Example schema:
```yaml
openapi: 3.0.3
info:
  title: REST API
  description: REST API description
  version: 1.0.0
servers:
  - url: http://{hostname}:{port}
    variables:
      hostname:
        default: localhost
      port:
        default: "80"

paths:
  /api/device/info:
    $ref: "#/paths/~1xxx~1ab"

  /xxx/ab:
    get:
      summary: Get information
      description: Return identifier
      responses:
        '200':
          description: info
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Info'

components:
  schemas:
    Info:
      type: object
      required:
        - id
      properties:
        id:
          type: string
```