### PR TITLE
Fix pytest warnings

### DIFF
--- a/restler/unit_tests/test_restler_settings.py
+++ b/restler/unit_tests/test_restler_settings.py
@@ -316,7 +316,7 @@ class RestlerSettingsTest(unittest.TestCase):
                      'target_ip': '192.168.0.1',
                      'token_refresh_cmd': 'some command'}
         settings = RestlerSettings(user_args)
-        with self.assertRaisesRegexp(OptionValidationError, "Must specify refresh period"):
+        with self.assertRaisesRegex(OptionValidationError, "Must specify refresh period"):
             settings.validate_options()
 
     def test_refresh_module_no_interval(self):
@@ -349,7 +349,7 @@ class RestlerSettingsTest(unittest.TestCase):
                         }
                      }}
         settings = RestlerSettings(user_args)
-        with self.assertRaisesRegexp(OptionValidationError, "module file does not exist"):
+        with self.assertRaisesRegex(OptionValidationError, "module file does not exist"):
             settings.validate_options()
 
     def test_multiple_auth_options(self):
@@ -373,7 +373,7 @@ class RestlerSettingsTest(unittest.TestCase):
                         },
                      }}
         settings = RestlerSettings(user_args)
-        with self.assertRaisesRegexp(OptionValidationError, "Must specify only one token authentication mechanism"):
+        with self.assertRaisesRegex(OptionValidationError, "Must specify only one token authentication mechanism"):
             settings.validate_options()
 
     def test_refresh_location_no_interval(self):
@@ -386,7 +386,7 @@ class RestlerSettingsTest(unittest.TestCase):
                         }
                      }}
         settings = RestlerSettings(user_args)
-        with self.assertRaisesRegexp(OptionValidationError, "Must specify refresh period"):
+        with self.assertRaisesRegex(OptionValidationError, "Must specify refresh period"):
             settings.validate_options()
 
     def test_refresh_interval_no_method(self):
@@ -394,7 +394,7 @@ class RestlerSettingsTest(unittest.TestCase):
                      'target_ip': '192.168.0.1',
                      'token_refresh_interval': 30}
         settings = RestlerSettings(user_args)
-        with self.assertRaisesRegexp(OptionValidationError, "Must specify token refresh method"):
+        with self.assertRaisesRegex(OptionValidationError, "Must specify token refresh method"):
             settings.validate_options()
 
     def test_throttling_multiple_fuzzing_jobs(self):
@@ -573,7 +573,7 @@ class RestlerSettingsTest(unittest.TestCase):
         self.assertFalse(settings.connection_settings.use_ssl)
         self.assertTrue(settings.connection_settings.disable_cert_validation)
         self.assertTrue(settings.no_tokens_in_logs)
-        self.assertEqual('(\w*)/blog/posts(\w*)', settings.path_regex)
+        self.assertEqual(r'(\w*)/blog/posts(\w*)', settings.path_regex)
         self.assertEqual(500, settings.request_throttle_ms)
         self.assertEqual('100.100.100.100', settings.connection_settings.target_ip)
         self.assertEqual(500, settings.connection_settings.target_port)


### PR DESCRIPTION
(minor)

Noticed in the CI while looking for pre-built binaries that the `EngineUnitTests` contained a few warnings:

https://dev.azure.com/ms/restler-fuzzer/_build/results?buildId=525358&view=logs&j=c1a1743c-78a2-53ee-8834-cd0bb3870179&t=401e5d2e-45d7-5aab-9556-6862a0474420&l=30

```
=============================== warnings summary ===============================
unit_tests/test_restler_settings.py:576
  /home/vsts/work/1/s/restler/unit_tests/test_restler_settings.py:576: DeprecationWarning: invalid escape sequence \w
    self.assertEqual('(\w*)/blog/posts(\w*)', settings.path_regex)

test_restler_settings.py::RestlerSettingsTest::test_multiple_auth_options
  /home/vsts/work/1/s/restler/unit_tests/test_restler_settings.py:376: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(OptionValidationError, "Must specify only one token authentication mechanism"):

test_restler_settings.py::RestlerSettingsTest::test_refresh_cmd_no_interval
  /home/vsts/work/1/s/restler/unit_tests/test_restler_settings.py:319: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(OptionValidationError, "Must specify refresh period"):

test_restler_settings.py::RestlerSettingsTest::test_refresh_interval_no_method
  /home/vsts/work/1/s/restler/unit_tests/test_restler_settings.py:397: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(OptionValidationError, "Must specify token refresh method"):

test_restler_settings.py::RestlerSettingsTest::test_refresh_location_no_interval
  /home/vsts/work/1/s/restler/unit_tests/test_restler_settings.py:389: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(OptionValidationError, "Must specify refresh period"):

test_restler_settings.py::RestlerSettingsTest::test_refresh_module_file_does_not_exist
  /home/vsts/work/1/s/restler/unit_tests/test_restler_settings.py:352: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(OptionValidationError, "module file does not exist"):
```
