### PR TITLE
Change JsonSerializer to require all non-optional fields

### DIFF
--- a/src/compiler/Restler.Compiler/Utilities.fs
+++ b/src/compiler/Restler.Compiler/Utilities.fs
@@ -57,7 +57,8 @@ module JsonSerialization =
                 JsonSerializerSettings(
                     NullValueHandling = NullValueHandling.Ignore,
                     MissingMemberHandling = MissingMemberHandling.Error,
-                    DateParseHandling = DateParseHandling.None
+                    DateParseHandling = DateParseHandling.None,
+                    ContractResolver = Compact.Strict.RequireNonOptionalPropertiesContractResolver()
                 )
             settings.Converters.Add(CompactUnionJsonConverter(true, true))
             settings


### PR DESCRIPTION
I was surprised by how permissive the JSON deserialization is, and it resulted in error messages hiding useful information.

My motivating use case was an annotations file like this:
```
{
  "x-restler-global-annotations": [
    { }
  ]
}
```

Trying to compile a grammar with that produces an extremely generic null-reference message:
> Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at Restler.Annotations.getAnnotationsFromJson(JToken annotationJson) in /data/src/restler-fuzzer/src/compiler/Restler.Compiler/Annotations.fs:line 168
   at Restler.Annotations.getGlobalAnnotationsFromFile(String filePath) in /data/src/restler-fuzzer/src/compiler/Restler.Compiler/Annotations.fs:line 220
   at Restler.Workflow.generateGrammarFromSwagger(String grammarOutputDirectoryPath, Config config) in /data/src/restler-fuzzer/src/compiler/Restler.Compiler/Workflow.fs:line 104
   at Restler.Workflow.generateRestlerGrammar(Config config) in /data/src/restler-fuzzer/src/compiler/Restler.Compiler/Workflow.fs:line 250
   at Program.main(String[] argv) in /data/src/restler-fuzzer/src/compiler/Restler.CompilerExe/Program.fs:line 43

It turns out that even though `ProducerConsumerUserAnnotation` says `producer_endpoint : string` (implying a non-optional field), it will parse `{}` and produce an object with `{producer_endpoint: null}`. Despite sensible checks on the result of `tryDeserialize`, this is missed and blows up later. I think this should be a parsing error, caught by all callers of `Utilities.JsonSerialization.tryDeserialize` and reported correctly.

This PR makes that change, by specifying a `ContractResolver` from `FSharpLu.Json`. The original example now produces a descriptive error:

> Unhandled exception. Newtonsoft.Json.JsonSerializationException: Required property 'producer_endpoint' not found in JSON. Path '', line 1, position 2.
...

(Disclaimer - I'm not familiar with F# or .NET, and I've only just started experimenting with restler, so this is a purely speculative change from a bit of docs-probing. Please let me know if there's a better way to achieve this, or some reason that the original behaviour is required)