### PR TITLE
Bump fastapi version to resolve security alert

### DIFF
--- a/demo_server/requirements.txt
+++ b/demo_server/requirements.txt
@@ -1,3 +1,3 @@
-fastapi==0.78.0
+fastapi==0.109.1
 uvicorn==0.18.1
-sqlmodel==0.0.6
+sqlmodel==0.0.14

--- a/restler/end_to_end_tests/test_quick_start.py
+++ b/restler/end_to_end_tests/test_quick_start.py
@@ -128,8 +128,8 @@ def test_fuzzlean_task(restler_working_dir, swagger_path, restler_drop_dir):
         'Attempted requests: 6 / 6',
         'Bugs were found!' ,
         'InvalidDynamicObjectChecker_20x: 2',
-        'PayloadBodyChecker_500: 2',
-        'UseAfterFreeChecker_20x: 1',
+        'PayloadBodyChecker_500: 1',
+        'UseAfterFreeChecker_500: 1',
         'InvalidValueChecker_500: 1',
         'Task FuzzLean succeeded.'
     ]


### PR DESCRIPTION
- Also bump sqlmodel version

- A few app issues needed to be fixed as part of this upgrade:

1) Use union type to be able to return None and trigger one of the planted bugs 2) Work around OverflowError: Python int too large to convert to SQLite INTEGER

3) adjust baseline since 500 is no longer getting returned after pydantic upgrade

The payload {"body":0} now generates a well-formed error response before reaching the demo_server implementation

4) Update baseline for use after free checker

This checker now returns a 500