### PR TITLE
updating regex to match logs expression

### DIFF
--- a/src/ResultsAnalyzer/Common/Log.fs
+++ b/src/ResultsAnalyzer/Common/Log.fs
@@ -37,7 +37,7 @@ module Log =
         match line with
         | Regex "^Generation-\d+: Rendering Sequence-\d+" [] ->
             Some SequenceBeginning
-        | Regex "^([^']*): Sending: '(.*)'" [ date; request ] ->
+        | Regex "^([^']*): Sending: ('.*'|\".*\")" [ date; request ] ->
             let date = parseDateTime date
             let parsedRequest =
                 request
@@ -57,7 +57,7 @@ module Log =
                     }
                 Some (Sending (date, r))
             | Some request -> Some (Sending (date, request))
-        | Regex "^([^']*): Received: '(.*)'" [ date; response ] ->
+        | Regex "^([^']*): Received: ('.*'|\".*\")" [ date; response ] ->
             let date = parseDateTime date
             let parsedResponse =
                 response


### PR DESCRIPTION
## Summary of the Pull Request

 This PR aims to solve the Resutls analyzer issue [632](https://github.com/microsoft/restler-fuzzer/issues/632) that gets generated by the use of double quotes in the log messages in the network.testing.x.logs, therefore the regex has been modified to include double quotes

## PR Checklist
* [x] Applies to work item: #632 
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign.
* [ ] Tests added/passed.  
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach. Issue number where discussion took place: #xxx

## Info on Pull Request

This includes only the Regex change

## Validation Steps Performed

Run the results analyzer with a network testing log that has double quotes and single quotes