### PR TITLE
Revert "Add ContractResolver to JsonSerialization, so that non-option…

### DIFF
--- a/src/compiler/Restler.Compiler/Utilities.fs
+++ b/src/compiler/Restler.Compiler/Utilities.fs
@@ -57,8 +57,7 @@ module JsonSerialization =
                 JsonSerializerSettings(
                     NullValueHandling = NullValueHandling.Ignore,
                     MissingMemberHandling = MissingMemberHandling.Error,
-                    DateParseHandling = DateParseHandling.None,
-                    ContractResolver = Compact.Strict.RequireNonOptionalPropertiesContractResolver()
+                    DateParseHandling = DateParseHandling.None
                 )
             settings.Converters.Add(CompactUnionJsonConverter(true, true))
             settings


### PR DESCRIPTION
…al fields are required (#852)"

This reverts commit 86581a2c2171c55db8902350631a2ec5fa4c2afd.

This change needs to be re-submitted after refactoring the compiler config to match the optional fields that are currently documented.