### PR TITLE
Workaround for dynamic object encoding bug

### DIFF
--- a/restler/engine/dependencies.py
+++ b/restler/engine/dependencies.py
@@ -109,13 +109,15 @@ def get_variable(type):
 
     # Make sure the value is properly escaped for being sent
     value = tlb[type]
+    if not Settings().encode_dynamic_objects:
+        return value
+
     encoded_value = json.dumps(value)
     if isinstance(value, (str)):
         encoded_value = encoded_value[1:-1]
 
     # thread_id = threading.current_thread().ident
     # print("Getting: {} / Value: {} ({})".format(type, encoded_value, thread_id))
-
     return encoded_value
 
 def __add_variable_to_dyn_cache(type, value, obj_cache, cache_lock):

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -532,6 +532,9 @@ class RestlerSettings(object):
         if self._generate_random_seed.val:
             self._random_seed.val = time.time()
 
+        ## Do not encode dynamic objects (workaround for incorrect encoding for headers)
+        self._encode_dynamic_objects = SettingsArg('encode_dynamic_objects', bool, True, user_args)
+
         self._connection_settings = ConnectionSettings(self._target_ip.val,
                                                        self._target_port.val,
                                                        not self._no_ssl.val,
@@ -766,6 +769,10 @@ class RestlerSettings(object):
     @property
     def generate_random_seed(self):
         return self._generate_random_seed.val
+
+    @property
+    def encode_dynamic_objects(self):
+        return self._encode_dynamic_objects.val
 
     @property
     def no_tokens_in_logs(self):


### PR DESCRIPTION
See issue #882 

For example, encoding for headers is not being handled correctly.

As a workaround, set
  "encode_dynamic_objects": false

to skip encoding.