### PR TITLE
Update default fuzzing timeout to 7 days

### DIFF
--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -453,9 +453,10 @@ The IP address of the target webserver.
 ### target_port: int (default None)
 The port of the target webserver.
 
-### time_budget: float (default 1 hour)
+### time_budget: float (default 168)
 Once this time is reached, the fuzzing will stop.
 Time is in hours.
+The default is 7 days.  
 
 ### token_refresh_cmd: str (default None)
 The command to execute in order to refresh the authentication token.

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -197,7 +197,7 @@ module Compile =
 
 module Fuzz =
 
-    let DefaultFuzzingDurationHours = 1.0
+    let DefaultFuzzingDurationHours = 168.0
 
     let SupportedCheckers =
         [


### PR DESCRIPTION
Currently, the fuzzing timeout is 1 hour by default.  This causes incorrect/misleading results for more complex services that require a longer fuzzing time, if timeout is accidentally omitted due to a configuration issue.

Providing a very long timeout in an attempt to mitigate this issue. (Note: this was already the default timeout in the RESTler engine - this change is only for the driver).

To restore the default timeout, add the following to the engine settings:

'time_budget': 1