### PR TITLE
Search mode default and doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ RESTler is described in these peer-reviewed research papers:
 
 If you use RESTler in your research, please cite the (default) ICSE'2019 paper ([BibTeX](./docs/user-guide/icse2019.bib)).
 
+RESTler includes multiple test generation strategies.  In order to get a comprehensive comparative view w.r.t. to (i) efficiency 
+(i.e., how quickly can RESTler find crashes) and (ii) effectiveness 
+(i.e., how many crashes can RESTler find in a give time frame), 
+we recommend comparing against all documented `fuzzing_mode(s)`
+because each one provides a different trade-off between breadth and depth of state space exploration.
+We also recommend running `test` mode before any fuzzing, as described below, 
+to discover and fix setup issues (e.g. adding required pre-requisite parameter values to the dictionary) prior to fuzzing.
+
 RESTler was created at Microsoft Research and is still under active development.
 
 For an overview and demo on how to get started, see [Webinar - Fuzzing to Improve the Security and Reliability of Cloud Services](https://www.youtube.com/watch?v=FYmiPoRwEbE).

--- a/docs/user-guide/Fuzzing.md
+++ b/docs/user-guide/Fuzzing.md
@@ -3,6 +3,9 @@
 In *Fuzz-lean* mode, RESTler executes once every endpoint+method in a compiled RESTler grammar with a default set of checkers to see if bugs can be found quickly.
 
 In *Fuzz* mode, RESTler will fuzz the service under test during a longer period of time with the goal of finding more bugs and issues (resource leaks, perf degradation, backend corruptions, etc.). **Warning:** The Fuzz mode is the more aggressive and may create outages in the service under test if the service is poorly implemented.
+**Warning** By default, RESTler will not fuzz all value combinations in `fuzz` mode.  You must change the `fuzzing_mode` to `bfs` in order to test all combinations of values provided 
+in the dictionary, enum values, etc.
+
 
 Inputs: (same as for test)
 

--- a/src/driver/Program.fs
+++ b/src/driver/Program.fs
@@ -419,7 +419,7 @@ module Fuzz =
 
         let fuzzingMode =
             if parameters.searchStrategy.IsNone then
-                "bfs-fast"
+                "bfs-cheap"
             else parameters.searchStrategy.Value
 
         let fuzzingParameters =


### PR DESCRIPTION
Per discussion in #823, updating the README and updating the default mode to be `bfs-cheap`.

Originally, the reasoning behind the default value of `bfs-fast` was that it provides different coverage from `fuzz-lean` (which is similar to `bfs-cheap` in that it does not exercise all of the renderings). However, many users only want to run one fuzzing mode (e.g. for evaluation purposes, having just one job in CI/CD), and that is typically the `fuzz` mode (since we document it to provide the best coverage).

Updating the documentation to reflect this.