### PR TITLE
Fix Content-Type custom payload bugs

### DIFF
--- a/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
+++ b/src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj
@@ -67,7 +67,13 @@
     <Content Include="baselines\dictionaryTests\customPayloadDict_ValueGeneratorTemplate.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="baselines\exampleTests\array_example_grammar.py">
+	  <Content Include="baselines\dictionaryTests\customPayloadContentType_grammar.py">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="baselines\dictionaryTests\customPayloadHeaderContentType_grammar.py">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="baselines\exampleTests\array_example_grammar.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 	  <Content Include="swagger\exampleTests\example_int_openapi3.yml">
@@ -235,13 +241,19 @@
 	  <Content Include="swagger\dictionaryTests\customPayloadSwagger.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="swagger\dictionaryTests\customPayloadDict.json">
+	  <Content Include="swagger\dictionaryTests\customPayloadContentTypeSwagger.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\dictionaryTests\customPayloadDict.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\dictionaryTests\customPayloadRequestTypeDict.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="swagger\dictionaryTests\serializationTestDict.json">
+	  <Content Include="swagger\dictionaryTests\customPayloadHeaderRequestTypeDict.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="swagger\dictionaryTests\serializationTestDict.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger\dependencyTests\lowercase_paths.json">

--- a/src/compiler/Restler.Compiler.Test/baselines/dictionaryTests/customPayloadContentType_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dictionaryTests/customPayloadContentType_grammar.py
@@ -1,0 +1,464 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_stores_post_id = dependencies.DynamicVariable("_stores_post_id")
+
+def parse_storespost(data, **kwargs):
+    """ Automatically generated response parser """
+    # Declare response variables
+    temp_7262 = None
+
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        try:
+            data = json.loads(data)
+        except Exception as error:
+            raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+        pass
+
+    # Try to extract each dynamic object
+
+        try:
+            temp_7262 = str(data["id"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
+
+
+
+    # If no dynamic objects were extracted, throw.
+    if not (temp_7262):
+        raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
+
+    # Set dynamic variables
+    if temp_7262:
+        dependencies.set_variable("_stores_post_id", temp_7262)
+
+req_collection = requests.RequestCollection([])
+# Endpoint: /stores, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+
+        'post_send':
+        {
+            'parser': parse_storespost,
+            'dependencies':
+            [
+                _stores_post_id.writer()
+            ]
+        }
+
+    },
+
+],
+requestId="/stores"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}, method: Put
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores_post_id.reader(), quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "metadata":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "delivery":
+        {
+            "metadata":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "id":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+    "name":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}/order, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores_post_id.reader(), quoted=False),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("order"),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("submittedDate="),
+    primitives.restler_fuzzable_datetime("2019-06-26T20:20:39+00:00", quoted=False),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("message="),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_custom_payload("/stores/{storeId}/order/post/Content-Type", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+    "storeProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "deliveryProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "rush":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bagType":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "items":
+    [
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "deliveryTags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+            "code":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "expirationMaxDate":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+        }
+    ],
+    "useDoubleBags":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bannedBrands":
+    [
+        """),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}/order"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}/order2, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores_post_id.reader(), quoted=False),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("order2"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("submittedDate: "),
+    primitives.restler_fuzzable_datetime("2019-06-26T20:20:39+00:00", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("message: "),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_custom_payload("/stores/{storeId}/order2/post/Content-Type", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+    "storeProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "deliveryProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "rush":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bagType":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "items":
+    [
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "deliveryTags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+            "code":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "expirationMaxDate":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+        }
+    ],
+    "useDoubleBags":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bannedBrands":
+    [
+        """),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}/order2"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}/order3, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores_post_id.reader(), quoted=False),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("order3"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("submittedDate: "),
+    primitives.restler_fuzzable_datetime("2019-06-26T20:20:39+00:00", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_custom_payload("/stores/{storeId}/order3/post/Content-Type", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+    "storeProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "deliveryProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "rush":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bagType":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "items":
+    [
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "deliveryTags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+            "code":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "expirationMaxDate":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+        }
+    ],
+    "useDoubleBags":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bannedBrands":
+    [
+        """),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}/order3"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}/order4, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores_post_id.reader(), quoted=False),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("order4"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("submittedDate: "),
+    primitives.restler_fuzzable_datetime("2019-06-26T20:20:39+00:00", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+    "storeProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "deliveryProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "rush":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bagType":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "items":
+    [
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "deliveryTags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+            "code":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "expirationMaxDate":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+        }
+    ],
+    "useDoubleBags":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bannedBrands":
+    [
+        """),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}/order4"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/baselines/dictionaryTests/customPayloadHeaderContentType_grammar.py
+++ b/src/compiler/Restler.Compiler.Test/baselines/dictionaryTests/customPayloadHeaderContentType_grammar.py
@@ -1,0 +1,464 @@
+""" THIS IS AN AUTOMATICALLY GENERATED FILE!"""
+from __future__ import print_function
+import json
+from engine import primitives
+from engine.core import requests
+from engine.errors import ResponseParsingException
+from engine import dependencies
+
+_stores_post_id = dependencies.DynamicVariable("_stores_post_id")
+
+def parse_storespost(data, **kwargs):
+    """ Automatically generated response parser """
+    # Declare response variables
+    temp_7262 = None
+
+    if 'headers' in kwargs:
+        headers = kwargs['headers']
+
+
+    # Parse body if needed
+    if data:
+
+        try:
+            data = json.loads(data)
+        except Exception as error:
+            raise ResponseParsingException("Exception parsing response, data was not valid json: {}".format(error))
+        pass
+
+    # Try to extract each dynamic object
+
+        try:
+            temp_7262 = str(data["id"])
+            
+        except Exception as error:
+            # This is not an error, since some properties are not always returned
+            pass
+
+
+
+    # If no dynamic objects were extracted, throw.
+    if not (temp_7262):
+        raise ResponseParsingException("Error: all of the expected dynamic objects were not present in the response.")
+
+    # Set dynamic variables
+    if temp_7262:
+        dependencies.set_variable("_stores_post_id", temp_7262)
+
+req_collection = requests.RequestCollection([])
+# Endpoint: /stores, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    
+    {
+
+        'post_send':
+        {
+            'parser': parse_storespost,
+            'dependencies':
+            [
+                _stores_post_id.writer()
+            ]
+        }
+
+    },
+
+],
+requestId="/stores"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}, method: Put
+request = requests.Request([
+    primitives.restler_static_string("PUT "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores_post_id.reader(), quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "metadata":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "delivery":
+        {
+            "metadata":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "id":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+    "name":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string("}"),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}/order, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores_post_id.reader(), quoted=False),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("order"),
+    primitives.restler_static_string("?"),
+    primitives.restler_static_string("submittedDate="),
+    primitives.restler_fuzzable_datetime("2019-06-26T20:20:39+00:00", quoted=False),
+    primitives.restler_static_string("&"),
+    primitives.restler_static_string("message="),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_custom_payload_header("/stores/{storeId}/order/post/Content-Type"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+    "storeProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "deliveryProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "rush":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bagType":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "items":
+    [
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "deliveryTags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+            "code":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "expirationMaxDate":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+        }
+    ],
+    "useDoubleBags":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bannedBrands":
+    [
+        """),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}/order"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}/order2, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores_post_id.reader(), quoted=False),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("order2"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("submittedDate: "),
+    primitives.restler_fuzzable_datetime("2019-06-26T20:20:39+00:00", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("message: "),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_custom_payload_header("/stores/{storeId}/order2/post/Content-Type"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+    "storeProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "deliveryProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "rush":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bagType":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "items":
+    [
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "deliveryTags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+            "code":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "expirationMaxDate":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+        }
+    ],
+    "useDoubleBags":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bannedBrands":
+    [
+        """),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}/order2"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}/order3, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores_post_id.reader(), quoted=False),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("order3"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("submittedDate: "),
+    primitives.restler_fuzzable_datetime("2019-06-26T20:20:39+00:00", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_custom_payload_header("/stores/{storeId}/order3/post/Content-Type"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+    "storeProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "deliveryProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "rush":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bagType":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "items":
+    [
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "deliveryTags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+            "code":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "expirationMaxDate":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+        }
+    ],
+    "useDoubleBags":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bannedBrands":
+    [
+        """),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}/order3"
+)
+req_collection.add_request(request)
+
+# Endpoint: /stores/{storeId}/order4, method: Post
+request = requests.Request([
+    primitives.restler_static_string("POST "),
+    primitives.restler_basepath("/api"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("stores"),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string(_stores_post_id.reader(), quoted=False),
+    primitives.restler_static_string("/"),
+    primitives.restler_static_string("order4"),
+    primitives.restler_static_string(" HTTP/1.1\r\n"),
+    primitives.restler_static_string("Accept: application/json\r\n"),
+    primitives.restler_static_string("Host: localhost:8888\r\n"),
+    primitives.restler_static_string("submittedDate: "),
+    primitives.restler_fuzzable_datetime("2019-06-26T20:20:39+00:00", quoted=False),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("Content-Type: "),
+    primitives.restler_static_string("application/json"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_refreshable_authentication_token("authentication_token_tag"),
+    primitives.restler_static_string("\r\n"),
+    primitives.restler_static_string("{"),
+    primitives.restler_static_string("""
+    "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+    "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+    "storeProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "deliveryProperties":
+        {
+            "tags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string("""
+        }
+    ,
+    "rush":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bagType":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+    "items":
+    [
+        {
+            "name":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string(""",
+            "deliveryTags":"""),
+    primitives.restler_fuzzable_object("{ \"fuzz\": false }"),
+    primitives.restler_static_string(""",
+            "code":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "storeId":"""),
+    primitives.restler_fuzzable_int("1"),
+    primitives.restler_static_string(""",
+            "expirationMaxDate":"""),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+        }
+    ],
+    "useDoubleBags":"""),
+    primitives.restler_fuzzable_bool("true"),
+    primitives.restler_static_string(""",
+    "bannedBrands":
+    [
+        """),
+    primitives.restler_fuzzable_string("fuzzstring", quoted=True),
+    primitives.restler_static_string("""
+    ]}"""),
+    primitives.restler_static_string("\r\n"),
+
+],
+requestId="/stores/{storeId}/order4"
+)
+req_collection.add_request(request)

--- a/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/customPayloadContentTypeSwagger.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/customPayloadContentTypeSwagger.json
@@ -1,0 +1,409 @@
+{
+  "basePath": "/api",
+  "consumes": [
+    "application/json"
+  ],
+  "definitions": {
+    "DeliveryMetadata": {
+      "properties": {
+        "metadata": {
+          "description": "The metadata tags of the store.",
+          "type": "object"
+        }
+      }
+    },
+    "Store": {
+      "properties": {
+        "metadata": {
+          "description": "The metadata tags of the store.",
+          "type": "object"
+        },
+        "delivery": {
+          "$ref": "#/definitions/DeliveryMetadata"
+        },
+        "id": {
+          "description": "The unique identifier of a store",
+          "type": "integer"
+        },
+        "name": {
+          "description": "The name of the store",
+          "type": "integer"
+        }
+      }
+    },
+    "Order": {
+      "properties": {
+        "tags": {
+          "description": "The order tags",
+          "type": "object"
+        },
+        "id": {
+          "description": "The unique identifier of an order",
+          "type": "integer"
+        },
+        "eta": {
+          "description": "The date the order will be ready",
+          "type": "string"
+        },
+        "status": {
+          "description": "The order status",
+          "type": "string"
+        },
+        "count": {
+          "description": "The count",
+          "type": "int"
+        },
+        "count2": {
+          "description": "The count",
+          "type": "int"
+        }
+
+
+      }
+    },
+    "StoreProperties": {
+      "properties": {
+        "tags": {
+          "description": "The unique identifier of the store",
+          "type": "object"
+        }
+      }
+    },
+    "DeliveryProperties": {
+      "properties": {
+        "tags": {
+          "description": "The unique identifier of the store",
+          "type": "object"
+        }
+      }
+    },
+    "GroceryList": {
+      "properties": {
+        "tags": {
+          "description": "The unique identifier of the store",
+          "type": "object"
+        },
+        "storeId": {
+          "description": "The unique identifier of the store",
+          "type": "integer"
+        },
+        "storeProperties": {
+          "$ref": "#/definitions/StoreProperties"
+        },
+        "deliveryProperties": {
+          "$ref": "#/definitions/DeliveryProperties"
+        },
+        "rush": {
+          "description": "Is it a rush order",
+          "type": "boolean"
+        },
+        "bagType": {
+          "description": "The type of bags to use",
+          "type": "string"
+        },
+        "items": {
+          "description": "The type of bags to use",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroceryListItem"
+          }
+        },
+        "useDoubleBags": {
+          "description": "Whether to use double bags",
+          "type": "boolean"
+        },
+        "bannedBrands": {
+          "description": "do not use these brands",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GroceryListItem": {
+      "properties": {
+        "name": {
+          "description": "The name of the item",
+          "type": "string"
+        },
+        "deliveryTags": {
+          "description": "The delivery tags",
+          "type": "object"
+        },
+
+        "code": {
+          "description": "The code of the item",
+          "type": "integer"
+        },
+        "storeId": {
+          "description": "The unique identifier of the store",
+          "type": "integer"
+        },
+        "expirationMaxDate": {
+          "description": "The maximum date that this item should expire",
+          "type": "string"
+        }
+      }
+    },
+    "KeyType": {
+      "type": "string",
+      "enum": [
+        "NotSpecified",
+        "Primary",
+        "Secondary"
+      ],
+      "x-ms-enum": {
+        "name": "KeyType",
+        "modelAsString": false
+      }
+    },
+    "GetCallbackUrlParameters": {
+      "type": "object",
+      "properties": {
+        "notAfter": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The expiry time."
+        },
+        "keyType": {
+          "$ref": "#/definitions/KeyType",
+          "description": "The key type."
+        }
+      },
+      "description": "The callback url parameters."
+    }
+
+  },
+  "host": "localhost:8888",
+  "info": {
+    "description": "A simple swagger spec that uses examples",
+    "title": "My Grocery API",
+    "version": "1.0"
+  },
+  "paths": {
+    "/stores": {
+      "post": {
+        "operationId": "post_stores",
+
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Store"
+            }
+          }
+        }
+      }
+    },
+    "/stores/{storeId}": {
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "bodyParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Store"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Store"
+            }
+          }
+        }
+      }
+    },
+    "/stores/{storeId}/order": {
+      "post": {
+        "operationId": "make_an_order",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "in": "query",
+            "name": "submittedDate",
+            "required": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "in": "query",
+            "name": "message",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "orderDetails",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GroceryList"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "404": {
+            "description": "Store not found."
+          }
+        }
+      }
+    },
+    "/stores/{storeId}/order2": {
+      "post": {
+        "operationId": "make_an_order_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "submittedDate",
+            "required": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "in": "header",
+            "name": "message",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "orderDetails",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GroceryList"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "404": {
+            "description": "Store not found."
+          }
+        }
+      }
+    },
+    "/stores/{storeId}/order3": {
+      "post": {
+        "operationId": "make_an_order_3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "submittedDate",
+            "required": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "in": "header",
+            "name": "Content-Type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "orderDetails",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GroceryList"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "404": {
+            "description": "Store not found."
+          }
+        }
+      }
+    },
+    "/stores/{storeId}/order4": {
+      "post": {
+        "operationId": "make_an_order_3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "submittedDate",
+            "required": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "in": "header",
+            "name": "Content-Type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "orderDetails",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GroceryList"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "404": {
+            "description": "Store not found."
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/customPayloadHeaderRequestTypeDict.json
+++ b/src/compiler/Restler.Compiler.Test/swagger/dictionaryTests/customPayloadHeaderRequestTypeDict.json
@@ -1,5 +1,5 @@
 {
-  "restler_custom_payload": {
+  "restler_custom_payload_header": {
     "/stores/{storeId}/order/post/Content-Type": [ "application/xml" ],
     "/stores/{storeId}/order2/post/Content-Type": [ "application/yyy" ],
     "/stores/{storeId}/order3/post/Content-Type": [ "application/zzz" ]

--- a/src/compiler/Restler.Compiler/Dictionary.fs
+++ b/src/compiler/Restler.Compiler/Dictionary.fs
@@ -58,8 +58,18 @@ type MutationsDictionary =
                 m |> Map.tryFind entryName
             | None -> None
 
+        member x.getRequestTypePayloadPrefix endpoint (method:string) = 
+            sprintf "%s/%s/" endpoint (method.ToLower())
+
+        member x.getRequestTypePayloadName endpoint (method:string) propertyNameOrPath = 
+            sprintf "%s/%s/%s" endpoint (method.ToLower()) propertyNameOrPath
+
+        member x.isRequestTypePayloadName endpoint (method:string) (propertyValue:string) = 
+             let prefix = sprintf "%s/%s" endpoint (method.ToLower())
+             propertyValue.StartsWith(prefix)
+
         member x.findBodyCustomPayload endpoint (method:string) =
-            let bodyPayloadName = sprintf "%s/%s/__body__" endpoint (method.ToLower())
+            let bodyPayloadName = x.getRequestTypePayloadName endpoint method "__body__" 
             match x.findPayloadEntry x.restler_custom_payload bodyPayloadName with
             | Some _ -> Some bodyPayloadName
             | None -> None
@@ -69,11 +79,23 @@ type MutationsDictionary =
         /// Examples:
         ///   - Specify values for the parameter 'blogId' anywhere in the payload
         ///         (path parameter will be replaced):  /blog/{blogId}/get/blogId
-        member x.findRequestTypeCustomPayload endpoint (method:string) propertyNameOrPath =
-            let requestTypePayloadName = sprintf "%s/%s/%s" endpoint (method.ToLower()) propertyNameOrPath
+        ///   - Substitute the Content-Type of the request
+        member x.findRequestTypeCustomPayload endpoint (method:string) propertyNameOrPath parameterKind =
+            let requestTypePayloadName = x.getRequestTypePayloadName endpoint method propertyNameOrPath
             match x.findPayloadEntry x.restler_custom_payload requestTypePayloadName with
-            | Some _ -> Some requestTypePayloadName
-            | None -> None
+            | Some _ -> Some (requestTypePayloadName, CustomPayloadType.String)
+            | None -> 
+                match parameterKind with
+                | ParameterKind.Header ->
+                    match x.findPayloadEntry x.restler_custom_payload_header requestTypePayloadName with
+                    | Some _ -> Some (requestTypePayloadName, CustomPayloadType.Header)
+                    | None -> None
+                | ParameterKind.Query ->
+                    match x.findPayloadEntry x.restler_custom_payload_query requestTypePayloadName with
+                    | Some _ -> Some (requestTypePayloadName, CustomPayloadType.Query)
+                    | None -> None
+                | _ ->
+                    raise (invalidArg "parameterKind" "only Query or Header is valid in this context")
 
         // Note: per-endpoint dictionaries allow restricting a payload to a specific endpoint.
         member x.getParameterForCustomPayload consumerResourceName (accessPathParts: AccessPath) primitiveType parameterKind =

--- a/src/compiler/Restler.Compiler/Dictionary.fs
+++ b/src/compiler/Restler.Compiler/Dictionary.fs
@@ -62,11 +62,12 @@ type MutationsDictionary =
             sprintf "%s/%s/" endpoint (method.ToLower())
 
         member x.getRequestTypePayloadName endpoint (method:string) propertyNameOrPath = 
-            sprintf "%s/%s/%s" endpoint (method.ToLower()) propertyNameOrPath
+            let prefix = x.getRequestTypePayloadPrefix endpoint method
+            sprintf "%s%s" prefix propertyNameOrPath
 
         member x.isRequestTypePayloadName endpoint (method:string) (propertyValue:string) = 
-             let prefix = sprintf "%s/%s" endpoint (method.ToLower())
-             propertyValue.StartsWith(prefix)
+            let prefix = x.getRequestTypePayloadPrefix endpoint method
+            propertyValue.StartsWith(prefix)
 
         member x.findBodyCustomPayload endpoint (method:string) =
             let bodyPayloadName = x.getRequestTypePayloadName endpoint method "__body__" 

--- a/src/compiler/Restler.Compiler/Grammar.fs
+++ b/src/compiler/Restler.Compiler/Grammar.fs
@@ -3,9 +3,9 @@
 
 module Restler.Grammar
 
-open System.IO
 open AccessPaths
 open Restler.XMsPaths
+open FSharp.Reflection
 
 /// Tree utilities.
 /// Reference: https://fsharpforfunandprofit.com/posts/recursive-types-and-folds/
@@ -95,6 +95,13 @@ let getOperationMethodFromString (m:string) =
     | "HEAD" -> OperationMethod.Head
     | "TRACE" -> OperationMethod.Trace
     | _ -> OperationMethod.NotSupported
+
+let SupportedOperationMethods = 
+    let t = typeof<OperationMethod>
+    let cases = FSharpType.GetUnionCases(t)
+    cases
+    |> Array.map (fun case -> case.Name.ToLower())
+    |> Array.filter(fun m -> m <> "NotSupported")
 
 type ParameterKind =
     | Path

--- a/src/compiler/Restler.CompilerExe/Properties/launchSettings.json
+++ b/src/compiler/Restler.CompilerExe/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Restler.CompilerExe": {
       "commandName": "Project",
-      "commandLineArgs": "d:\\test\\exformat\\config.json"
+      "commandLineArgs": "D:\\test\\demo_server\\xml\\restlerConfig\\config.json"
     }
   }
 }


### PR DESCRIPTION
When a custom payload body is used to work around unsupported content types, the Content-Type header must also be modified via the dictionary.  This functionality had several bugs, which are fixed in this change.  After this update, using either `restler_custom_payload_header` or `restler_custom_payload` with the request-specific syntax for dictionary payloads now works as expected, for example:

  "restler_custom_payload": {
    "/stores/{storeId}/order/post/Content-Type": [ "xml" ]
  }

This change also fixes the same bugs with per-request syntax with restler_custom_payload_query.

Testing:
- manual testing with demo_server
- added new compiler tests