### PR TITLE
adjusted if statement for single-chunk data transfer

### DIFF
--- a/restler/engine/transport_layer/messaging.py
+++ b/restler/engine/transport_layer/messaging.py
@@ -20,6 +20,7 @@ if util.find_spec("test_servers"):
     from test_servers.test_socket import TestSocket
 
 DELIM = "\r\n\r\n"
+TERMINATING_CHUNK_DELIM = "0\r\n\r\n"
 UTF8 = 'utf-8'
 
 
@@ -262,6 +263,7 @@ class HttpSock(object):
 
         """
         global DELIM
+        global TERMINATING_CHUNK_DELIM
         data = ''
 
         def decode_buf (buf):
@@ -296,7 +298,7 @@ class HttpSock(object):
             'transfer-encoding: chunked\r\n' in data:
             # Handle corner case of single-chunk data transfer. Without this
             # check, the next recv call on _sock will hang until timeout.
-            if data.endswith(DELIM):
+            if data.endswith(TERMINATING_CHUNK_DELIM):
                 return data
             chuncked_encoding = True
         if chuncked_encoding:
@@ -312,7 +314,7 @@ class HttpSock(object):
 
                 data += decode_buf(buf)
 
-                if data.endswith(DELIM):
+                if data.endswith(TERMINATING_CHUNK_DELIM):
                     return data
 
         header_len = data.index(DELIM) + len(DELIM)


### PR DESCRIPTION
## Summary of the Pull Request
This PR aims to improve the handling of the corner case when a chunked response has just a single chunk.

## PR Checklist
- [x]  Applies to work item: engine/transport_layer/messaging.py
- [x] CLA signed.
- [ ] Tests added/passed
- [ ] Requires documentation to be updated
- [ ]  I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different approach. Issue number where discussion took place:

## Info on Pull Request
While testing restler I encountered the problem that every second request got a time out.
To address this I added a `TERMINATING_CHUNK_DELIM` constant which should ensure that [this line](https://github.com/microsoft/restler-fuzzer/blob/c41ef5641abd161b485f348c7cfe27527308cf30/restler/engine/transport_layer/messaging.py#L299) doesn't trigger on the HEADER delimiter like it currently does.

Currently if the response is chunked, only the header of the response could be assigned to data which causes a timeout on [this call](https://github.com/microsoft/restler-fuzzer/blob/c41ef5641abd161b485f348c7cfe27527308cf30/restler/engine/transport_layer/messaging.py#L338). I suspect this is the case because the response from the first request of a TCP connection is still buffered, but only the payload without the HEADER is available, because the previous call consumed the HEADER. This causes the tool to retry the request with a new TCP connection, which succeeds, but the next request runs into the same problem.

## Validation Steps Performed
Run the tool with the modified code without encountering the time out problem.

