### PR TITLE
Add validation to engine dictionary

### DIFF
--- a/restler/engine/primitives.py
+++ b/restler/engine/primitives.py
@@ -471,6 +471,15 @@ class CandidateValuesPool(object):
         @rtype : None
 
         """
+
+        def validate_string_values(dictionary):
+            """ Validates that all values in the provided dictionary are strings. """
+            for key, values in dictionary.items():
+                if not all(isinstance(value, str) for value in values):
+                    raise ValueError(f"All values for '{key}' must be strings, but found: {values}")
+
+        validate_string_values(custom_values)
+
         # Set default primitives
         self.candidate_values = self._set_custom_values(self.candidate_values, custom_values)
         if not self._dates_added:

--- a/restler/unit_tests/test_restler_settings.py
+++ b/restler/unit_tests/test_restler_settings.py
@@ -235,6 +235,30 @@ class RestlerSettingsTest(unittest.TestCase):
         self.assertEqual(None, settings.get_checker_arg('leakage_rule_mode', 'mode'))
         self.assertEqual(None, settings.get_checker_arg('resource_hierarchy_rule_mode', 'mode'))
 
+    def test_validate_string_values_in_candidate_values(self):
+        candidate_values = primitives.CandidateValuesPool()
+        
+        invalid_dict = {
+            "restler_fuzzable_int": [
+                1  # Invalid as it's not a string
+            ]
+        }
+
+        with self.assertRaises(ValueError):
+            candidate_values.set_candidate_values(invalid_dict)
+
+        valid_dict = {
+            "restler_fuzzable_int": [
+                "1"  # Valid as it's a string
+            ]
+        }
+
+        # No error should since input is valid
+        try:
+            candidate_values.set_candidate_values(valid_dict)
+        except ValueError as e:
+            self.fail(f"ValueError raised unexpectedly: {e}")
+
     def test_invalid_entries(self):
         user_args = {
             'max_sequence_length': '10'

--- a/restler/unit_tests/test_restler_settings.py
+++ b/restler/unit_tests/test_restler_settings.py
@@ -236,6 +236,7 @@ class RestlerSettingsTest(unittest.TestCase):
         self.assertEqual(None, settings.get_checker_arg('resource_hierarchy_rule_mode', 'mode'))
 
     def test_validate_string_values_in_candidate_values(self):
+        _ = RestlerSettings({})
         candidate_values = primitives.CandidateValuesPool()
         
         invalid_dict = {


### PR DESCRIPTION
Fixes #773

This adds a local function to see if `custom_values` dictionary only contains strings. It will throw an error if the dictionary is not valid.
I have also added a test case for testing the code change.

Please let me know if there are any changes to be made, as it is my first time contributing to this codebase.