### PR TITLE
Fix Windows only CI failure

### DIFF
--- a/.github/workflows/ci_build_test_pr.yaml
+++ b/.github/workflows/ci_build_test_pr.yaml
@@ -53,13 +53,25 @@ jobs:
         run: |
           pip install -r ./restler/requirements.txt
       
+      - name: Print .NET SDK info
+        run: |
+          dotnet --info
+          dotnet --list-sdks
+          dotnet --list-runtimes
+
       - name: Build RESTler drop
+        shell: pwsh
         run: |
           python ./build-restler.py --dest_dir ${{ github.workspace }}/${{ runner.os }}/restlerdrop/${{ env.RESTLER_VERSION }} 2>stderr.log
+          if ($LASTEXITCODE -ne 0) { exit 1 }
           python ./.github/actions/utilities/check_stderr.py stderr.log
+          if ($LASTEXITCODE -ne 0) { exit 1 }
 
       - name: Build unit tests
-        run: dotnet build src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj --no-restore -c ${{ env.BUILD_CONFIGURATION }} /p:Platform='${{ env.BUILD_PLATFORM }}'
+        shell: pwsh
+        run: | 
+          dotnet build src/compiler/Restler.Compiler.Test/Restler.Compiler.Test.fsproj --no-restore -c ${{ env.BUILD_CONFIGURATION }} /p:Platform='${{ env.BUILD_PLATFORM }}'
+          if ($LASTEXITCODE -ne 0) { exit 1 }
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -158,6 +170,11 @@ jobs:
         with:
           name: restler-drop-${{ env.RESTLER_VERSION }}-${{ runner.os }}
           path: ${{ github.workspace }}/restlerDrop
+
+      - name: Output contents of the RESTler drop directory
+        run: |
+          echo "Contents of the RESTler drop directory:"
+          ls ${{ github.workspace }}/restlerDrop
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "8.0.406",
+      "rollForward": "latestPatch"
+    }
+}

--- a/restler-quick-start.py
+++ b/restler-quick-start.py
@@ -38,6 +38,18 @@ def compile_spec(api_spec_path, restler_dll_path):
         os.makedirs(RESTLER_TEMP_DIR)
 
     with usedir(RESTLER_TEMP_DIR):
+
+        # Check that the executable exists
+        if not os.path.exists(restler_dll_path):
+            print(f"RESTler dll not found when compiling at {restler_dll_path}")
+            exit(-1)
+
+        # Check that the file paths specified in required parameters exist,
+        # and print an informative message that includes the function name
+        if not os.path.exists(api_spec_path):
+            print(f"API spec not found at {api_spec_path}")
+            exit(-1)
+
         command=f"dotnet \"{restler_dll_path}\" compile --api_spec \"{api_spec_path}\""
         print(f"command: {command}")
         subprocess.run(command, shell=True)
@@ -144,6 +156,11 @@ if __name__ == '__main__':
     args = parser.parse_args()
     restler_dll_path = Path(os.path.abspath(args.restler_drop_dir)).joinpath('restler', 'Restler.dll')
     print(f"\nrestler_dll_path: {restler_dll_path}\n")
+
+    # Check that the RESTler dll exists
+    if not os.path.exists(restler_dll_path):
+        print(f"RESTler dll not found at {restler_dll_path}")
+        exit(-1)
 
     if args.task == "replay":
         replay_from_dir(args.ip, args.port, args.host, args.use_ssl, restler_dll_path.absolute(), args.replay_bug_buckets_dir)

--- a/src/driver/SpecCoverage.fs
+++ b/src/driver/SpecCoverage.fs
@@ -15,7 +15,6 @@ type RequestResponseText =
     }
 
 /// If a request is invalid (not covered), the reason for the failure
-[<Flags>]
 type RequestFailureInformation =
     /// The request was not executed, because an earlier dependency failed
     | SequenceFailure


### PR DESCRIPTION
This started occurring due to a compilation error in the F# code base, which was due to a bug in an unused data structure.  This is only caught by .NET 9 SDK, which was being used on Windows but not on Linux.

Changes include:
- fix the bug
- add error handling and debugging to the github action.  The error handling was automatically done in ADO pipelines, and adding it was missed during the migration to github actions.
- pin the .NET SDK to the version that is currently supported.