### PR TITLE
AWS S3 Authentication and Fuzzing for Ceph RGW

### DIFF
--- a/docs/user-guide/Authentication.md
+++ b/docs/user-guide/Authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-RESTler supports token-based and certificate based authentication.
+RESTler supports token-based, certificate based, and request signing authentication.
 
 **Token based authentication**
 
@@ -72,3 +72,7 @@ RESTler has logic to prevent token values from being written to the network logs
 **Certificate based authentication**
 
 A Certificate and corresponding keys can be used as an authentication mechanism. See the SettingsFile.md for the settings that should be used to specify a certificate. If both the keyfile and certificate path are valid, RESTler will attempt to use it during the SSL handshake.
+
+**Request signing authentication**
+
+RESTler supports custom request signing mechanisms through user-provided Python modules. This is useful for APIs that require signature-based authentication like AWS SigV4. The signing module should implement a function that takes request components and returns signed headers to be added to the request.

--- a/docs/user-guide/SettingsFile.md
+++ b/docs/user-guide/SettingsFile.md
@@ -103,6 +103,33 @@ __client_certificate_key_path__ str (default None):  Path to your key file in a 
 }
 ```
 
+#### _signing_ dict (Default empty): Can optionally provide request signing module
+
+__module__ dict (Default None): Dictionary containing settings for RESTler to invoke user-specified module to sign requests
+
+```json
+"authentication": {
+    "signing": {
+        "module": {
+            "file": "/path/to/signing_module.py",
+            "function": "sign_request",
+            "data": {
+                "access_key": "YOUR_ACCESS_KEY",
+                "secret_key": "YOUR_SECRET_KEY",
+                "region": "us-east-1",
+                "service": "s3"
+            }
+        }
+    }
+}
+```
+
+```file``` str (default None): File path to python file containing function that signs requests
+
+```function``` str (default "sign_request"): Name of function in file that signs requests. The function must accept parameters for method, message, headers_end, headers_str, body, and auth_data
+
+```data``` dict (Default None): Optional data payload to provide to signing function. If data is included, RESTler will pass it to the signing function as auth_data parameter
+
 ### custom_bug_codes: list(str)
 List of status codes that will be flagged as bugs.
 

--- a/restler/engine/transport_layer/messaging.py
+++ b/restler/engine/transport_layer/messaging.py
@@ -12,6 +12,7 @@ from utils.logging.trace_db import (DB as TraceDatabase,
                                     SequenceTracker)
 from utils.formatting import iso_timestamp
 from utils.logger import raw_network_logging as RAW_LOGGING
+from utils.import_utilities import import_attr
 from engine.errors import TransportLayerException
 from restler_settings import ConnectionSettings
 from restler_settings import Settings
@@ -209,12 +210,12 @@ class HttpSock(object):
                 message = _append_to_header(message, f"x-restler-sequence-id: {sequence_id}")
 
         # Add request signing if enabled in authentication settings    
-        if Settings().authentication and Settings().authentication.get('module', {}).get('signing'):
+        if Settings().authentication and Settings().authentication.get('signing', {}).get('module'):
             try:                
-                auth_module = Settings().authentication['module']
-                signing_function = auth_module.get('function', 'sign_request')
-                signing_module = __import__(auth_module['name'], fromlist=[signing_function])
-                sign_request = getattr(signing_module, signing_function)
+                signing_config = Settings().authentication['signing']
+                signing_module_config = signing_config['module']
+                signing_function = signing_module_config.get('function', 'sign_request')
+                sign_request = import_attr(signing_module_config['file'], signing_function)
 
                 # Extract request components needed for signing
                 method = self._get_method_from_message(message)
@@ -228,7 +229,7 @@ class HttpSock(object):
                     headers_end = headers_end,
                     headers_str=headers_str,
                     body=body,
-                    auth_data=auth_module.get('data', {})
+                    auth_data=signing_module_config.get('data', {})
                 )
                 # Update message with signed headers
                 for header_name, header_value in signed_headers.items():

--- a/restler/restler_settings.py
+++ b/restler/restler_settings.py
@@ -905,6 +905,11 @@ class RestlerSettings(object):
     @property
     def wait_for_async_delete_completion(self):
         return self._poll_async_delete_status.val
+    
+    @property
+    def authentication(self):
+        """Returns the authentication settings dictionary"""
+        return self._authentication_settings.val
 
     def include_request(self, endpoint, method):
         """"Returns whether the specified endpoint and method should be tested according to


### PR DESCRIPTION
## Summary

This pull request adds support for AWS Signature Version 4 (SigV4) authentication in RESTler, enabling fuzzing of AWS S3-compatible endpoints that require AWS request signing.

## Details

- Introduced a sample authentication module `aws_sigv4_auth.py` (originally located in `restler/utils`) to demonstrate how RESTler can sign requests using AWS S3 credentials (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`), leveraging `boto3` and `botocore`.
- After review feedback, the sample file has been removed from `restler/utils` to avoid including service-specific logic in the RESTler core codebase.
- The full sample, with usage and dependency details, is now tracked in a separate GitHub issue for discoverability and ongoing maintenance.

## Usage

- To enable request signing for AWS S3 or other SigV4-compatible endpoints, follow the [`aws_sigv4_auth.py` example in Issue #987](https://github.com/microsoft/restler-fuzzer/issues/987).
- **Install dependencies:** `pip install boto3 botocore`
- Put your AWS credentials in the appropriate environment variables or pass them to the script.
- Integrate the sample into your test deployment or adapt as needed for your authentication flow.

## Related

- Issue: [#987 – AWS SigV4 Authentication Example for RESTler](https://github.com/microsoft/restler-fuzzer/issues/987)

